### PR TITLE
Updates graph_group_multinode.h with cuda_runtime

### DIFF
--- a/src/training/graph_group_multinode.h
+++ b/src/training/graph_group_multinode.h
@@ -2,6 +2,7 @@
 
 #if MPI_FOUND
 #include "mpi.h"
+#include "cuda_runtime.h"
 #endif
 
 #include <condition_variable>


### PR DESCRIPTION
With MPI enabled, I hit a compilation error on the cudaMemcpy in graph_group_multinode.cpp.
This is a one-liner, adding #include <cuda_runtime.h> to graph_group_multinode.h inside the MPI_FOUND block.