### PR TITLE
Bug fix in: i < vocabPaths.size() - 1 => i + 1 < vocabPath.size()

### DIFF
--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -47,7 +47,11 @@ Corpus::Corpus(Ptr<Config> options, bool translate)
   }
 
   std::vector<int> maxVocabs = options_->get<std::vector<int>>("dim-vocabs");
-
+  UTIL_THROW_IF2(maxVocabs.size() != vocabPaths.size(),
+                 "number of vocabularies and specification of vocabulary sizes "
+                 "does not match!");
+  // If vocabularies exist, can't we get the dimensions from them and require
+  // dim-vocabs only when they don't? [UG]
   if(!translate) {
     std::vector<Vocab> vocabs;
     if(vocabPaths.empty()) {
@@ -64,7 +68,8 @@ Corpus::Corpus(Ptr<Config> options, bool translate)
         vocabs_.emplace_back(vocab);
       }
     }
-  } else {
+  } else { // i.e., if translating
+    UTIL_THROW_IF2(vocabPaths.empty(), "translating but vocabularies are missing!");
     for(size_t i = 0; i+1 < vocabPaths.size(); ++i) {
       Ptr<Vocab> vocab = New<Vocab>();
       vocab->loadOrCreate(vocabPaths[i], paths_[i], maxVocabs[i]);

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -65,7 +65,7 @@ Corpus::Corpus(Ptr<Config> options, bool translate)
       }
     }
   } else {
-    for(size_t i = 0; i < vocabPaths.size() - 1; ++i) {
+    for(size_t i = 0; i+1 < vocabPaths.size(); ++i) {
       Ptr<Vocab> vocab = New<Vocab>();
       vocab->loadOrCreate(vocabPaths[i], paths_[i], maxVocabs[i]);
       vocabs_.emplace_back(vocab);


### PR DESCRIPTION
in corpus.cpp

If vocabPaths.size() is empty in translation mode, s2s segfaults because 0 < size_t(0)-1 is always true.
Needless to say, vocabPaths should NOT be empty, but s2s should complain and exit instead of segfaulting.

See also #99.