### PR TITLE
Some more boost-related housekeeping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_RELEASE})
 set(EXT_LIBS ${EXT_LIBS} ${CMAKE_DL_LIBS})
 
 if(COMPILE_CUDA)
-find_package(CUDA "8.0" REQUIRED)
+find_package(CUDA "8.0")
 if(CUDA_FOUND)
   set(EXT_LIBS ${EXT_LIBS} ${CUDA_curand_LIBRARY} ${CUDA_cusparse_LIBRARY})
 
@@ -65,7 +65,7 @@ if(CUDA_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUDA_FOUND")
   list(APPEND CUDA_NVCC_FLAGS -DCUDA_FOUND; )
 else(CUDA_FOUND)
-  message(WARNING "Cannot find CUDA compiling CPU version only")
+  message(FATAL_ERROR "CUDA has not been found, set -DCOMPILE_CUDA=off to avoid this check and to compile the CPU version only")
 endif(CUDA_FOUND)
 
 else(COMPILE_CUDA)
@@ -124,8 +124,7 @@ if(COMPILE_CPU)
   endif(MKL_FOUND)
 endif(COMPILE_CPU)
 
-set(BOOST_COMPONENTS system timer iostreams filesystem chrono thread)
-
+set(BOOST_COMPONENTS system timer iostreams filesystem chrono)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
   add_definitions(-DUSE_BOOST_REGEX=1)
   set(BOOST_COMPONENTS ${BOOST_COMPONENTS} regex)
@@ -133,7 +132,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERS
 else()
   message("-- Using std::regex")
 endif()
-
 
 if(COMPILE_SERVER)
   find_package(OpenSSL)
@@ -170,8 +168,6 @@ if(Boost_FOUND)
 else(Boost_FOUND)
   message(SEND_ERROR "Cannot find Boost libraries. Terminating.")
 endif(Boost_FOUND)
-
-
 
 if(COMPILE_TESTS)
   enable_testing()

--- a/src/3rd_party/exception.cpp
+++ b/src/3rd_party/exception.cpp
@@ -12,6 +12,7 @@
 #include <io.h>
 #endif
 
+namespace marian {
 namespace util {
 
 Exception::Exception() throw() {}
@@ -106,3 +107,4 @@ WindowsException::~WindowsException() throw() {}
 #endif
 
 } // namespace util
+} // marian

--- a/src/3rd_party/exception.h
+++ b/src/3rd_party/exception.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <stdint.h>
 
+namespace marian {
 namespace util {
 
 template <class Except, class Data> typename Except::template ExceptionTag<Except&>::Identity operator<<(Except &e, const Data &data);
@@ -170,3 +171,4 @@ class WindowsException : public Exception {
 #endif
 
 } // namespace util
+} // namespace marian

--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -67,7 +67,7 @@ void loadItems(const void* current, std::vector<io::Item>& items, bool mapped) {
 
 void loadItems(const std::string& fileName, std::vector<io::Item>& items) {
   // Read file into buffer
-  size_t fileSize = boost::filesystem::file_size(fileName);
+  size_t fileSize = filesystem::fileSize(fileName);
   char* ptr = new char[fileSize];
   InputFileStream in(fileName);
   in.read(ptr, fileSize);

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -48,7 +48,7 @@ void Config::initialize(int argc, char** argv, cli::mode mode, bool validate) {
     seed = get<size_t>("seed");
 
   if(mode != cli::mode::translation) {
-    if(boost::filesystem::exists(get<std::string>("model"))
+    if(filesystem::exists(get<std::string>("model"))
        && !get<bool>("no-reload")) {
       try {
         if(!get<bool>("ignore-model-config"))

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -1,8 +1,17 @@
+#include "common/definitions.h"
+
+#include "common/cli_helper.h"
+#include "common/config_parser.h"
+#include "common/config_validator.h"
+#include "common/file_stream.h"
+#include "common/logging.h"
+#include "common/utils.h"
+#include "3rd_party/exception.h"
+
 #include <algorithm>
 #include <set>
 #include <stdexcept>
 #include <string>
-
 #include <boost/algorithm/string.hpp>
 
 #if MKL_FOUND
@@ -12,15 +21,6 @@
 #include <cblas.h>
 #endif
 #endif
-
-#include "common/definitions.h"
-
-#include "common/cli_helper.h"
-#include "common/config_parser.h"
-#include "common/config_validator.h"
-#include "common/file_stream.h"
-#include "common/logging.h"
-#include "common/utils.h"
 
 namespace marian {
 

--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -3,8 +3,7 @@
 #include "common/logging.h"
 #include "common/regex.h"
 #include "common/utils.h"
-
-#include <boost/filesystem.hpp>
+#include "common/filesystem.h"
 
 namespace marian {
 
@@ -45,8 +44,8 @@ void ConfigValidator::validateOptionsTranslation() const {
                  "Translating, but vocabularies are not given!");
 
   for(const auto& modelFile : models) {
-    boost::filesystem::path modelPath(modelFile);
-    UTIL_THROW_IF2(!boost::filesystem::exists(modelPath),
+    filesystem::Path modelPath(modelFile);
+    UTIL_THROW_IF2(!filesystem::exists(modelPath),
                    "Model file does not exist: " + modelFile);
   }
 }
@@ -62,9 +61,9 @@ void ConfigValidator::validateOptionsParallelData() const {
 }
 
 void ConfigValidator::validateOptionsScoring() const {
-  boost::filesystem::path modelPath(get<std::string>("model"));
+  filesystem::Path modelPath(get<std::string>("model"));
 
-  UTIL_THROW_IF2(!boost::filesystem::exists(modelPath),
+  UTIL_THROW_IF2(!filesystem::exists(modelPath),
                  "Model file does not exist: " + modelPath.string());
   UTIL_THROW_IF2(get<std::vector<std::string>>("vocabs").empty(),
                  "Scoring, but vocabularies are not given!");
@@ -79,19 +78,17 @@ void ConfigValidator::validateOptionsTraining() const {
                  != trainSets.size(),
       "There should be as many embedding vector files as training sets");
 
-  boost::filesystem::path modelPath(get<std::string>("model"));
+  filesystem::Path modelPath(get<std::string>("model"));
 
-  auto modelDir = modelPath.parent_path();
+  auto modelDir = modelPath.parentPath();
   if(modelDir.empty())
-    modelDir = boost::filesystem::current_path();
+    modelDir = filesystem::currentPath();
 
   UTIL_THROW_IF2(
-      !modelDir.empty() && !boost::filesystem::is_directory(modelDir),
+      !modelDir.empty() && !filesystem::isDirectory(modelDir),
       "Model directory does not exist");
 
-  UTIL_THROW_IF2(!modelDir.empty()
-                     && !(boost::filesystem::status(modelDir).permissions()
-                          & boost::filesystem::owner_write),
+  UTIL_THROW_IF2(!modelDir.empty() && !filesystem::canWrite(modelDir),
                  "No write permission in model directory");
 
   UTIL_THROW_IF2(has("valid-sets")

--- a/src/common/file_stream.h
+++ b/src/common/file_stream.h
@@ -12,7 +12,6 @@
 #pragma warning(pop)
 #include <boost/iostreams/filtering_stream.hpp>
 #include <iostream>
-#include "3rd_party/exception.h"
 #include "common/logging.h"
 
 #ifdef _WIN32

--- a/src/common/file_stream.h
+++ b/src/common/file_stream.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <boost/filesystem.hpp>
+// @TODO: this file still contains lots of stuff from boost::filesystem and boost::iostreams,
+// this has to be figured out.
+
+#include "common/filesystem.h"
+
 #include <boost/filesystem/fstream.hpp>
 #include <boost/iostreams/device/file_descriptor.hpp>
 #pragma warning(push)
@@ -94,11 +98,11 @@ public:
 
 class InputFileStream {
 public:
-  InputFileStream(const std::string& file) : file_(file), ifstream_(file_) {
+  InputFileStream(const std::string& file) : file_(file), ifstream_(file_.getBoost()) {
     ABORT_IF(
-        !boost::filesystem::exists(file_), "File '{}' does not exist", file);
+        !marian::filesystem::exists(file_), "File '{}' does not exist", file);
 
-    if(file_.extension() == ".gz")
+    if(file_.extension() == marian::filesystem::Path(std::string(".gz")))
       istream_.push(io::gzip_decompressor());
     istream_.push(ifstream_);
   }
@@ -132,7 +136,7 @@ public:
   bool empty() { return ifstream_.peek() == std::ifstream::traits_type::eof(); }
 
 private:
-  boost::filesystem::path file_;
+  marian::filesystem::Path file_;
   boost::filesystem::ifstream ifstream_;
   io::file_descriptor_source fds_;
   io::filtering_istream istream_;
@@ -140,11 +144,11 @@ private:
 
 class OutputFileStream {
 public:
-  OutputFileStream(const std::string& file) : file_(file), ofstream_(file_) {
+  OutputFileStream(const std::string& file) : file_(file), ofstream_(file_.getBoost()) {
     ABORT_IF(
-        !boost::filesystem::exists(file_), "File '{}' does not exist", file);
+        !marian::filesystem::exists(file_), "File '{}' does not exist", file);
 
-    if(file_.extension() == ".gz")
+    if(file_.extension() == marian::filesystem::Path(std::string(".gz")))
       ostream_.push(io::gzip_compressor());
     ostream_.push(ofstream_);
   }
@@ -176,7 +180,7 @@ public:
   std::string path() { return file_.string(); }
 
 private:
-  boost::filesystem::path file_;
+  marian::filesystem::Path file_;
   boost::filesystem::ofstream ofstream_;
   io::file_descriptor_sink fds_;
   io::filtering_ostream ostream_;

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -1,0 +1,95 @@
+#pragma once
+
+// @TODO: This is a temporary file to move every function from boost::filesystem used in Marian
+// into one place. Marian should call functions only from this file. boost::filesystem will
+// be removed. This needs to be portable to Windows too.
+
+#include <boost/filesystem.hpp>
+
+namespace marian {
+namespace filesystem {
+
+  struct Path {
+    private:
+      boost::filesystem::path path;
+
+    public:
+      Path() {}
+      Path(const Path& p) : path{p.path} {}
+      Path(const std::string& s) : path{s} {}
+      Path(const boost::filesystem::path& p) : path{p} {}
+
+      Path parentPath() const {
+        return Path{path.parent_path()};
+      }
+
+      Path filename() const {
+        return Path{path.filename()};
+      }
+
+      Path extension() const {
+        return Path{path.extension()};
+      }
+
+      bool empty() const {
+        return path.empty();
+      }
+
+      const boost::filesystem::path& getBoost() const {
+        return path;
+      }
+
+      operator std::string&() {
+        return (std::string&)path;
+      }
+
+      operator std::string() const {
+        return path.string();
+      }
+
+      std::string string() const {
+        return path.string();
+      }
+
+      bool operator==(const Path& p) const {
+        return path == p.path;
+      }
+
+      bool operator!=(const Path& p) const {
+        return path != p.path;
+      }
+  };
+
+  static inline Path currentPath() {
+    return Path{boost::filesystem::current_path()};
+  }
+
+  static inline Path canonical(const Path& p, const Path& dir) {
+    return Path{ boost::filesystem::canonical(p.getBoost(), dir.getBoost()) };
+  }
+
+  static inline bool exists(const Path& p) {
+    return boost::filesystem::exists(p.getBoost());
+  }
+
+  static inline size_t fileSize(const Path& p) {
+    return boost::filesystem::file_size(p.getBoost());
+  }
+
+  static inline bool isDirectory(const Path& p) {
+    return boost::filesystem::is_directory(p.getBoost());
+  }
+
+  static inline bool canWrite(const Path& p) {
+    return (bool)(boost::filesystem::status(p.getBoost()).permissions() & boost::filesystem::owner_write);
+  }
+
+  // concatenation?
+  static inline Path operator/ (const Path& lhs, const Path& rhs) {
+    return lhs.getBoost() / rhs.getBoost();
+  }
+
+  using FilesystemError = boost::filesystem::filesystem_error;
+
+}
+}

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <functional>
+
+namespace marian {
+namespace util {
+
+template <class T> using hash = std::hash<T>;
+
+template <class T>
+inline void hash_combine(std::size_t& seed, T const& v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+}
+
+}
+}

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -7,9 +7,13 @@ namespace util {
 
 template <class T> using hash = std::hash<T>;
 
+// This combinator is based on boost::hash_combine, but uses
+// std::hash as the hash implementation. Used as a drop-in
+// replacement for boost::hash_combine.
+
 template <class T>
 inline void hash_combine(std::size_t& seed, T const& v) {
-    std::hash<T> hasher;
+    hash<T> hasher;
     seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
 }
 

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -5,7 +5,6 @@
 #include "common/config.h"
 #include "common/definitions.h"
 
-#include "3rd_party/exception.h"
 #include "3rd_party/yaml-cpp/yaml.h"
 
 #define YAML_REGISTER_TYPE(registered, type)                \

--- a/src/common/shape.h
+++ b/src/common/shape.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <algorithm>
-#include <boost/functional/hash.hpp>
 #include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "common/hash.h"
 #include "common/logging.h"
 
 namespace marian {
@@ -197,9 +197,9 @@ public:
   }
 
   size_t hash() const {
-    size_t seed = boost::hash<int>()(shape_[0]);
+    size_t seed = util::hash<int>()(shape_[0]);
     for(size_t i = 1; i < shape_.size(); ++i)
-      boost::hash_combine(seed, shape_[i]);
+      util::hash_combine(seed, shape_[i]);
     return seed;
   }
 };

--- a/src/data/corpus_base.cpp
+++ b/src/data/corpus_base.cpp
@@ -147,7 +147,7 @@ CorpusBase::CorpusBase(Ptr<Config> options, bool translate)
   if(training && options_->has("guided-alignment")) {
     auto path = options_->get<std::string>("guided-alignment");
 
-    ABORT_IF(!boost::filesystem::exists(path), "Alignment file does not exist");
+    ABORT_IF(!filesystem::exists(path), "Alignment file does not exist");
     LOG(info, "[data] Using word alignments from file {}", path);
 
     alignFileIdx_ = paths_.size();
@@ -158,7 +158,7 @@ CorpusBase::CorpusBase(Ptr<Config> options, bool translate)
   if(training && options_->has("data-weighting")) {
     auto path = options_->get<std::string>("data-weighting");
 
-    ABORT_IF(!boost::filesystem::exists(path), "Weight file does not exist");
+    ABORT_IF(!filesystem::exists(path), "Weight file does not exist");
     LOG(info, "[data] Using weights from file {}", path);
 
     weightFileIdx_ = paths_.size();

--- a/src/data/corpus_sqlite.cpp
+++ b/src/data/corpus_sqlite.cpp
@@ -33,7 +33,7 @@ void CorpusSQLite::fillSQLite() {
   } else {
     auto path = options_->get<std::string>("sqlite");
 
-    if(boost::filesystem::exists(path)) {
+    if(filesystem::exists(path)) {
       LOG(info, "[sqlite] Reusing persistent database {}", path);
 
       db_.reset(new SQLite::Database(path, SQLite::OPEN_READWRITE));

--- a/src/examples/iris/iris.cpp
+++ b/src/examples/iris/iris.cpp
@@ -1,7 +1,6 @@
 #include <vector>
 
-#include <boost/filesystem.hpp>
-
+#include "common/filesystem.h"
 #include "common/config.h"
 #include "examples/iris/helper.cpp"
 #include "marian.h"
@@ -61,8 +60,7 @@ int main() {
 
   // Get path do data set
   std::string dataPath
-      = (boost::filesystem::path(__FILE__).parent_path() / "iris.data")
-            .string();
+      = (filesystem::Path(__FILE__).parentPath() / filesystem::Path("iris.data")).string();
 
   // Read data set (all 150 examples)
   std::vector<float> trainX;

--- a/src/graph/chainable.h
+++ b/src/graph/chainable.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <boost/functional/hash.hpp>
-#include <memory>
-#include <vector>
-
 #include "3rd_party/exception.h"
 #include "common/definitions.h"
+
+#include <memory>
+#include <vector>
 
 namespace marian {
 

--- a/src/graph/expression_operators.cpp
+++ b/src/graph/expression_operators.cpp
@@ -274,14 +274,14 @@ Expr affine(Expr a, Expr b, Expr bias, bool transA, bool transB, float scale) {
 
       // create context for current call as hash
       std::size_t hash = sh(a->shape()).hash();
-      boost::hash_combine(hash, sh(b->shape()).hash());
-      boost::hash_combine(hash, sh(bias->shape()).hash());
-      boost::hash_combine(hash, transA);
-      boost::hash_combine(hash, transB);
+      util::hash_combine(hash, sh(b->shape()).hash());
+      util::hash_combine(hash, sh(bias->shape()).hash());
+      util::hash_combine(hash, transA);
+      util::hash_combine(hash, transB);
 
       // add first algorithm variant (Int16)
       size_t hash1 = hash;
-      boost::hash_combine(hash1, 1);
+      util::hash_combine(hash1, 1);
       auto rec1 = [=](Expr e, bool stop = false) {
         e->record(tuner, hash1, stop);
         return e;
@@ -300,7 +300,7 @@ Expr affine(Expr a, Expr b, Expr bias, bool transA, bool transB, float scale) {
 
       // add second algorithm variant (CBlas)
       size_t hash2 = hash;
-      boost::hash_combine(hash2, 2);
+      util::hash_combine(hash2, 2);
       auto rec2 = [=](Expr e, bool stop = false) {
         e->record(tuner, hash2, stop);
         return e;

--- a/src/graph/node.h
+++ b/src/graph/node.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <thread>
 
+#include "common/hash.h"
 #include "common/keywords.h"
 #include "tensors/backend.h"
 #include "tensors/tensor.h"
@@ -183,10 +184,10 @@ struct NaryNodeOp : public Node {
 
   virtual size_t hash() override {
     if(!hash_) {
-      std::size_t seed = boost::hash<std::string>()(name());
-      boost::hash_combine(seed, type());
+      std::size_t seed = util::hash<std::string>()(name());
+      util::hash_combine(seed, type());
       for(size_t i = 0; i < children_.size(); ++i)
-        boost::hash_combine(seed, child(i)->hash());
+        util::hash_combine(seed, child(i)->hash());
       hash_ = seed;
     }
     return hash_;

--- a/src/graph/node_operators.h
+++ b/src/graph/node_operators.h
@@ -29,9 +29,9 @@ struct ConstantNode : public Node {
 
   virtual size_t hash() override {
     // TODO: add value_type
-    std::size_t seed = boost::hash<std::string>()(name());
-    boost::hash_combine(seed, type());
-    boost::hash_combine(seed, this);
+    std::size_t seed = util::hash<std::string>()(name());
+    util::hash_combine(seed, type());
+    util::hash_combine(seed, this);
     return seed;
   }
 
@@ -65,9 +65,9 @@ struct ParamNode : public Node {
   const std::string color() override { return "orangered"; }
 
   virtual size_t hash() override {
-    std::size_t seed = boost::hash<std::string>()(name());
-    boost::hash_combine(seed, type());
-    boost::hash_combine(seed, this);
+    std::size_t seed = util::hash<std::string>()(name());
+    util::hash_combine(seed, type());
+    util::hash_combine(seed, this);
     return seed;
   }
 

--- a/src/graph/node_operators_binary.h
+++ b/src/graph/node_operators_binary.h
@@ -2,6 +2,7 @@
 
 #include <thread>
 
+#include "common/hash.h"
 #include "functional/functional.h"
 #include "graph/node.h"
 #include "tensors/tensor_operators.h"
@@ -705,7 +706,7 @@ struct ConcatenateNodeOp : public NaryNodeOp {
 
   virtual size_t hash() override {
     size_t seed = NaryNodeOp::hash();
-    boost::hash_combine(seed, ax_);
+    util::hash_combine(seed, ax_);
     return seed;
   }
 

--- a/src/graph/node_operators_unary.h
+++ b/src/graph/node_operators_unary.h
@@ -45,7 +45,7 @@ public:
   virtual size_t hash() override {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
-      boost::hash_combine(hash_, scalar_);
+      util::hash_combine(hash_, scalar_);
     }
     return hash_;
   }
@@ -84,7 +84,7 @@ public:
   virtual size_t hash() override {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
-      boost::hash_combine(hash_, scalar_);
+      util::hash_combine(hash_, scalar_);
     }
     return hash_;
   }
@@ -124,7 +124,7 @@ public:
   virtual size_t hash() override {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
-      boost::hash_combine(hash_, clip_);
+      util::hash_combine(hash_, clip_);
     }
     return hash_;
   }
@@ -318,7 +318,7 @@ struct PReLUNodeOp : public UnaryNodeOp {
   virtual size_t hash() override {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
-      boost::hash_combine(hash_, alpha_);
+      util::hash_combine(hash_, alpha_);
     }
     return hash_;
   }
@@ -386,7 +386,7 @@ struct SoftmaxNodeOp : public UnaryNodeOp {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
       if(mask_)
-        boost::hash_combine(hash_, mask_->hash());
+        util::hash_combine(hash_, mask_->hash());
     }
     return hash_;
   }
@@ -471,7 +471,7 @@ struct SumNodeOp : public UnaryNodeOp {
   virtual size_t hash() override {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
-      boost::hash_combine(hash_, ax_);
+      util::hash_combine(hash_, ax_);
     }
     return hash_;
   }
@@ -525,7 +525,7 @@ struct MeanNodeOp : public UnaryNodeOp {
   virtual size_t hash() override {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
-      boost::hash_combine(hash_, ax_);
+      util::hash_combine(hash_, ax_);
     }
     return hash_;
   }
@@ -596,7 +596,7 @@ struct SqrtNodeOp : public UnaryNodeOp {
   virtual size_t hash() override {
     if(!hash_) {
       size_t seed = NaryNodeOp::hash();
-      boost::hash_combine(seed, epsilon_);
+      util::hash_combine(seed, epsilon_);
       hash_ = seed;
     }
     return hash_;
@@ -682,7 +682,7 @@ struct RowsNodeOp : public UnaryNodeOp {
     if(!hash_) {
       size_t seed = NaryNodeOp::hash();
       for(auto i : indices_)
-        boost::hash_combine(seed, i);
+        util::hash_combine(seed, i);
       hash_ = seed;
     }
     return hash_;
@@ -733,7 +733,7 @@ struct ColsNodeOp : public UnaryNodeOp {
     if(!hash_) {
       size_t seed = NaryNodeOp::hash();
       for(auto i : indices_)
-        boost::hash_combine(seed, i);
+        util::hash_combine(seed, i);
       hash_ = seed;
     }
     return hash_;
@@ -755,8 +755,8 @@ struct ColsNodeOp : public UnaryNodeOp {
 
 struct SelectNodeOp : public UnaryNodeOp {
   SelectNodeOp(Expr a, int axis, const std::vector<size_t>& indices)
-      : UnaryNodeOp(a, newShape(a, axis, indices)), 
-        indices_(indices), 
+      : UnaryNodeOp(a, newShape(a, axis, indices)),
+        indices_(indices),
         axis_{a->shape().axis(axis)} {
     setMemoize(false);
   }
@@ -785,9 +785,9 @@ struct SelectNodeOp : public UnaryNodeOp {
   virtual size_t hash() override {
     if(!hash_) {
       size_t seed = NaryNodeOp::hash();
-      boost::hash_combine(seed, axis_);
+      util::hash_combine(seed, axis_);
       for(auto i : indices_)
-        boost::hash_combine(seed, i);
+        util::hash_combine(seed, i);
       hash_ = seed;
     }
     return hash_;
@@ -845,7 +845,7 @@ struct TransposeNodeOp : public UnaryNodeOp {
     if(!hash_) {
       size_t seed = NaryNodeOp::hash();
       for(auto ax : axes_)
-        boost::hash_combine(seed, ax);
+        util::hash_combine(seed, ax);
       hash_ = seed;
     }
     return hash_;
@@ -912,7 +912,7 @@ public:
     if(!hash_) {
       size_t seed = NaryNodeOp::hash();
       for(auto s : shape())
-        boost::hash_combine(seed, s);
+        util::hash_combine(seed, s);
       hash_ = seed;
     }
     return hash_;
@@ -991,8 +991,8 @@ public:
   virtual size_t hash() override {
     if(!hash_) {
       hash_ = NaryNodeOp::hash();
-      boost::hash_combine(hash_, step_);
-      boost::hash_combine(hash_, axis_);
+      util::hash_combine(hash_, step_);
+      util::hash_combine(hash_, axis_);
     }
     return hash_;
   }
@@ -1032,8 +1032,8 @@ struct ShiftNodeOp : public UnaryNodeOp {
     if(!hash_) {
       size_t seed = NaryNodeOp::hash();
       for(auto i : shift_)
-        boost::hash_combine(seed, i);
-      boost::hash_combine(seed, padValue_);
+        util::hash_combine(seed, i);
+      util::hash_combine(seed, padValue_);
       hash_ = seed;
     }
     return hash_;
@@ -1080,7 +1080,7 @@ struct ShiftNodeOp : public UnaryNodeOp {
 //  virtual size_t hash() {
 //    if(!hash_) {
 //      size_t seed = NaryNodeOp::hash();
-//      boost::hash_combine(seed, (size_t)lf_.get());
+//      util::hash_combine(seed, (size_t)lf_.get());
 //      hash_ = seed;
 //    }
 //    return hash_;

--- a/src/optimizers/optimizers.cpp
+++ b/src/optimizers/optimizers.cpp
@@ -40,7 +40,7 @@ void Adagrad::updateImpl(Tensor params, Tensor grads) {
 void Adagrad::load(const std::string& name,
                    std::vector<Ptr<OptimizerBase>> opts,
                    std::vector<Ptr<Backend>> backends) {
-  if(!boost::filesystem::exists(name))
+  if(!filesystem::exists(name))
     return;
 
   LOG(info, "Loading Adagrad parameters from {}", name);
@@ -160,7 +160,7 @@ void Adam::updateImpl(Tensor params, Tensor grads) {
 void Adam::load(const std::string& name,
                 std::vector<Ptr<OptimizerBase>> opts,
                 std::vector<Ptr<Backend>> backends) {
-  if(!boost::filesystem::exists(name))
+  if(!filesystem::exists(name))
     return;
 
   LOG(info, "Loading Adam parameters from {}", name);

--- a/src/rescorer/score_collector.cpp
+++ b/src/rescorer/score_collector.cpp
@@ -14,7 +14,7 @@ ScoreCollector::ScoreCollector(const Ptr<Config>& options)
       alignmentThreshold_(getAlignmentThreshold(alignment_)) {}
 
 void ScoreCollector::Write(long id, const std::string& message) {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   if(id == nextId_) {
     ((std::ostream&)*outStrm_) << message << std::endl;
 
@@ -84,7 +84,7 @@ void ScoreCollectorNBest::Write(long id,
                                 const data::SoftAlignment& align) {
   std::string line;
   {
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     auto iter = buffer_.find(id);
     if(iter == buffer_.end()) {
       ABORT_IF(lastRead_ >= id,

--- a/src/rescorer/score_collector.h
+++ b/src/rescorer/score_collector.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <boost/thread/mutex.hpp>
-#include <map>
-
 #include "common/config.h"
 #include "common/definitions.h"
 #include "common/file_stream.h"
 #include "data/alignment.h"
+
+#include <map>
+#include <mutex>
 
 namespace marian {
 
@@ -22,7 +22,7 @@ public:
 protected:
   long nextId_{0};
   UPtr<OutputFileStream> outStrm_;
-  boost::mutex mutex_;
+  std::mutex mutex_;
 
   typedef std::map<long, std::string> Outputs;
   Outputs outputs_;

--- a/src/training/graph_group_async.cpp
+++ b/src/training/graph_group_async.cpp
@@ -146,7 +146,7 @@ void AsyncGraphGroup::init(Ptr<data::Batch> batch) {
   if(mvAvg_ && paramsAvg_.empty()) {
     Ptr<ExpressionGraph> graphAvg;
     std::string name = options_->get<std::string>("model");
-    if(boost::filesystem::exists(name + ".orig.npz")) {
+    if(filesystem::exists(name + ".orig.npz")) {
       // Load the averaged parameters into a temporary graph
       graphAvg = New<ExpressionGraph>();
       graphAvg->setDevice({0, DeviceType::cpu});
@@ -304,12 +304,12 @@ void AsyncGraphGroup::load() {
   if(!options_->get<bool>("no-reload")) {
     std::string name = options_->get<std::string>("model");
 
-    if(boost::filesystem::exists(name)) {
+    if(filesystem::exists(name)) {
       if(scheduler_)
         scheduler_->load(name);
 
       std::string nameGraph = name;
-      if(mvAvg_ && boost::filesystem::exists(name + ".orig.npz"))
+      if(mvAvg_ && filesystem::exists(name + ".orig.npz"))
         // Load the original parameters from model.npz.orig.npz
         nameGraph += ".orig.npz";
 

--- a/src/training/graph_group_async.h
+++ b/src/training/graph_group_async.h
@@ -4,7 +4,6 @@
 #include <future>
 #include <thread>
 
-#include <boost/filesystem.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
 

--- a/src/training/graph_group_multinode.h
+++ b/src/training/graph_group_multinode.h
@@ -8,16 +8,17 @@
 #include "cuda_runtime.h"
 #endif
 
+#include "common/filesystem.h"
+#include "3rd_party/threadpool.h"
+#include "training/graph_group.h"
+
 #include <condition_variable>
 #include <future>
 #include <thread>
 
-#include <boost/filesystem.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
-#include "3rd_party/threadpool.h"
-#include "training/graph_group.h"
 
 namespace marian {
 
@@ -463,7 +464,7 @@ public:
     if(!options_->get<bool>("no-reload")) {
       std::string name = options_->get<std::string>("model");
 
-      if(boost::filesystem::exists(name)) {
+      if(filesystem::exists(name)) {
         if(scheduler_)
           scheduler_->load(name);
         size_t i = 0;

--- a/src/training/graph_group_multinode_sync.h
+++ b/src/training/graph_group_multinode_sync.h
@@ -12,12 +12,12 @@
 #include <future>
 #include <thread>
 
-#include <boost/filesystem.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
 #include "3rd_party/threadpool.h"
 #include "training/graph_group.h"
+#include "common/filesystem.h"
 
 namespace marian {
 
@@ -227,7 +227,7 @@ public:
     if(!options_->get<bool>("no-reload")) {
       std::string name = options_->get<std::string>("model");
 
-      if(boost::filesystem::exists(name)) {
+      if(filesystem::exists(name)) {
         if(scheduler_)
           scheduler_->load(name);
         size_t i = 0;

--- a/src/training/graph_group_singleton.h
+++ b/src/training/graph_group_singleton.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <boost/filesystem.hpp>
 #include <future>
 
 #include "training/exponential_smoothing.h"
 #include "training/graph_group.h"
+#include "common/filesystem.h"
 
 namespace marian {
 
@@ -44,11 +44,11 @@ public:
     if(!options_->get<bool>("no-reload")) {
       std::string name = options_->get<std::string>("model");
 
-      if(boost::filesystem::exists(name)) {
+      if(filesystem::exists(name)) {
         if(scheduler_)
           scheduler_->load(name);
 
-        if(mvAvg_ && boost::filesystem::exists(name + ".orig.npz")) {
+        if(mvAvg_ && filesystem::exists(name + ".orig.npz")) {
           // Load the original parameters from model.npz
           builder_->load(graph_, name + ".orig.npz");
 

--- a/src/training/graph_group_sync.cpp
+++ b/src/training/graph_group_sync.cpp
@@ -56,7 +56,7 @@ void SyncGraphGroup::initialize(const std::vector<Ptr<data::Batch>>& batches) {
 void SyncGraphGroup::initializeAvg() {
   Ptr<ExpressionGraph> graphAvg;
   std::string name = options_->get<std::string>("model");
-  if(boost::filesystem::exists(name + ".orig.npz")) {
+  if(filesystem::exists(name + ".orig.npz")) {
     // Load the averaged parameters into a temporary graph
     graphAvg = New<ExpressionGraph>();
     graphAvg->setDevice({0, DeviceType::cpu});
@@ -219,12 +219,12 @@ void SyncGraphGroup::load() {
   if(!options_->get<bool>("no-reload")) {
     std::string name = options_->get<std::string>("model");
 
-    if(boost::filesystem::exists(name)) {
+    if(filesystem::exists(name)) {
       if(scheduler_)
         scheduler_->load(name);
 
       std::string nameGraph = name;
-      if(mvAvg_ && boost::filesystem::exists(name + ".orig.npz"))
+      if(mvAvg_ && filesystem::exists(name + ".orig.npz"))
         // Load the original parameters from model.npz.orig.npz
         nameGraph += ".orig.npz";
 

--- a/src/training/scheduler.h
+++ b/src/training/scheduler.h
@@ -274,7 +274,7 @@ public:
 
   void load(const std::string& name) {
     std::string nameYaml = name + ".progress.yml";
-    if(boost::filesystem::exists(nameYaml))
+    if(filesystem::exists(nameYaml))
       state_->load(nameYaml);
 
     if(options_->get<bool>("no-restore-corpus")) {

--- a/src/training/training_state.h
+++ b/src/training/training_state.h
@@ -1,11 +1,10 @@
 #pragma once
 
+#include "common/definitions.h"
+#include "common/filesystem.h"
+
 #include <fstream>
 #include <vector>
-
-#include "common/definitions.h"
-
-#include <boost/filesystem.hpp>
 
 namespace marian {
 
@@ -109,7 +108,7 @@ public:
   }
 
   void load(const std::string& name) {
-    if(!boost::filesystem::exists(name))
+    if(!filesystem::exists(name))
       return;
 
     YAML::Node config = YAML::LoadFile(name);

--- a/src/translator/output_collector.cpp
+++ b/src/translator/output_collector.cpp
@@ -1,7 +1,8 @@
 #include "output_collector.h"
-#include <cassert>
 #include "common/file_stream.h"
 #include "common/logging.h"
+
+#include <cassert>
 
 namespace marian {
 
@@ -14,7 +15,7 @@ void OutputCollector::Write(long sourceId,
                             const std::string& best1,
                             const std::string& bestn,
                             bool nbest) {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   if(sourceId == nextId_) {
     if(printing_->shouldBePrinted(sourceId))
       LOG(info, "Best translation {} : {}", sourceId, best1);
@@ -71,7 +72,7 @@ StringCollector::StringCollector() : maxId_(-1) {}
 void StringCollector::add(long sourceId,
                           const std::string& best1,
                           const std::string& bestn) {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   LOG(info, "Best translation {} : {}", sourceId, best1);
   outputs_[sourceId] = std::make_pair(best1, bestn);
   if(maxId_ <= sourceId)

--- a/src/translator/output_collector.h
+++ b/src/translator/output_collector.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <boost/thread/mutex.hpp>
-#include <boost/unordered_map.hpp>
-#include <iostream>
-#include <map>
-
 #include "common/definitions.h"
 #include "common/file_stream.h"
+
+#include <mutex>
+#include <iostream>
+#include <map>
 
 namespace marian {
 
@@ -68,7 +67,7 @@ protected:
   long nextId_;
   UPtr<OutputFileStream> outStrm_;
   Ptr<PrintingStrategy> printing_;
-  boost::mutex mutex_;
+  std::mutex mutex_;
 };
 
 class StringCollector {
@@ -81,7 +80,7 @@ public:
 
 protected:
   long maxId_;
-  boost::mutex mutex_;
+  std::mutex mutex_;
 
   typedef std::map<long, std::pair<std::string, std::string>> Outputs;
   Outputs outputs_;


### PR DESCRIPTION
* Move all references to boost::filesystem to util:filesystem which is a very thin wrapper around boost. Boost is to be removed, this is a first step. 
* Replace boost::hash_combine with a similar implementation using std::hash
* Replace boost::mutex with std::mutex where trivially possible, more to come.