### PR TITLE
Update the way batch_flexible_lr is applied

### DIFF
--- a/src/data/batch.h
+++ b/src/data/batch.h
@@ -11,6 +11,12 @@ class Batch {
 public:
   virtual size_t size() const = 0;
   virtual size_t words() const { return 0; };
+  virtual size_t width() const { return 0; };
+
+  virtual size_t sizeTrg() const { return 0; };
+  virtual size_t wordsTrg() const { return 0; };
+  virtual size_t widthTrg() const { return 0; };
+
   virtual void debug(){};
 
   virtual std::vector<Ptr<Batch>> split(size_t n) = 0;

--- a/src/data/corpus.h
+++ b/src/data/corpus.h
@@ -172,6 +172,14 @@ public:
 
   size_t words() const { return batches_[0]->batchWords(); }
 
+  size_t width() const { return batches_[0]->batchWidth(); }
+
+  size_t sizeTrg() const { return batches_.back()->batchSize(); }
+
+  size_t wordsTrg() const { return batches_.back()->batchWords(); };
+
+  size_t widthTrg() const { return batches_.back()->batchWidth(); };
+
   size_t sets() const { return batches_.size(); }
 
   static Ptr<CorpusBatch> fakeBatch(std::vector<size_t>& lengths,

--- a/src/training/graph_group.h
+++ b/src/training/graph_group.h
@@ -13,6 +13,8 @@ protected:
   Ptr<Config> options_;
   Ptr<OptimizerBase> opt_;
   Ptr<Scheduler> scheduler_;
+  std::vector<size_t> batch_size_perthread_;
+  std::unordered_map<std::thread::id, size_t> threadIDs_;
 
   bool scaleLearningRate_;
   float avgBatchWords_;
@@ -22,7 +24,8 @@ public:
       : options_(options),
         opt_(Optimizer(options)),
         scaleLearningRate_(options->get<bool>("batch-flexible-lr")),
-        avgBatchWords_(options->get<float>("batch-normal-words")) {}
+        avgBatchWords_(options->get<float>("batch-normal-words")),
+          batch_size_perthread_(options->get<std::vector<int> >("devices").size()) {}
 
   virtual ~GraphGroup() {}
 

--- a/src/training/graph_group_async.cu
+++ b/src/training/graph_group_async.cu
@@ -48,8 +48,7 @@ void AsyncGraphGroup::pushGradients(Tensor newGrads) {
           grads_[idx]->copyFrom(newGrads->subtensor(pos, grads_[idx]->size()));
 
           shardOpt_[idx]->update(
-                params_[idx], grads_[idx],
-                  batch_size_perthread_[threadIDs_.find(std::this_thread::get_id())->second]);
+                params_[idx], grads_[idx]);
 
           if(movingAvg_)
             updateMovingAverage(

--- a/src/training/graph_group_async.cu
+++ b/src/training/graph_group_async.cu
@@ -36,7 +36,7 @@ void AsyncGraphGroup::fetchParams(Tensor oldParams,
   }
 }
 
-void AsyncGraphGroup::pushGradients(Tensor newGrads, size_t batch_words) {
+void AsyncGraphGroup::pushGradients(Tensor newGrads) {
   // add instead of copy?
   std::vector<std::thread> threads;
   int pos = 0;
@@ -47,12 +47,9 @@ void AsyncGraphGroup::pushGradients(Tensor newGrads, size_t batch_words) {
           std::lock_guard<std::mutex> guard(shardSync_[idx]);
           grads_[idx]->copyFrom(newGrads->subtensor(pos, grads_[idx]->size()));
 
-          if(scaleLearningRate_) {
-            shardOpt_[idx]->update(
-                params_[idx], grads_[idx], batch_words / avgBatchWords_);
-          } else {
-            shardOpt_[idx]->update(params_[idx], grads_[idx]);
-          }
+          shardOpt_[idx]->update(
+                params_[idx], grads_[idx],
+                  batch_size_perthread_[threadIDs_.find(std::this_thread::get_id())->second]);
 
           if(movingAvg_)
             updateMovingAverage(
@@ -157,8 +154,12 @@ void AsyncGraphGroup::execute(Ptr<data::Batch> batch) {
     thread_local Tensor accGradients;
     thread_local Ptr<TensorAllocator> accAlloc;
 
+    thread_local size_t my_id = 0;
+
     if(!graph) {
       std::lock_guard<std::mutex> lock(sync_);
+      my_id = i;
+      threadIDs_.insert(std::pair<std::thread::id, size_t>(std::this_thread::get_id(), my_id));
       graph = graphs_[i];
       builder = builders_[i++];
     }
@@ -174,7 +175,7 @@ void AsyncGraphGroup::execute(Ptr<data::Batch> batch) {
     graph->backward();
 
     // Get batch stats
-    size_t batch_words = batch->words();
+    size_t batch_words = batch->wordsTrg();
 
     Tensor gradients;
     if(tau_ > 1) {
@@ -199,7 +200,8 @@ void AsyncGraphGroup::execute(Ptr<data::Batch> batch) {
     t++;
 
     if(t % tau_ == 0) {
-      pushGradients(gradients, num_seen_words);
+      batch_size_perthread_[my_id] = scaleLearningRate_ ? num_seen_words/avgBatchWords_ : 1; //Optionally scale learning rate
+      pushGradients(gradients);
       // Reset the counter of seen words after gradient update
       num_seen_words = 0;
 

--- a/src/training/graph_group_async.h
+++ b/src/training/graph_group_async.h
@@ -50,7 +50,7 @@ private:
 
   void fetchParams(Tensor oldParams, const std::vector<Tensor>& params);
 
-  void pushGradients(Tensor newGrads, size_t batch_words);
+  void pushGradients(Tensor newGrads);
 
   void updateMovingAverage(Tensor paramsAvg, Tensor params, size_t batches);
 

--- a/src/training/graph_group_singleton.cu
+++ b/src/training/graph_group_singleton.cu
@@ -26,13 +26,10 @@ void SingletonGraph::execute(Ptr<data::Batch> batch) {
   graph_->backward();
 
   // Get batch stats
-  size_t batch_words = batch->words();
+  size_t batch_words = batch->wordsTrg();
 
-  if(scaleLearningRate_) {
-    opt_->update(graph_, batch_words / avgBatchWords_);
-  } else {
-    opt_->update(graph_);
-  }
+  opt_->update(graph_, scaleLearningRate_ ? batch_words / avgBatchWords_ : 1);
+
 
   if(mvAvg_) {
     if(!mvAvgGraph_) {

--- a/src/training/graph_group_singleton.cu
+++ b/src/training/graph_group_singleton.cu
@@ -19,6 +19,9 @@ void SingletonGraph::updateMovingAverage(Tensor mvAvgParams,
 }
 
 void SingletonGraph::execute(Ptr<data::Batch> batch) {
+  if(scheduler_) {
+    scheduler_->preUpdate(batch);
+  }
   auto costNode = builder_->build(graph_, batch);
 
   graph_->forward();
@@ -28,7 +31,7 @@ void SingletonGraph::execute(Ptr<data::Batch> batch) {
   // Get batch stats
   size_t batch_words = batch->wordsTrg();
 
-  opt_->update(graph_, scaleLearningRate_ ? batch_words / avgBatchWords_ : 1);
+  opt_->update(graph_);
 
 
   if(mvAvg_) {

--- a/src/training/graph_group_sync.cu
+++ b/src/training/graph_group_sync.cu
@@ -114,6 +114,7 @@ void SyncGraphGroup::execute(Ptr<data::Batch> batch) {
         graph->forward();
         costs[idx] = costNode->scalar();
         graph->backward();
+        batch_size_perthread_[idx] = batch->wordsTrg();
       }
     };
 
@@ -138,7 +139,7 @@ void SyncGraphGroup::execute(Ptr<data::Batch> batch) {
         i++;
       }
 
-      shardOpt_[idx]->update(params_[idx], grads_[idx]);
+      shardOpt_[idx]->update(params_[idx], grads_[idx], scaleLearningRate_ ? batch_size_perthread_[idx] / avgBatchWords_ : 1);
 
       if(movingAvg_)
         updateMovingAverage(

--- a/src/training/graph_group_sync.cu
+++ b/src/training/graph_group_sync.cu
@@ -139,7 +139,7 @@ void SyncGraphGroup::execute(Ptr<data::Batch> batch) {
         i++;
       }
 
-      shardOpt_[idx]->update(params_[idx], grads_[idx], scaleLearningRate_ ? batch_size_perthread_[idx] / avgBatchWords_ : 1);
+      shardOpt_[idx]->update(params_[idx], grads_[idx]);
 
       if(movingAvg_)
         updateMovingAverage(

--- a/src/training/training_state.h
+++ b/src/training/training_state.h
@@ -11,6 +11,7 @@ class TrainingState;
 class TrainingObserver {
 public:
   virtual void actAfterEpoch(TrainingState& state) = 0;
+  virtual void actBeforeBatches(TrainingState& state, size_t batchWords=0) {}
   virtual void actAfterBatches(TrainingState& state) {}
   virtual void actAfterStalled(TrainingState& state) {}
 };
@@ -23,6 +24,8 @@ public:
   int maxStalled{0};
   int warmupStart{0};
   float eta;
+  float multiplyFactor_; // For scaling LR according to batch size.
+                                      // @TODO make sure it works for pushGradients because they spawn subthreads
   float factor{1.f};
   bool reset{false};
 
@@ -36,6 +39,11 @@ public:
     ++epochs;
     for(auto observer : observers_)
       observer->actAfterEpoch(*this);
+  }
+
+  void preBatch(size_t batchWords) {
+    for(auto observer : observers_)
+      observer->actBeforeBatches(*this, batchWords); //Nothing To do here so far
   }
 
   void newBatch() {


### PR DESCRIPTION
This is more of Request for comment than a pull request. It compiles but it's not completely tested.

I have simplified the way batch-flexible-lr is applied, using an array of the size of devices to keep what the last number of words for this batch was.

We can move this code to the scheduler pretty much as it is by adding functions such as "scheduler_->SetbatchSize(batch, threadID)" and "scheduler->getLRforThread(threadID)" but it'd not really simplify the code further, it will just call the scheduler instead of doing the work directly. If you have other ideas, please suggest!.