### PR TITLE
optimize asynchronous gradient dropping

### DIFF
--- a/src/training/gradient_dropping/gpu/sparse_algorithm.h
+++ b/src/training/gradient_dropping/gpu/sparse_algorithm.h
@@ -16,5 +16,10 @@ namespace marian {
     int buildSparse(Tensor t, float* data, int* indices);
 
     void scatterAdd(Tensor t, float* data, int *indices, int size, int offset);
+
+    void scatterUpdate(Tensor t, float* data, int *indices, int size, int offset);
+    
+    void gather(Tensor t, float* data, int *indices, int size, int offset);
+     
   }
 }

--- a/src/training/graph_group_async_drop.cpp
+++ b/src/training/graph_group_async_drop.cpp
@@ -8,108 +8,75 @@
 
 namespace marian {
 
-Tensor AsyncGraphGroupDrop::newTensor(int size, Ptr<Backend> backend) {
-  Tensor t;
-  Ptr<TensorAllocator> allocator_ = New<TensorAllocator>(backend);
-  allocator_->reserveExact(size * sizeof(float));
-  allocator_->allocate(t, {1, size});
-  allocators.push_back(allocator_);
-
-  return t;
-}
-
 void AsyncGraphGroupDrop::fetchParams(Tensor oldParams,
                                       const std::vector<Tensor>& params,
                                       int device_id) {
-  using namespace functional;
-  // @TODO read guard on parameters
-  int pos = 0;
+
+  // Full fetch when fetching moving average OR still in warm-up period.
+  if(&params == &paramsAvg_ || 
+    fetchStep_[device_id]++ <= dropping_warmup) {
+    AsyncGraphGroup::fetchParams(oldParams, params, device_id);
+    return;
+  }
 
   std::vector<std::thread> threads;
-  for(int i = 0; i < devices_.size(); i++) {
-    threads.emplace_back(std::thread(
-        [&](int idx, int pos) {
-          // individual mutex per-shard
-          std::lock_guard<std::mutex> guard(shardSync_[idx]);
+  int pos = 0;
+  for(int idx = 0; idx < devices_.size(); idx++) {
+  threads.emplace_back(std::thread(
+      [=](int idx, int pos) {
+        auto sparseGrad = sparseGrads_[device_id][idx];
+        auto sparseShard = sparseShards_[device_id][idx];
 
-          // normal fetch
-          if(fetchStep_[device_id] <= dropping_warmup
-             || &params == &paramsAvg_) {  // Do not use sparse fetch when
-                                           // fetching from paramsAvg
-            oldParams->subtensor(pos, params[idx]->size())
-                ->copyFrom(params[idx]);
-            paramsLocal_[device_id][idx]->copyFrom(params[idx]);
-            return;
-          }
+        // individual mutex per-shard
+        std::lock_guard<std::mutex> guard(shardSync_[idx]);
 
-          // sparse fetch
-          // get delta : params latest version - current param (locally)
-          Element(_1 = _2 - _3,
-                  paramsDelta_[idx],
-                  params[idx],
-                  paramsLocal_[device_id][idx]);
-
-          // update current local param
-          paramsLocal_[device_id][idx]->copyFrom(params[idx]);
-
-          // get sparse delta
-          fetchDropper[device_id][idx]->dropGraph(paramsDelta_[idx],
-                                                  fetchSparseGradient_[idx],
-                                                  droping_rate,
-                                                  dropping_momentum);
-
-          // move sparse delta
-          fetchShardedSparseGradient_[device_id][idx]->copyFrom(
-              fetchSparseGradient_[idx]);
-
-          fetchShardedSparseGradient_[device_id][idx]->scatterAdd(
-              oldParams->subtensor(pos, params[idx]->size()));
-        },
-        i,
-        pos));
+        sparseShard->gather(params[idx]);
+        sparseGrad->copyFrom(sparseShard);
+        sparseGrad->scatterUpdate(oldParams->subtensor(pos, params[idx]->size()));
+      },
+      idx,
+      pos));
 
     pos += shardSize_;
   }
-  for(auto&& t : threads) {
+  for(auto&& t : threads)
     t.join();
-  }
-  fetchStep_[device_id]++;
 }
 
 void AsyncGraphGroupDrop::pushGradients(Tensor newGrads,
                                         size_t batch_words,
                                         int device_id) {
-  if(pushStep_[device_id]++ <= dropping_warmup) {
+  if(pushStep_[device_id]++ < dropping_warmup) {
     AsyncGraphGroup::pushGradients(newGrads, batch_words, device_id);
     return;
   }
 
-  // get the sparse gradient
-  pushDropper_[device_id]->dropGraph(newGrads,
-                                     pushSparseGradient_[device_id],
-                                     droping_rate,
-                                     dropping_momentum);
-
-  SparseTensor newSparseGrads = pushSparseGradient_[device_id];
   // add instead of copy?
   std::vector<std::thread> threads;
   int pos = 0;
   for(int idx = 0; idx < devices_.size(); idx++) {
     threads.emplace_back(std::thread(
         [=](int idx, int pos) {
+          auto dropper = droppers_[device_id][idx];
+          auto sparseGrad = sparseGrads_[device_id][idx];
+          auto sparseShard = sparseShards_[device_id][idx];
+          auto tensor = newGrads->subtensor(pos, grads_[idx]->size());
           // individual mutex per-shard
           std::lock_guard<std::mutex> guard(shardSync_[idx]);
-
-          // split to shard
-          SparseTensor subGrad
-              = newSparseGrads->subtensor(pos, grads_[idx]->size());
-
+          
+          // drop the gradients
+          dropper->dropGraph(tensor, sparseGrad, 
+                             droping_rate, dropping_momentum);
+          
           // send the sharded sparse tensor
-          pushShardedSparseGradient_[idx]->copyFrom(subGrad);
+          sparseShard->copyFrom(sparseGrad);
 
           // convert back to dense, store it in grads_[idx]
-          pushShardedSparseGradient_[idx]->toDense(grads_[idx], -pos);
+          // sparseShard indices is equal to the indices of the sparse gradient
+          // which will be used for sparse fetching
+          sparseShard->toDense(grads_[idx]);
 
+          // optimize
           if(scaleLearningRate_) {
             shardOpt_[idx]->update(
                 params_[idx], grads_[idx], batch_words / avgBatchWords_);
@@ -120,7 +87,6 @@ void AsyncGraphGroupDrop::pushGradients(Tensor newGrads,
           if(movingAvg_)
             updateMovingAverage(
                 paramsAvg_[idx], params_[idx], scheduler_->numberOfBatches());
-
         },
         idx,
         pos));
@@ -135,51 +101,35 @@ void AsyncGraphGroupDrop::init(Ptr<data::Batch> batch) {
   AsyncGraphGroup::init(batch);
   // extra inits for gradient dropping
   if(drop_first) {
-    int totalSize = graphs_[0]->params()->vals()->size();
-    int sparseCap = totalSize * 1.5 * (1.0 - droping_rate);
-    int shardSize = ceil(totalSize / devices_.size());
-
-    for(int i = 0; i < devices_.size(); i++)
-      paramsLocal_.push_back(std::vector<Tensor>());
-
     for(int i = 0; i < devices_.size(); i++) {
       // warm-up counter
       fetchStep_.push_back(0);
       pushStep_.push_back(0);
+      fetch_ready.push_back(false);
 
-      // temporary tensor to compute parameter delta before fetching
-      paramsDelta_.push_back(newTensor(shardSize, graphs_[i]->getBackend()));
+      // Size of the sparse tensor
+      int totalSize = graphs_[0]->params()->vals()->size();
+      int sparseCap = totalSize * 1.2 * (1.0 - droping_rate);
 
-      // tensors to store local params history
-      for(int h_id = 0; h_id < devices_.size(); h_id++) {
-        Tensor tmp = newTensor(params_[i]->size(), graphs_[i]->getBackend());
-        tmp->copyFrom(params_[i]);
-        paramsLocal_[h_id].push_back(tmp);
-      }
-
-      // individual Gradient dropper per-device
-      pushDropper_.push_back(PrepareGradientDrop(graphs_[i]->getDevice()));
-
-      // N-dropper for fetch
+      // prepare droppers
       std::vector<GradientDrop> tmpDropper;
       for(auto device : devices_)
         tmpDropper.push_back(PrepareGradientDrop(graphs_[i]->getDevice()));
-      fetchDropper.push_back(tmpDropper);
+      droppers_.push_back(tmpDropper);
 
-      // sparsetensor to store sparsified gradients per-device
-      pushSparseGradient_.push_back(SparseTensor(
-          new SparseTensorBase(sparseCap, graphs_[i]->getBackend())));
-
-      pushShardedSparseGradient_.push_back(SparseTensor(
-          new SparseTensorBase(sparseCap, graphs_[i]->getBackend())));
-      fetchSparseGradient_.push_back(SparseTensor(new SparseTensorBase(
-          sparseCap / devices_.size(), graphs_[i]->getBackend())));
-
+      // sparsetensor to store sparsified gradients per-device per-shard
       std::vector<SparseTensor> tmp;
       for(int j = 0; j < devices_.size(); j++)
         tmp.push_back(SparseTensor(new SparseTensorBase(
             sparseCap / devices_.size(), graphs_[i]->getBackend())));
-      fetchShardedSparseGradient_.push_back(tmp);
+      sparseGrads_.push_back(tmp);
+       
+      std::vector<SparseTensor> tmp2;
+      for(int j = 0; j < devices_.size(); j++)
+        tmp2.push_back(SparseTensor(new SparseTensorBase(
+            sparseCap / devices_.size(), graphs_[j]->getBackend()))); 
+      sparseShards_.push_back(tmp2);
+
     }
     drop_first = false;
   }

--- a/src/training/graph_group_async_drop.h
+++ b/src/training/graph_group_async_drop.h
@@ -10,6 +10,7 @@ namespace marian {
 class AsyncGraphGroupDrop : public AsyncGraphGroup {
   std::vector<int> fetchStep_;
   std::vector<int> pushStep_;
+  std::vector<bool> fetch_ready;
 
   bool drop_first = 1;
 
@@ -17,21 +18,9 @@ class AsyncGraphGroupDrop : public AsyncGraphGroup {
   float droping_rate;
   float dropping_momentum;
 
-  std::vector<GradientDrop> pushDropper_;
-  std::vector<std::vector<GradientDrop>> fetchDropper;
+  std::vector<std::vector<GradientDrop>> droppers_;
 
-  std::vector<SparseTensor> pushSparseGradient_;
-  std::vector<SparseTensor> pushShardedSparseGradient_;
-
-  std::vector<SparseTensor> fetchSparseGradient_;
-  std::vector<std::vector<SparseTensor>> fetchShardedSparseGradient_;
-
-  std::vector<Tensor> paramsDelta_;
-  std::vector<std::vector<Tensor>> paramsLocal_;
-
-  std::vector<Ptr<TensorAllocator>> allocators;
-
-  Tensor newTensor(int size, Ptr<Backend> backend);
+  std::vector<std::vector<SparseTensor>> sparseGrads_, sparseShards_;
 
 protected:
   void init(Ptr<data::Batch> batch);


### PR DESCRIPTION
 - Reduce memory usage on gradient dropping.
 - Add some class function (mainly preparation for multinode).
 - Do not re-compress delta parameter when fetching. Just get a sparse new parameter based on the sent sparse gradient.
 - The code in graph_group_async_drop is much more simpler