### PR TITLE
Tidy up CuDNN code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ cuda_add_library(marian
   tensors/memory_piece.cu
   kernels/tensor_operators.cu
   kernels/dropout.cu
+  kernels/cudnn_wrappers.cu
 #  kernels/sparse.cu
   layers/param_initializers.cu
   layers/generic.cpp

--- a/src/common/shape.h
+++ b/src/common/shape.h
@@ -4,6 +4,9 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <vector>
+
+#include "common/logging.h"
 
 namespace marian {
 

--- a/src/common/shape.h
+++ b/src/common/shape.h
@@ -32,6 +32,10 @@ struct Shape {
       return shape_.data();
     }
 
+    int* data() {
+      return shape_.data();
+    }
+
     Shape(const Shape& shape) : Shape() {
       shape_.resize(shape.size());
       std::copy(shape.begin(), shape.end(), begin());

--- a/src/common/shape.h
+++ b/src/common/shape.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <sstream>
 
 namespace marian {
 
@@ -109,12 +110,18 @@ struct Shape {
 
     bool operator!=(const Shape& other) const { return !(*this == other); }
 
+    std::string toString() const {
+      std::stringstream strm;
+      strm << "shape=" << (*this)[0];
+      for(int i = 1; i < size(); ++i)
+        strm << "x" << (*this)[i];
+      strm << " size=" << elements() << " ("
+           << elements() * sizeof(float) << "B)";
+      return strm.str();
+    }
+
     friend std::ostream& operator<<(std::ostream& strm, const Shape& shape) {
-      strm << "shape=" << shape[0];
-      for(int i = 1; i < shape.size(); ++i)
-        strm << "x" << shape[i];
-      strm << " size=" << shape.elements() << " ("
-           << shape.elements() * sizeof(float) << "B)";
+      strm << shape.toString();
       return strm;
     }
 

--- a/src/examples/mnist/model_lenet.h
+++ b/src/examples/mnist/model_lenet.h
@@ -32,9 +32,8 @@ protected:
     // Construct hidden layers
 
     auto conv_1 = Convolution("Conv1", 3, 3, 32)(x);
-    // auto conv_2 = relu(Convolution("Conv2", 3, 3, 64)(conv_1));
-    // auto pool = MaxPooling("MaxPooling", 2, 2)(conv_2);
-    auto pool = conv_1;
+    auto conv_2 = relu(Convolution("Conv2", 3, 3, 64)(conv_1));
+    auto pool = MaxPooling("MaxPooling", 2, 2)(conv_2);
 
     auto flatten
         = reshape(pool,

--- a/src/examples/mnist/model_lenet.h
+++ b/src/examples/mnist/model_lenet.h
@@ -38,9 +38,7 @@ protected:
     auto flatten
         = reshape(pool,
                   {pool->shape()[0],
-                   pool->shape()[1] * pool->shape()[2] * pool->shape()[3],
-                   1,
-                   1});
+                   pool->shape()[1] * pool->shape()[2] * pool->shape()[3]});
     auto drop1 = dropout(flatten, keywords::dropout_prob = 0.25);
     std::vector<Expr> layers, weights, biases;
 

--- a/src/examples/mnist/model_lenet.h
+++ b/src/examples/mnist/model_lenet.h
@@ -32,8 +32,9 @@ protected:
     // Construct hidden layers
 
     auto conv_1 = Convolution("Conv1", 3, 3, 32)(x);
-    auto conv_2 = relu(Convolution("Conv2", 3, 3, 64)(conv_1));
-    auto pool = MaxPooling("MaxPooling", 2, 2)(conv_2);
+    // auto conv_2 = relu(Convolution("Conv2", 3, 3, 64)(conv_1));
+    // auto pool = MaxPooling("MaxPooling", 2, 2)(conv_2);
+    auto pool = conv_1;
 
     auto flatten
         = reshape(pool,

--- a/src/graph/expression_operators.cu
+++ b/src/graph/expression_operators.cu
@@ -296,8 +296,6 @@ Expr shift(Expr a, Shape shift) {
 //  return Expression<LexicalProbNodeOp>(logits, att, eps, lf);
 //}
 
-#ifdef CUDNN
-
 Expr convolution(Expr x, Expr filters, Expr bias) {
   std::vector<Expr> nodes = {x, filters, bias};
   return Expression<ConvolutionOp>(nodes);
@@ -341,5 +339,4 @@ Expr max_pooling(
       "max");
 }
 
-#endif
 }

--- a/src/graph/expression_operators.cu
+++ b/src/graph/expression_operators.cu
@@ -303,33 +303,43 @@ Expr convolution(Expr x, Expr filters, Expr bias) {
   return Expression<ConvolutionOp>(nodes);
 }
 
-// clang-format off
 Expr avg_pooling(
     Expr x,
-    int height, int width,
-    int padHeight, int padWidth,
-    int strideHeight, int strideWidth)
+    int height,
+    int width,
+    int padHeight,
+    int padWidth,
+    int strideHeight,
+    int strideWidth)
 {
   return Expression<PoolingOp>(x,
-      height, width,
-      padHeight, padWidth,
-      strideHeight, strideWidth,
-      PoolingOp::Mode::AVERAGE_POOLING);
+      height,
+      width,
+      padHeight,
+      padWidth,
+      strideHeight,
+      strideWidth,
+      "avg");
 }
 
 Expr max_pooling(
     Expr x,
-    int height, int width,
-    int padHeight, int padWidth,
-    int strideHeight, int strideWidth)
+    int height,
+    int width,
+    int padHeight,
+    int padWidth,
+    int strideHeight,
+    int strideWidth)
 {
   return Expression<PoolingOp>(x,
-      height, width,
-      padHeight, padWidth,
-      strideHeight, strideWidth,
-      PoolingOp::Mode::MAX_POOLING);
+      height,
+      width,
+      padHeight,
+      padWidth,
+      strideHeight,
+      strideWidth,
+      "max");
 }
-// clang-format on
 
 #endif
 }

--- a/src/graph/node_operators_binary.h
+++ b/src/graph/node_operators_binary.h
@@ -712,18 +712,23 @@ class ConvolutionOp : public NaryNodeOp {
 public:
   ConvolutionOp(const std::vector<Expr>& nodes)
     : NaryNodeOp(nodes),
-      conv_(nodes[1]->val(), nodes[2]->val()) {
-    conv_.getOutputShape(nodes[0]->val(), shape_);
+      conv_(nodes[1]->shape(), nodes[2]->shape()) {
+    conv_.getOutputShape(nodes[0]->shape(), shape_);
   }
 
   NodeOps forwardOps() {
-    return {NodeOp(conv_.forward(child(0)->val(), val_))};
+    return {NodeOp(conv_.forward(
+          child(0)->val(),
+          child(1)->val(),
+          child(2)->val(),
+          val_))};
   }
 
   NodeOps backwardOps() {
     return {NodeOp(conv_.backward(
           child(0)->val(),
           child(0)->grad(),
+          child(1)->val(),
           child(1)->grad(),
           child(2)->grad(),
           adj_))};

--- a/src/kernels/cudnn_wrappers.cu
+++ b/src/kernels/cudnn_wrappers.cu
@@ -16,7 +16,6 @@ namespace marian {
     }                                 \
   } while(0)
 
-
 CUDNNWrapper::CUDNNWrapper() {
   CUDNN_CALL(cudnnCreate(&cudnnHandle_));
 }
@@ -30,58 +29,51 @@ void CUDNNWrapper::setCudnnTensor(cudnnTensorDescriptor_t& desc, Tensor x) {
   setCudnnTensor(desc, x->shape());
 }
 
-void CUDNNWrapper::setCudnnTensor(
-    cudnnTensorDescriptor_t& desc,
-    const Shape& shape) {
+void CUDNNWrapper::setCudnnTensor(cudnnTensorDescriptor_t& desc,
+                                  const Shape& shape) {
   CUDNN_CALL(cudnnCreateTensorDescriptor(&desc));
-  CUDNN_CALL(cudnnSetTensor4dDescriptor(
-        desc,
-        CUDNN_TENSOR_NCHW,
-        CUDNN_DATA_FLOAT,
-        shape[0],
-        shape[1],
-        shape[2],
-        shape[3]));
+  CUDNN_CALL(cudnnSetTensor4dDescriptor(desc,
+                                        CUDNN_TENSOR_NCHW,
+                                        CUDNN_DATA_FLOAT,
+                                        shape[0],
+                                        shape[1],
+                                        shape[2],
+                                        shape[3]));
 }
 
 /******************************************************************************
  * ConvolutionWrapper
  *****************************************************************************/
 
-ConvolutionWrapper::ConvolutionWrapper(
-    const Shape& kernelShape,
-    const Shape& biasShape,
-    int hPad,
-    int wPad,
-    int hStride,
-    int wStride) {
+ConvolutionWrapper::ConvolutionWrapper(const Shape& kernelShape,
+                                       const Shape& biasShape,
+                                       int hPad,
+                                       int wPad,
+                                       int hStride,
+                                       int wStride) {
   setKernelDescriptor(kernelShape);
   setConvDescriptor(hPad, wPad, hStride, wStride);
   setCudnnTensor(biasDesc_, biasShape);
 }
 
-void ConvolutionWrapper::getOutputShape(
-    const Shape& xShape,
-    Shape& shape) {
+void ConvolutionWrapper::getOutputShape(const Shape& xShape, Shape& shape) {
   cudnnTensorDescriptor_t xDesc;
   setCudnnTensor(xDesc, xShape);
   shape.resize(4);
-  CUDNN_CALL(cudnnGetConvolution2dForwardOutputDim(
-        convDesc_,
-        xDesc,
-        kernelDesc_,
-        shape.data(),
-        shape.data() + 1,
-        shape.data() + 2,
-        shape.data() + 3));
+  CUDNN_CALL(cudnnGetConvolution2dForwardOutputDim(convDesc_,
+                                                   xDesc,
+                                                   kernelDesc_,
+                                                   shape.data(),
+                                                   shape.data() + 1,
+                                                   shape.data() + 2,
+                                                   shape.data() + 3));
   cudnnDestroyTensorDescriptor(xDesc);
 }
 
-void ConvolutionWrapper::forward(
-    Tensor x,
-    Tensor kernels,
-    Tensor bias,
-    Tensor y) {
+void ConvolutionWrapper::forward(Tensor x,
+                                 Tensor kernels,
+                                 Tensor bias,
+                                 Tensor y) {
   cudaSetDevice(x->getDevice());
 
   cudnnTensorDescriptor_t xDesc, yDesc;
@@ -91,39 +83,31 @@ void ConvolutionWrapper::forward(
   const float alpha = 1.0f;
   const float beta = 0.0f;
 
-  CUDNN_CALL(cudnnConvolutionForward(
-        cudnnHandle_,
-        &alpha,
-        xDesc,
-        x->data(),
-        kernelDesc_,
-        kernels->data(),
-        convDesc_,
-        CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
-        nullptr,
-        0,
-        &beta,
-        yDesc,
-        y->data()));
+  CUDNN_CALL(cudnnConvolutionForward(cudnnHandle_,
+                                     &alpha,
+                                     xDesc,
+                                     x->data(),
+                                     kernelDesc_,
+                                     kernels->data(),
+                                     convDesc_,
+                                     CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
+                                     nullptr,
+                                     0,
+                                     &beta,
+                                     yDesc,
+                                     y->data()));
   CUDNN_CALL(cudnnAddTensor(
-        cudnnHandle_,
-        &alpha,
-        biasDesc_,
-        bias->data(),
-        &alpha,
-        yDesc,
-        y->data()));
+      cudnnHandle_, &alpha, biasDesc_, bias->data(), &alpha, yDesc, y->data()));
   cudnnDestroyTensorDescriptor(xDesc);
   cudnnDestroyTensorDescriptor(yDesc);
 }
 
-void ConvolutionWrapper::backward(
-    Tensor x,
-    Tensor xGrad,
-    Tensor kernels,
-    Tensor kernelGrad,
-    Tensor biasGrad,
-    Tensor yGrad) {
+void ConvolutionWrapper::backward(Tensor x,
+                                  Tensor xGrad,
+                                  Tensor kernels,
+                                  Tensor kernelGrad,
+                                  Tensor biasGrad,
+                                  Tensor yGrad) {
   cudaSetDevice(xGrad->getDevice());
 
   cudnnTensorDescriptor_t xDesc, yDesc;
@@ -133,44 +117,41 @@ void ConvolutionWrapper::backward(
   const float alpha = 1.0f;
   const float beta = 1.0f;
 
-  CUDNN_CALL(cudnnConvolutionBackwardData(
-        cudnnHandle_,
-        &alpha,
-        kernelDesc_,
-        kernels->data(),
-        yDesc,
-        yGrad->data(),
-        convDesc_,
-        CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
-        nullptr,
-        0,
-        &beta,
-        xDesc,
-        xGrad->data()));
+  CUDNN_CALL(cudnnConvolutionBackwardData(cudnnHandle_,
+                                          &alpha,
+                                          kernelDesc_,
+                                          kernels->data(),
+                                          yDesc,
+                                          yGrad->data(),
+                                          convDesc_,
+                                          CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
+                                          nullptr,
+                                          0,
+                                          &beta,
+                                          xDesc,
+                                          xGrad->data()));
 
-  CUDNN_CALL(cudnnConvolutionBackwardFilter(
-      cudnnHandle_,
-      &alpha,
-      xDesc,
-      x->data(),
-      yDesc,
-      yGrad->data(),
-      convDesc_,
-      CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
-      nullptr,
-      0,
-      &beta,
-      kernelDesc_,
-      kernelGrad->data()));
+  CUDNN_CALL(cudnnConvolutionBackwardFilter(cudnnHandle_,
+                                            &alpha,
+                                            xDesc,
+                                            x->data(),
+                                            yDesc,
+                                            yGrad->data(),
+                                            convDesc_,
+                                            CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
+                                            nullptr,
+                                            0,
+                                            &beta,
+                                            kernelDesc_,
+                                            kernelGrad->data()));
 
-  CUDNN_CALL(cudnnConvolutionBackwardBias(
-        cudnnHandle_,
-        &alpha,
-        yDesc,
-        yGrad->data(),
-        &beta,
-        biasDesc_,
-        biasGrad->data()));
+  CUDNN_CALL(cudnnConvolutionBackwardBias(cudnnHandle_,
+                                          &alpha,
+                                          yDesc,
+                                          yGrad->data(),
+                                          &beta,
+                                          biasDesc_,
+                                          biasGrad->data()));
 
   cudnnDestroyTensorDescriptor(xDesc);
   cudnnDestroyTensorDescriptor(yDesc);
@@ -183,33 +164,31 @@ ConvolutionWrapper::~ConvolutionWrapper() {
   cudnnDestroyTensorDescriptor(biasDesc_);
 }
 
-void ConvolutionWrapper::setConvDescriptor(
-    int hPad,
-    int wPad,
-    int hStride,
-    int wStride) {
+void ConvolutionWrapper::setConvDescriptor(int hPad,
+                                           int wPad,
+                                           int hStride,
+                                           int wStride) {
   CUDNN_CALL(cudnnCreateConvolutionDescriptor(&convDesc_));
 
-  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-        convDesc_,
-        hPad,
-        wPad,
-        hStride,
-        wStride,
-        1,
-        1,  // upscales
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(convDesc_,
+                                             hPad,
+                                             wPad,
+                                             hStride,
+                                             wStride,
+                                             1,
+                                             1,  // upscales
 #if CUDNN_MAJOR > 5
-        CUDNN_CROSS_CORRELATION,
-        CUDNN_DATA_FLOAT));
+                                             CUDNN_CROSS_CORRELATION,
+                                             CUDNN_DATA_FLOAT));
 #else
-        CUDNN_CROSS_CORRELATION));
+                                             CUDNN_CROSS_CORRELATION));
 #endif
-
 }
 
 void ConvolutionWrapper::setKernelDescriptor(const Shape& shape) {
   ABORT_IF(shape.size() != 4,
-            "CUDN requires tensors 4D. Provided {}", shape.toString());
+           "CUDN requires tensors 4D. Provided {}",
+           shape.toString());
   CUDNN_CALL(cudnnCreateFilterDescriptor(&kernelDesc_));
 
   int layerIn = shape[0];
@@ -217,55 +196,48 @@ void ConvolutionWrapper::setKernelDescriptor(const Shape& shape) {
   int kernelH = shape[2];
   int kernelW = shape[3];
 
-  CUDNN_CALL(cudnnSetFilter4dDescriptor(
-        kernelDesc_,
-        CUDNN_DATA_FLOAT,
-        CUDNN_TENSOR_NCHW,
-        layerOut,
-        layerIn,
-        kernelH,
-        kernelW));
+  CUDNN_CALL(cudnnSetFilter4dDescriptor(kernelDesc_,
+                                        CUDNN_DATA_FLOAT,
+                                        CUDNN_TENSOR_NCHW,
+                                        layerOut,
+                                        layerIn,
+                                        kernelH,
+                                        kernelW));
 }
-
 
 /******************************************************************************
  * PoolingWrapper
  *****************************************************************************/
 
-PoolingWrapper::PoolingWrapper(
-    int height,
-    int width,
-    int padHeight,
-    int padWidth,
-    int strideHeight,
-    int strideWidth,
-    std::string mode) {
-  if (mode == "max") {
+PoolingWrapper::PoolingWrapper(int height,
+                               int width,
+                               int padHeight,
+                               int padWidth,
+                               int strideHeight,
+                               int strideWidth,
+                               std::string mode) {
+  if(mode == "max") {
     poolingMode_ = CUDNN_POOLING_MAX;
-  } else if (mode == "avg") {
+  } else if(mode == "avg") {
     poolingMode_ = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
   } else {
-      ABORT("Unknown pooling mode.");
+    ABORT("Unknown pooling mode.");
   }
 
-  setPoolingDescriptor(height, width,
-      padHeight, padWidth,
-      strideHeight, strideWidth);
+  setPoolingDescriptor(
+      height, width, padHeight, padWidth, strideHeight, strideWidth);
 }
 
-void PoolingWrapper::getOutputShape(
-    const Shape& xShape,
-    Shape& shape) {
+void PoolingWrapper::getOutputShape(const Shape& xShape, Shape& shape) {
   cudnnTensorDescriptor_t xDesc;
   setCudnnTensor(xDesc, xShape);
   shape.resize(4);
-  CUDNN_CALL(cudnnGetPooling2dForwardOutputDim(
-        poolingDesc_,
-        xDesc,
-        shape.data(),
-        shape.data() + 1,
-        shape.data() + 2,
-        shape.data() + 3));
+  CUDNN_CALL(cudnnGetPooling2dForwardOutputDim(poolingDesc_,
+                                               xDesc,
+                                               shape.data(),
+                                               shape.data() + 1,
+                                               shape.data() + 2,
+                                               shape.data() + 3));
   cudnnDestroyTensorDescriptor(xDesc);
 }
 
@@ -279,24 +251,19 @@ void PoolingWrapper::forward(Tensor x, Tensor y) {
   const float alpha = 1.0f;
   const float beta = 0.0f;
 
-  CUDNN_CALL(cudnnPoolingForward(
-        cudnnHandle_,
-        poolingDesc_,
-        &alpha,
-        xDesc,
-        x->data(),
-        &beta,
-        yDesc,
-        y->data()));
+  CUDNN_CALL(cudnnPoolingForward(cudnnHandle_,
+                                 poolingDesc_,
+                                 &alpha,
+                                 xDesc,
+                                 x->data(),
+                                 &beta,
+                                 yDesc,
+                                 y->data()));
   cudnnDestroyTensorDescriptor(xDesc);
   cudnnDestroyTensorDescriptor(yDesc);
 }
 
-void PoolingWrapper::backward(
-    Tensor x,
-    Tensor xGrad,
-    Tensor y,
-    Tensor yGrad) {
+void PoolingWrapper::backward(Tensor x, Tensor xGrad, Tensor y, Tensor yGrad) {
   cudaSetDevice(x->getDevice());
 
   cudnnTensorDescriptor_t xDesc, yDesc;
@@ -306,40 +273,38 @@ void PoolingWrapper::backward(
   const float alpha = 1.0f;
   const float beta = 1.0f;
 
-  CUDNN_CALL(cudnnPoolingBackward(
-        cudnnHandle_,
-        poolingDesc_,
-        &alpha,
-        yDesc,
-        y->data(),
-        yDesc,
-        yGrad->data(),
-        xDesc,
-        x->data(),
-        &beta,
-        xDesc,
-        xGrad->data()));
+  CUDNN_CALL(cudnnPoolingBackward(cudnnHandle_,
+                                  poolingDesc_,
+                                  &alpha,
+                                  yDesc,
+                                  y->data(),
+                                  yDesc,
+                                  yGrad->data(),
+                                  xDesc,
+                                  x->data(),
+                                  &beta,
+                                  xDesc,
+                                  xGrad->data()));
   cudnnDestroyTensorDescriptor(xDesc);
   cudnnDestroyTensorDescriptor(yDesc);
 }
 
-void PoolingWrapper::setPoolingDescriptor(
-    int height,
-    int width,
-    int padHeight,
-    int padWidth,
-    int strideHeight,
-    int strideWidth) {
+void PoolingWrapper::setPoolingDescriptor(int height,
+                                          int width,
+                                          int padHeight,
+                                          int padWidth,
+                                          int strideHeight,
+                                          int strideWidth) {
   CUDNN_CALL(cudnnCreatePoolingDescriptor(&poolingDesc_));
   CUDNN_CALL(cudnnSetPooling2dDescriptor(poolingDesc_,
-                                          poolingMode_,
-                                          CUDNN_NOT_PROPAGATE_NAN,
-                                          height,
-                                          width,
-                                          padHeight,
-                                          padWidth,
-                                          strideHeight,
-                                          strideWidth));
+                                         poolingMode_,
+                                         CUDNN_NOT_PROPAGATE_NAN,
+                                         height,
+                                         width,
+                                         padHeight,
+                                         padWidth,
+                                         strideHeight,
+                                         strideWidth));
 }
 
 PoolingWrapper::~PoolingWrapper() {
@@ -347,57 +312,88 @@ PoolingWrapper::~PoolingWrapper() {
   CUDNN_CALL(cudnnDestroyPoolingDescriptor(poolingDesc_));
 }
 
-
 #else
 
-
 CUDNNWrapper::CUDNNWrapper() {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 CUDNNWrapper::~CUDNNWrapper() {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
-ConvolutionWrapper::ConvolutionWrapper(const Shape&, const Shape&, int, int,
-                                       int, int) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+ConvolutionWrapper::ConvolutionWrapper(const Shape&,
+                                       const Shape&,
+                                       int,
+                                       int,
+                                       int,
+                                       int) {
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 void ConvolutionWrapper::getOutputShape(const Shape&, Shape&) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 void ConvolutionWrapper::forward(Tensor, Tensor, Tensor, Tensor) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
-void ConvolutionWrapper::backward( Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+void ConvolutionWrapper::backward(Tensor,
+                                  Tensor,
+                                  Tensor,
+                                  Tensor,
+                                  Tensor,
+                                  Tensor) {
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 ConvolutionWrapper::~ConvolutionWrapper() {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 PoolingWrapper::PoolingWrapper(int, int, int, int, int, int, std::string) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 void PoolingWrapper::getOutputShape(const Shape&, Shape&) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 void PoolingWrapper::forward(Tensor x, Tensor y) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 void PoolingWrapper::backward(Tensor, Tensor, Tensor, Tensor) {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 PoolingWrapper::~PoolingWrapper() {
-  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+  ABORT(
+      "To use convolution and pooling, recompile with CUDNN (cmake flag "
+      "-DUSE_CUDNN=on)");
 }
 
 #endif

--- a/src/kernels/cudnn_wrappers.cu
+++ b/src/kernels/cudnn_wrappers.cu
@@ -21,7 +21,8 @@ CUDNNWrapper::CUDNNWrapper() {
 }
 
 CUDNNWrapper::~CUDNNWrapper() {
-  cudnnDestroy(cudnnHandle_);
+  // std::cerr << "destroy wrapper" << std::endl;
+  CUDNN_CALL(cudnnDestroy(cudnnHandle_));
 }
 
 void CUDNNWrapper::setCudnnTensor(cudnnTensorDescriptor_t& desc, Tensor x) {
@@ -171,6 +172,7 @@ void ConvolutionWrapper::backward(
 }
 
 ConvolutionWrapper::~ConvolutionWrapper() {
+  // std::cerr << "destroy conv-wrapper" << std::endl;
   cudnnDestroyConvolutionDescriptor(convDesc_);
   cudnnDestroyFilterDescriptor(kernelDesc_);
   cudnnDestroyTensorDescriptor(biasDesc_);
@@ -336,6 +338,7 @@ void PoolingWrapper::setPoolingDescriptor(
 }
 
 PoolingWrapper::~PoolingWrapper() {
+  // std::cerr << "destroy pool-wrapper" << std::endl;
   CUDNN_CALL(cudnnDestroyPoolingDescriptor(poolingDesc_));
 }
 

--- a/src/kernels/cudnn_wrappers.cu
+++ b/src/kernels/cudnn_wrappers.cu
@@ -1,5 +1,7 @@
 #include "kernels/cudnn_wrappers.h"
 
+namespace marian {
+
 #ifdef CUDNN
 
 #include <cudnn.h>
@@ -14,7 +16,6 @@
     }                                 \
   } while(0)
 
-namespace marian {
 
 CUDNNWrapper::CUDNNWrapper() {
   CUDNN_CALL(cudnnCreate(&cudnnHandle_));
@@ -42,6 +43,10 @@ void CUDNNWrapper::setCudnnTensor(
         shape[2],
         shape[3]));
 }
+
+/******************************************************************************
+ * ConvolutionWrapper
+ *****************************************************************************/
 
 ConvolutionWrapper::ConvolutionWrapper(
     const Shape& kernelShape,
@@ -342,6 +347,58 @@ PoolingWrapper::~PoolingWrapper() {
   CUDNN_CALL(cudnnDestroyPoolingDescriptor(poolingDesc_));
 }
 
+
+#else
+
+
+CUDNNWrapper::CUDNNWrapper() {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+CUDNNWrapper::~CUDNNWrapper() {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+ConvolutionWrapper::ConvolutionWrapper(const Shape&, const Shape&, int, int,
+                                       int, int) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+void ConvolutionWrapper::getOutputShape(const Shape&, Shape&) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+void ConvolutionWrapper::forward(Tensor, Tensor, Tensor, Tensor) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+void ConvolutionWrapper::backward( Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+ConvolutionWrapper::~ConvolutionWrapper() {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+PoolingWrapper::PoolingWrapper(int, int, int, int, int, int, std::string) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+void PoolingWrapper::getOutputShape(const Shape&, Shape&) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+void PoolingWrapper::forward(Tensor x, Tensor y) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+void PoolingWrapper::backward(Tensor, Tensor, Tensor, Tensor) {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
+}
+
+PoolingWrapper::~PoolingWrapper() {
+  ABORT("To use convolution and pooling, recompile with CUDNN (cmake flag -DUSE_CUDNN=on)");
 }
 
 #endif
+}

--- a/src/kernels/cudnn_wrappers.cu
+++ b/src/kernels/cudnn_wrappers.cu
@@ -1,0 +1,224 @@
+#include "kernels/cudnn_wrappers.h"
+
+#ifdef CUDNN
+
+#include <cudnn.h>
+
+#define CUDNN_CALL(x)                 \
+  do {                                \
+    if((x) != CUDNN_STATUS_SUCCESS) { \
+      printf("Error (%s) at %s:%d\n", \
+             cudnnGetErrorString(x),  \
+             __FILE__,                \
+             __LINE__);               \
+    }                                 \
+  } while(0)
+
+namespace marian {
+
+CUDNNWrapper::CUDNNWrapper() {
+  CUDNN_CALL(cudnnCreate(&cudnnHandle_));
+}
+
+CUDNNWrapper::~CUDNNWrapper() {
+  cudnnDestroy(cudnnHandle_);
+}
+
+void CUDNNWrapper::setCudnnTensor(cudnnTensorDescriptor_t& desc, Tensor x) {
+  setCudnnTensor(desc, x->shape());
+}
+
+void CUDNNWrapper::setCudnnTensor(
+    cudnnTensorDescriptor_t& desc,
+    const Shape& shape) {
+  CUDNN_CALL(cudnnCreateTensorDescriptor(&desc));
+  CUDNN_CALL(cudnnSetTensor4dDescriptor(
+        desc,
+        CUDNN_TENSOR_NCHW,
+        CUDNN_DATA_FLOAT,
+        shape[0],
+        shape[1],
+        shape[2],
+        shape[3]));
+}
+
+ConvolutionWrapper::ConvolutionWrapper(
+    const Shape& kernelShape,
+    const Shape& biasShape,
+    int hPad,
+    int wPad,
+    int hStride,
+    int wStride) {
+  setKernelDescriptor(kernelShape);
+  setConvDescriptor(hPad, wPad, hStride, wStride);
+  setCudnnTensor(biasDesc_, biasShape);
+}
+
+void ConvolutionWrapper::getOutputShape(
+    const Shape& xShape,
+    Shape& shape) {
+  cudnnTensorDescriptor_t xDesc;
+  setCudnnTensor(xDesc, xShape);
+  shape.resize(4);
+  CUDNN_CALL(cudnnGetConvolution2dForwardOutputDim(
+        convDesc_,
+        xDesc,
+        kernelDesc_,
+        shape.data(),
+        shape.data() + 1,
+        shape.data() + 2,
+        shape.data() + 3));
+  cudnnDestroyTensorDescriptor(xDesc);
+}
+
+void ConvolutionWrapper::forward(
+    Tensor x,
+    Tensor kernels,
+    Tensor bias,
+    Tensor y) {
+  cudnnTensorDescriptor_t xDesc, yDesc;
+  setCudnnTensor(xDesc, x);
+  setCudnnTensor(yDesc, y);
+
+  const float alpha = 1.0f;
+  const float beta = 0.0f;
+  cudaSetDevice(x->getDevice());
+
+  CUDNN_CALL(cudnnConvolutionForward(
+        cudnnHandle_,
+        &alpha,
+        xDesc,
+        x->data(),
+        kernelDesc_,
+        kernels->data(),
+        convDesc_,
+        CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
+        nullptr,
+        0,
+        &beta,
+        yDesc,
+        y->data()));
+  CUDNN_CALL(cudnnAddTensor(
+        cudnnHandle_,
+        &alpha,
+        biasDesc_,
+        bias->data(),
+        &alpha,
+        yDesc,
+        y->data()));
+  cudnnDestroyTensorDescriptor(xDesc);
+  cudnnDestroyTensorDescriptor(yDesc);
+}
+
+void ConvolutionWrapper::backward(
+    Tensor x,
+    Tensor xGrad,
+    Tensor kernels,
+    Tensor kernelGrad,
+    Tensor biasGrad,
+    Tensor yGrad) {
+  cudaSetDevice(xGrad->getDevice());
+
+  cudnnTensorDescriptor_t xDesc, yDesc;
+  setCudnnTensor(xDesc, xGrad);
+  setCudnnTensor(yDesc, yGrad);
+
+  const float alpha = 1.0f;
+  const float beta = 1.0f;
+
+  CUDNN_CALL(cudnnConvolutionBackwardData(
+        cudnnHandle_,
+        &alpha,
+        kernelDesc_,
+        kernels->data(),
+        yDesc,
+        yGrad->data(),
+        convDesc_,
+        CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
+        nullptr,
+        0,
+        &beta,
+        xDesc,
+        xGrad->data()));
+
+  CUDNN_CALL(cudnnConvolutionBackwardFilter(
+      cudnnHandle_,
+      &alpha,
+      xDesc,
+      x->data(),
+      yDesc,
+      yGrad->data(),
+      convDesc_,
+      CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
+      nullptr,
+      0,
+      &beta,
+      kernelDesc_,
+      kernelGrad->data()));
+
+  CUDNN_CALL(cudnnConvolutionBackwardBias(
+        cudnnHandle_,
+        &alpha,
+        yDesc,
+        yGrad->data(),
+        &beta,
+        biasDesc_,
+        biasGrad->data()));
+
+  cudnnDestroyTensorDescriptor(xDesc);
+  cudnnDestroyTensorDescriptor(yDesc);
+}
+
+ConvolutionWrapper::~ConvolutionWrapper() {
+  cudnnDestroyConvolutionDescriptor(convDesc_);
+  cudnnDestroyFilterDescriptor(kernelDesc_);
+  cudnnDestroyTensorDescriptor(biasDesc_);
+}
+
+void ConvolutionWrapper::setConvDescriptor(
+    int hPad,
+    int wPad,
+    int hStride,
+    int wStride) {
+  CUDNN_CALL(cudnnCreateConvolutionDescriptor(&convDesc_));
+
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
+        convDesc_,
+        hPad,
+        wPad,
+        hStride,
+        wStride,
+        1,
+        1,  // upscales
+#if CUDNN_MAJOR > 5
+        CUDNN_CROSS_CORRELATION,
+        CUDNN_DATA_FLOAT));
+#else
+        CUDNN_CROSS_CORRELATION));
+#endif
+
+}
+
+void ConvolutionWrapper::setKernelDescriptor(const Shape& shape) {
+  ABORT_IF(shape.size() != 4,
+            "CUDN requires tensors 4D. Provided {}", shape.toString());
+  CUDNN_CALL(cudnnCreateFilterDescriptor(&kernelDesc_));
+
+  int layerIn = shape[0];
+  int layerOut = shape[1];
+  int kernelH = shape[2];
+  int kernelW = shape[3];
+
+  CUDNN_CALL(cudnnSetFilter4dDescriptor(
+        kernelDesc_,
+        CUDNN_DATA_FLOAT,
+        CUDNN_TENSOR_NCHW,
+        layerOut,
+        layerIn,
+        kernelH,
+        kernelW));
+}
+
+}
+
+#endif

--- a/src/kernels/cudnn_wrappers.h
+++ b/src/kernels/cudnn_wrappers.h
@@ -1,228 +1,63 @@
 #pragma once
 
-#ifdef CUDNN
-
 #include <cudnn.h>
+#include <iostream>
 
-#define CUDNN_CALL(x)                 \
-  do {                                \
-    if((x) != CUDNN_STATUS_SUCCESS) { \
-      printf("Error (%s) at %s:%d\n", \
-             cudnnGetErrorString(x),  \
-             __FILE__,                \
-             __LINE__);               \
-    }                                 \
-  } while(0)
+#include "common/shape.h"
+#include "tensors/tensor.h"
 
 namespace marian {
 
 class CUDNNWrapper {
 public:
-  CUDNNWrapper() {
-    CUDNN_CALL(cudnnCreate(&cudnnHandle_));
-  }
-
-  virtual ~CUDNNWrapper() {
-    cudnnDestroy(cudnnHandle_);
-  }
+  CUDNNWrapper();
+  virtual ~CUDNNWrapper();
 
 protected:
-  void setCudnnTensor(cudnnTensorDescriptor_t& desc, Tensor x) {
-    setCudnnTensor(desc, x->shape());
-  }
+  void setCudnnTensor(cudnnTensorDescriptor_t& desc, Tensor x);
 
-  void setCudnnTensor(cudnnTensorDescriptor_t& desc, const Shape& shape) {
-    CUDNN_CALL(cudnnCreateTensorDescriptor(&desc));
-    CUDNN_CALL(cudnnSetTensor4dDescriptor(
-          desc,
-          CUDNN_TENSOR_NCHW,
-          CUDNN_DATA_FLOAT,
-          shape[0],
-          shape[1],
-          shape[2],
-          shape[3]));
-  }
+  void setCudnnTensor(cudnnTensorDescriptor_t& desc, const Shape& shape);
 
 protected:
   cudnnHandle_t cudnnHandle_;
 };
 
+
 class ConvolutionWrapper : public CUDNNWrapper {
 public:
   ConvolutionWrapper(
-      Tensor kernels,
-      Tensor bias,
+      const Shape& kernelShape,
+      const Shape& biasShape,
       int hPad = 1,
       int wPad = 1,
       int hStride = 1,
-      int wStride = 1) {
-    setKernelDescriptor(kernels->shape());
-    setConvDescriptor(hPad, wPad, hStride, wStride);
-    setCudnnTensor(biasDesc_, bias);
-  }
+      int wStride = 1);
 
-  ~ConvolutionWrapper() {
-    cudnnDestroyConvolutionDescriptor(convDesc_);
-    cudnnDestroyFilterDescriptor(kernelDesc_);
-    cudnnDestroyTensorDescriptor(biasDesc_);
-  }
+  void getOutputShape(const Shape& xShape, Shape& shape);
 
-  void getOutputShape(Tensor x, Shape& shape) {
-    cudnnTensorDescriptor_t xDesc;
-    setCudnnTensor(xDesc, x);
-    shape.resize(4);
-    CUDNN_CALL(cudnnGetConvolution2dForwardOutputDim(
-          convDesc_,
-          xDesc,
-          kernelDesc_,
-          shape.data(),
-          shape.data() + 1,
-          shape.data() + 2,
-          shape.data() + 3));
-    cudnnDestroyTensorDescriptor(xDesc);
-  }
+  virtual ~ConvolutionWrapper();
 
-  void forward(Tensor x, Tensor y) {
-    cudnnTensorDescriptor_t xDesc, yDesc;
-    setCudnnTensor(xDesc, x);
-    setCudnnTensor(yDesc, y);
-
-    const float alpha = 1.0f;
-    const float beta = 0.0f;
-    cudaSetDevice(x->getDevice());
-
-    CUDNN_CALL(cudnnConvolutionForward(
-          cudnnHandle_,
-          &alpha,
-          xDesc,
-          x->data(),
-          kernelDesc_,
-          kernels_->data(),
-          convDesc_,
-          CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
-          nullptr,
-          0,
-          &beta,
-          yDesc,
-          y->data()));
-    CUDNN_CALL(cudnnAddTensor(
-          cudnnHandle_,
-          &alpha,
-          biasDesc_,
-          bias_->data(),
-          &alpha,
-          yDesc,
-          y->data()));
-    cudnnDestroyTensorDescriptor(xDesc);
-    cudnnDestroyTensorDescriptor(yDesc);
-  }
+  void forward(Tensor x, Tensor Kernels, Tensor bias, Tensor y);
 
   void backward(
       Tensor x,
       Tensor xGrad,
+      Tensor kernels,
       Tensor kernelGrad,
       Tensor biasGrad,
-      Tensor yGrad) {
-    cudaSetDevice(xGrad->getDevice());
-
-    cudnnTensorDescriptor_t xDesc, yDesc;
-    setCudnnTensor(xDesc, xGrad);
-    setCudnnTensor(yDesc, yGrad);
-
-    const float alpha = 1.0f;
-    const float beta = 1.0f;
-
-    CUDNN_CALL(cudnnConvolutionBackwardData(
-          cudnnHandle_,
-          &alpha,
-          kernelDesc_,
-          kernels_->data(),
-          yDesc,
-          yGrad->data(),
-          convDesc_,
-          CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
-          nullptr,
-          0,
-          &beta,
-          xDesc,
-          xGrad->data()));
-
-    CUDNN_CALL(cudnnConvolutionBackwardFilter(
-        cudnnHandle_,
-        &alpha,
-        xDesc,
-        x->data(),
-        yDesc,
-        yGrad->data(),
-        convDesc_,
-        CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
-        nullptr,
-        0,
-        &beta,
-        kernelDesc_,
-        kernelGrad->data()));
-
-    CUDNN_CALL(cudnnConvolutionBackwardBias(
-          cudnnHandle_,
-          &alpha,
-          yDesc,
-          yGrad->data(),
-          &beta,
-          biasDesc_,
-          biasGrad->data()));
-
-    cudnnDestroyTensorDescriptor(xDesc);
-    cudnnDestroyTensorDescriptor(yDesc);
-  }
+      Tensor yGrad);
 
 protected:
-  void setConvDescriptor(int hPad, int wPad, int hStride, int wStride) {
-    CUDNN_CALL(cudnnCreateConvolutionDescriptor(&convDesc_));
+  void setConvDescriptor(int hPad, int wPad, int hStride, int wStride);
 
-    CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-          convDesc_,
-          hPad,
-          wPad,
-          hStride,
-          wStride,
-          1,
-          1,  // upscales
-#if CUDNN_MAJOR > 5
-          CUDNN_CROSS_CORRELATION,
-          CUDNN_DATA_FLOAT));
-#else
-          CUDNN_CROSS_CORRELATION));
-#endif
-  }
-
-  void setKernelDescriptor(const Shape& shape) {
-    CUDNN_CALL(cudnnCreateFilterDescriptor(&kernelDesc_));
-
-    int layerIn = shape[0];
-    int layerOut = shape[1];
-    int kernelH = shape[2];
-    int kernelW = shape[3];
-
-    CUDNN_CALL(cudnnSetFilter4dDescriptor(
-          kernelDesc_,
-          CUDNN_DATA_FLOAT,
-          CUDNN_TENSOR_NCHW,
-          layerOut,
-          layerIn,
-          kernelH,
-          kernelW));
-  }
+  void setKernelDescriptor(const Shape& shape);
 
 protected:
-  Tensor kernels_;
-  Tensor bias_;
   cudnnConvolutionDescriptor_t convDesc_;
   cudnnFilterDescriptor_t kernelDesc_;
   cudnnTensorDescriptor_t biasDesc_;
 
 };
-
-#endif
 
 }
 

--- a/src/kernels/cudnn_wrappers.h
+++ b/src/kernels/cudnn_wrappers.h
@@ -59,5 +59,39 @@ protected:
 
 };
 
+class PoolingWrapper : public CUDNNWrapper {
+public:
+  PoolingWrapper(
+      int height,
+      int width,
+      int padHeight,
+      int padWidth,
+      int strideHeight,
+      int strideWidth,
+      std::string mode);
+
+  void getOutputShape(const Shape& xShape, Shape& shape);
+
+  void forward(Tensor x, Tensor y);
+
+  void backward(Tensor x, Tensor xGrad, Tensor y, Tensor yGrad);
+
+  virtual ~PoolingWrapper();
+
+protected:
+  void setPoolingDescriptor(
+      int height,
+      int width,
+      int padHeight,
+      int padWidth,
+      int strideHeight,
+      int strideWidth);
+
+protected:
+  cudnnPoolingDescriptor_t poolingDesc_;
+  cudnnPoolingMode_t poolingMode_;
+
+};
+
 }
 

--- a/src/kernels/cudnn_wrappers.h
+++ b/src/kernels/cudnn_wrappers.h
@@ -1,0 +1,228 @@
+#pragma once
+
+#ifdef CUDNN
+
+#include <cudnn.h>
+
+#define CUDNN_CALL(x)                 \
+  do {                                \
+    if((x) != CUDNN_STATUS_SUCCESS) { \
+      printf("Error (%s) at %s:%d\n", \
+             cudnnGetErrorString(x),  \
+             __FILE__,                \
+             __LINE__);               \
+    }                                 \
+  } while(0)
+
+namespace marian {
+
+class CUDNNWrapper {
+public:
+  CUDNNWrapper() {
+    CUDNN_CALL(cudnnCreate(&cudnnHandle_));
+  }
+
+  virtual ~CUDNNWrapper() {
+    cudnnDestroy(cudnnHandle_);
+  }
+
+protected:
+  void setCudnnTensor(cudnnTensorDescriptor_t& desc, Tensor x) {
+    setCudnnTensor(desc, x->shape());
+  }
+
+  void setCudnnTensor(cudnnTensorDescriptor_t& desc, const Shape& shape) {
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(
+          desc,
+          CUDNN_TENSOR_NCHW,
+          CUDNN_DATA_FLOAT,
+          shape[0],
+          shape[1],
+          shape[2],
+          shape[3]));
+  }
+
+protected:
+  cudnnHandle_t cudnnHandle_;
+};
+
+class ConvolutionWrapper : public CUDNNWrapper {
+public:
+  ConvolutionWrapper(
+      Tensor kernels,
+      Tensor bias,
+      int hPad = 1,
+      int wPad = 1,
+      int hStride = 1,
+      int wStride = 1) {
+    setKernelDescriptor(kernels->shape());
+    setConvDescriptor(hPad, wPad, hStride, wStride);
+    setCudnnTensor(biasDesc_, bias);
+  }
+
+  ~ConvolutionWrapper() {
+    cudnnDestroyConvolutionDescriptor(convDesc_);
+    cudnnDestroyFilterDescriptor(kernelDesc_);
+    cudnnDestroyTensorDescriptor(biasDesc_);
+  }
+
+  void getOutputShape(Tensor x, Shape& shape) {
+    cudnnTensorDescriptor_t xDesc;
+    setCudnnTensor(xDesc, x);
+    shape.resize(4);
+    CUDNN_CALL(cudnnGetConvolution2dForwardOutputDim(
+          convDesc_,
+          xDesc,
+          kernelDesc_,
+          shape.data(),
+          shape.data() + 1,
+          shape.data() + 2,
+          shape.data() + 3));
+    cudnnDestroyTensorDescriptor(xDesc);
+  }
+
+  void forward(Tensor x, Tensor y) {
+    cudnnTensorDescriptor_t xDesc, yDesc;
+    setCudnnTensor(xDesc, x);
+    setCudnnTensor(yDesc, y);
+
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    cudaSetDevice(x->getDevice());
+
+    CUDNN_CALL(cudnnConvolutionForward(
+          cudnnHandle_,
+          &alpha,
+          xDesc,
+          x->data(),
+          kernelDesc_,
+          kernels_->data(),
+          convDesc_,
+          CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
+          nullptr,
+          0,
+          &beta,
+          yDesc,
+          y->data()));
+    CUDNN_CALL(cudnnAddTensor(
+          cudnnHandle_,
+          &alpha,
+          biasDesc_,
+          bias_->data(),
+          &alpha,
+          yDesc,
+          y->data()));
+    cudnnDestroyTensorDescriptor(xDesc);
+    cudnnDestroyTensorDescriptor(yDesc);
+  }
+
+  void backward(
+      Tensor x,
+      Tensor xGrad,
+      Tensor kernelGrad,
+      Tensor biasGrad,
+      Tensor yGrad) {
+    cudaSetDevice(xGrad->getDevice());
+
+    cudnnTensorDescriptor_t xDesc, yDesc;
+    setCudnnTensor(xDesc, xGrad);
+    setCudnnTensor(yDesc, yGrad);
+
+    const float alpha = 1.0f;
+    const float beta = 1.0f;
+
+    CUDNN_CALL(cudnnConvolutionBackwardData(
+          cudnnHandle_,
+          &alpha,
+          kernelDesc_,
+          kernels_->data(),
+          yDesc,
+          yGrad->data(),
+          convDesc_,
+          CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
+          nullptr,
+          0,
+          &beta,
+          xDesc,
+          xGrad->data()));
+
+    CUDNN_CALL(cudnnConvolutionBackwardFilter(
+        cudnnHandle_,
+        &alpha,
+        xDesc,
+        x->data(),
+        yDesc,
+        yGrad->data(),
+        convDesc_,
+        CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
+        nullptr,
+        0,
+        &beta,
+        kernelDesc_,
+        kernelGrad->data()));
+
+    CUDNN_CALL(cudnnConvolutionBackwardBias(
+          cudnnHandle_,
+          &alpha,
+          yDesc,
+          yGrad->data(),
+          &beta,
+          biasDesc_,
+          biasGrad->data()));
+
+    cudnnDestroyTensorDescriptor(xDesc);
+    cudnnDestroyTensorDescriptor(yDesc);
+  }
+
+protected:
+  void setConvDescriptor(int hPad, int wPad, int hStride, int wStride) {
+    CUDNN_CALL(cudnnCreateConvolutionDescriptor(&convDesc_));
+
+    CUDNN_CALL(cudnnSetConvolution2dDescriptor(
+          convDesc_,
+          hPad,
+          wPad,
+          hStride,
+          wStride,
+          1,
+          1,  // upscales
+#if CUDNN_MAJOR > 5
+          CUDNN_CROSS_CORRELATION,
+          CUDNN_DATA_FLOAT));
+#else
+          CUDNN_CROSS_CORRELATION));
+#endif
+  }
+
+  void setKernelDescriptor(const Shape& shape) {
+    CUDNN_CALL(cudnnCreateFilterDescriptor(&kernelDesc_));
+
+    int layerIn = shape[0];
+    int layerOut = shape[1];
+    int kernelH = shape[2];
+    int kernelW = shape[3];
+
+    CUDNN_CALL(cudnnSetFilter4dDescriptor(
+          kernelDesc_,
+          CUDNN_DATA_FLOAT,
+          CUDNN_TENSOR_NCHW,
+          layerOut,
+          layerIn,
+          kernelH,
+          kernelW));
+  }
+
+protected:
+  Tensor kernels_;
+  Tensor bias_;
+  cudnnConvolutionDescriptor_t convDesc_;
+  cudnnFilterDescriptor_t kernelDesc_;
+  cudnnTensorDescriptor_t biasDesc_;
+
+};
+
+#endif
+
+}
+

--- a/src/kernels/cudnn_wrappers.h
+++ b/src/kernels/cudnn_wrappers.h
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <cudnn.h>
 #include <iostream>
 
 #include "common/shape.h"
 #include "tensors/tensor.h"
+
+#ifdef CUDNN
+
+#include <cudnn.h>
 
 namespace marian {
 
@@ -94,4 +97,65 @@ protected:
 };
 
 }
+
+#else
+
+namespace marian {
+
+class CUDNNWrapper {
+public:
+  CUDNNWrapper();
+  virtual ~CUDNNWrapper();
+};
+
+
+class ConvolutionWrapper : public CUDNNWrapper {
+public:
+  ConvolutionWrapper(
+      const Shape& kernelShape,
+      const Shape& biasShape,
+      int hPad = 1,
+      int wPad = 1,
+      int hStride = 1,
+      int wStride = 1);
+
+  void getOutputShape(const Shape& xShape, Shape& shape);
+
+  virtual ~ConvolutionWrapper();
+
+  void forward(Tensor x, Tensor Kernels, Tensor bias, Tensor y);
+
+  void backward(
+      Tensor x,
+      Tensor xGrad,
+      Tensor kernels,
+      Tensor kernelGrad,
+      Tensor biasGrad,
+      Tensor yGrad);
+
+};
+
+class PoolingWrapper : public CUDNNWrapper {
+public:
+  PoolingWrapper(
+      int height,
+      int width,
+      int padHeight,
+      int padWidth,
+      int strideHeight,
+      int strideWidth,
+      std::string mode);
+
+  void getOutputShape(const Shape& xShape, Shape& shape);
+
+  void forward(Tensor x, Tensor y);
+
+  void backward(Tensor x, Tensor xGrad, Tensor y, Tensor yGrad);
+
+  virtual ~PoolingWrapper();
+};
+
+}
+
+#endif
 

--- a/src/kernels/cudnn_wrappers.h
+++ b/src/kernels/cudnn_wrappers.h
@@ -25,16 +25,14 @@ protected:
   cudnnHandle_t cudnnHandle_;
 };
 
-
 class ConvolutionWrapper : public CUDNNWrapper {
 public:
-  ConvolutionWrapper(
-      const Shape& kernelShape,
-      const Shape& biasShape,
-      int hPad = 1,
-      int wPad = 1,
-      int hStride = 1,
-      int wStride = 1);
+  ConvolutionWrapper(const Shape& kernelShape,
+                     const Shape& biasShape,
+                     int hPad = 1,
+                     int wPad = 1,
+                     int hStride = 1,
+                     int wStride = 1);
 
   void getOutputShape(const Shape& xShape, Shape& shape);
 
@@ -42,13 +40,12 @@ public:
 
   void forward(Tensor x, Tensor Kernels, Tensor bias, Tensor y);
 
-  void backward(
-      Tensor x,
-      Tensor xGrad,
-      Tensor kernels,
-      Tensor kernelGrad,
-      Tensor biasGrad,
-      Tensor yGrad);
+  void backward(Tensor x,
+                Tensor xGrad,
+                Tensor kernels,
+                Tensor kernelGrad,
+                Tensor biasGrad,
+                Tensor yGrad);
 
 protected:
   void setConvDescriptor(int hPad, int wPad, int hStride, int wStride);
@@ -59,19 +56,17 @@ protected:
   cudnnConvolutionDescriptor_t convDesc_;
   cudnnFilterDescriptor_t kernelDesc_;
   cudnnTensorDescriptor_t biasDesc_;
-
 };
 
 class PoolingWrapper : public CUDNNWrapper {
 public:
-  PoolingWrapper(
-      int height,
-      int width,
-      int padHeight,
-      int padWidth,
-      int strideHeight,
-      int strideWidth,
-      std::string mode);
+  PoolingWrapper(int height,
+                 int width,
+                 int padHeight,
+                 int padWidth,
+                 int strideHeight,
+                 int strideWidth,
+                 std::string mode);
 
   void getOutputShape(const Shape& xShape, Shape& shape);
 
@@ -82,20 +77,17 @@ public:
   virtual ~PoolingWrapper();
 
 protected:
-  void setPoolingDescriptor(
-      int height,
-      int width,
-      int padHeight,
-      int padWidth,
-      int strideHeight,
-      int strideWidth);
+  void setPoolingDescriptor(int height,
+                            int width,
+                            int padHeight,
+                            int padWidth,
+                            int strideHeight,
+                            int strideWidth);
 
 protected:
   cudnnPoolingDescriptor_t poolingDesc_;
   cudnnPoolingMode_t poolingMode_;
-
 };
-
 }
 
 #else
@@ -108,16 +100,14 @@ public:
   virtual ~CUDNNWrapper();
 };
 
-
 class ConvolutionWrapper : public CUDNNWrapper {
 public:
-  ConvolutionWrapper(
-      const Shape& kernelShape,
-      const Shape& biasShape,
-      int hPad = 1,
-      int wPad = 1,
-      int hStride = 1,
-      int wStride = 1);
+  ConvolutionWrapper(const Shape& kernelShape,
+                     const Shape& biasShape,
+                     int hPad = 1,
+                     int wPad = 1,
+                     int hStride = 1,
+                     int wStride = 1);
 
   void getOutputShape(const Shape& xShape, Shape& shape);
 
@@ -125,26 +115,23 @@ public:
 
   void forward(Tensor x, Tensor Kernels, Tensor bias, Tensor y);
 
-  void backward(
-      Tensor x,
-      Tensor xGrad,
-      Tensor kernels,
-      Tensor kernelGrad,
-      Tensor biasGrad,
-      Tensor yGrad);
-
+  void backward(Tensor x,
+                Tensor xGrad,
+                Tensor kernels,
+                Tensor kernelGrad,
+                Tensor biasGrad,
+                Tensor yGrad);
 };
 
 class PoolingWrapper : public CUDNNWrapper {
 public:
-  PoolingWrapper(
-      int height,
-      int width,
-      int padHeight,
-      int padWidth,
-      int strideHeight,
-      int strideWidth,
-      std::string mode);
+  PoolingWrapper(int height,
+                 int width,
+                 int padHeight,
+                 int padWidth,
+                 int strideHeight,
+                 int strideWidth,
+                 std::string mode);
 
   void getOutputShape(const Shape& xShape, Shape& shape);
 
@@ -154,8 +141,6 @@ public:
 
   virtual ~PoolingWrapper();
 };
-
 }
 
 #endif
-

--- a/src/kernels/tensor_operators.cu
+++ b/src/kernels/tensor_operators.cu
@@ -1,5 +1,4 @@
-#include <thrust/transform_reduce.h>
-
+#include <thrust/transform_reduce.h> 
 #include "kernels/cuda_helpers.h"
 #include "kernels/tensor_operators.h"
 

--- a/src/models/model_factory.cpp
+++ b/src/models/model_factory.cpp
@@ -8,9 +8,7 @@
 #include "models/transformer.h"
 
 #include "examples/mnist/model.h"
-#ifdef CUDNN
 #include "examples/mnist/model_lenet.h"
-#endif
 
 namespace marian {
 namespace models {
@@ -169,11 +167,10 @@ Ptr<ModelBase> by_type(std::string type, Ptr<Options> options) {
   if(type == "mnist-ffnn") {
     return New<MnistFeedForwardNet>(options);
   }
-#ifdef CUDNN
+
   if(type == "mnist-lenet") {
     return New<MnistLeNet>(options);
   }
-#endif
 
   // clang-format on
   ABORT("Unknown model type: {}", type);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -37,11 +37,9 @@ endforeach(exec)
 
 if(CUDNN_FOUND)
     cuda_add_executable(conv_test conv_test.cu)
-    # cuda_add_executable(conv_char_test conv_char_test.cu)
 
     foreach(exec
             conv_test
-            # conv_char_test
     )
         target_link_libraries(${exec} marian ${EXT_LIBS})
         cuda_add_cublas_to_target(${exec})


### PR DESCRIPTION
Tiding up cudnn depended code. I moved the code to new files. Moreover, the ``#ifdef CUDNN`` occurs only in those files.  I didn't change cmake configuration, so in default, so the compilation with cudnn is turned off. What I changed is the presence of e.g. mnist-lenet model. Whether someone tries to run mnist-lenet model without cudnn support, they get an informative message .