### PR TITLE
Fix logging version; support .yaml extension

### DIFF
--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -1,5 +1,6 @@
 #include "common/cli_wrapper.h"
 #include "common/options.h"
+#include "common/version.h"
 
 namespace marian {
 namespace cli {
@@ -70,14 +71,20 @@ CLIWrapper::CLIWrapper(YAML::Node &config,
   // set footer
   if(!footer.empty())
     app_->footer("\n" + footer);
-  // set group name for --help option
+
+  // set group name for the automatically added --help option
   app_->get_help_ptr()->group(defaultGroup_);
+
   // set custom failure message
   app_->failure_message(failureMessage);
-
   // set custom formatter for help message
   auto fmt = std::make_shared<CLIFormatter>(columnWidth, screenWidth);
   app_->formatter(fmt);
+
+  // add --version option
+  optVersion_
+      = app_->add_flag("--version", "Print the version number and exit");
+  optVersion_->group(defaultGroup_);
 }
 
 CLIWrapper::CLIWrapper(Ptr<marian::Options> options,
@@ -107,6 +114,12 @@ void CLIWrapper::parse(int argc, char **argv) {
     app_->parse(argc, argv);
   } catch(const CLI::ParseError &e) {
     exit(app_->exit(e));
+  }
+
+  // handle --version flag
+  if(optVersion_->count()) {
+    std::cerr << PROJECT_VERSION_FULL << std::endl;
+    exit(0);
   }
 }
 

--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -80,6 +80,10 @@ private:
   // then we do not have the added level of containment.
   YAML::Node &config_;
 
+  // Option for --version flag. This is a special flag and similarly to --help,
+  // the key "version" will be not added into the YAML config
+  CLI::Option* optVersion_;
+
   static std::string failureMessage(const CLI::App *app, const CLI::Error &e);
 
   // Extract an option name from comma-separated list of command-line arguments,

--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -160,8 +160,9 @@ public:
    * default value is T()
    *
    * The option will be defined in the config file even if not given as a
-   * command-line argument. The implicit default value for a numeric option is
-   * 0, for a string is an empty string, and for a vector is an empty vector.
+   * command-line argument. The implicit default value for a boolean or numeric
+   * option is 0, for a string is an empty string, and for a vector is an empty
+   * vector.
    *
    * @param args Comma-separated list of short and long option names
    * @param help Help message

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -55,9 +55,7 @@ void Config::initialize(int argc, char** argv, cli::mode mode, bool validate) {
   log();
 
   if(has("version"))
-    LOG(info,
-        "[config] Model created with Marian {}",
-        get("version").as<std::string>());
+    LOG(info, "Model created with Marian {}", get("version").as<std::string>());
 }
 
 bool Config::has(const std::string& key) const {

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -37,16 +37,18 @@ void Config::initialize(int argc, char** argv, cli::mode mode, bool validate) {
 
   // load model parameters
   if(mode != cli::mode::translation) {
-    if(filesystem::exists(get<std::string>("model"))
-       && !get<bool>("no-reload")) {
+    auto model = get<std::string>("model");
+    if(filesystem::exists(model) && !get<bool>("no-reload")) {
       try {
         if(!get<bool>("ignore-model-config"))
-          loadModelParameters(get<std::string>("model"));
+          loadModelParameters(model);
       } catch(std::runtime_error& e) {
         LOG(info, "[config] No model configuration found in model file");
       }
     }
-  } else {
+  }
+  // if cli::mode::translation
+  else {
     auto model = get<std::vector<std::string>>("models")[0];
     try {
       if(!get<bool>("ignore-model-config"))
@@ -63,9 +65,9 @@ void Config::initialize(int argc, char** argv, cli::mode mode, bool validate) {
   // Key "version" is present only if loaded from model parameters and is not
   // related to --version flag
   if(has("version")) {
-    auto version = get("version").as<std::string>();
+    auto version = get<std::string>("version");
 
-    if(version != PROJECT_VERSION_FULL)
+    if(mode == cli::mode::training && version != PROJECT_VERSION_FULL)
       LOG(info,
           "[config] Loaded model has been created with Marian {}, "
           "will be overwritten with current version {} at saving",
@@ -79,9 +81,8 @@ void Config::initialize(int argc, char** argv, cli::mode mode, bool validate) {
   // If this is a newly started training
   else if(mode == cli::mode::training) {
     LOG(info,
-        "[config] The model is being created with Marian {}",
+        "[config] Model is being created with Marian {}",
         PROJECT_VERSION_FULL);
-    config_["version"] = PROJECT_VERSION_FULL;
   }
 }
 

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -44,8 +44,7 @@ void ConfigParser::addOptionsGeneral(cli::CLIWrapper& cli) {
 
   // clang-format off
   cli.add<bool>("--version",
-     "Print version number and exit",
-     false);
+     "Print version number and exit");
   cli.add<std::vector<std::string>>("--config,-c",
      "Configuration file(s). If multiple, later overrides earlier");
   cli.add<size_t>("--workspace,-w",
@@ -635,6 +634,8 @@ void ConfigParser::parseOptions(int argc, char** argv, bool doValidate) {
   if(get<bool>("version")) {
     std::cerr << PROJECT_VERSION_FULL << std::endl;
     exit(0);
+  } else {
+    config_["version"] = PROJECT_VERSION_FULL;
   }
 
   // get paths to extra config files

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -6,7 +6,6 @@
 #include "common/file_stream.h"
 #include "common/logging.h"
 #include "common/utils.h"
-#include "common/version.h"
 #include "3rd_party/exception.h"
 
 #include <algorithm>
@@ -43,8 +42,6 @@ void ConfigParser::addOptionsGeneral(cli::CLIWrapper& cli) {
   cli.switchGroup("General options");
 
   // clang-format off
-  cli.add_nondefault<bool>("--version",
-     "Print version number and exit");
   cli.add<std::vector<std::string>>("--config,-c",
      "Configuration file(s). If multiple, later overrides earlier");
   cli.add<size_t>("--workspace,-w",
@@ -629,12 +626,6 @@ void ConfigParser::parseOptions(int argc, char** argv, bool doValidate) {
 
   // parse command-line options and fill wrapped YAML config
   cli.parse(argc, argv);
-
-  // handle version printing
-  if(has("version")) {
-    std::cerr << PROJECT_VERSION_FULL << std::endl;
-    exit(0);
-  }
 
   // get paths to extra config files
   auto configPaths = loadConfigPaths();

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -43,7 +43,7 @@ void ConfigParser::addOptionsGeneral(cli::CLIWrapper& cli) {
   cli.switchGroup("General options");
 
   // clang-format off
-  cli.add<bool>("--version",
+  cli.add_nondefault<bool>("--version",
      "Print version number and exit");
   cli.add<std::vector<std::string>>("--config,-c",
      "Configuration file(s). If multiple, later overrides earlier");
@@ -631,11 +631,9 @@ void ConfigParser::parseOptions(int argc, char** argv, bool doValidate) {
   cli.parse(argc, argv);
 
   // handle version printing
-  if(get<bool>("version")) {
+  if(has("version")) {
     std::cerr << PROJECT_VERSION_FULL << std::endl;
     exit(0);
-  } else {
-    config_["version"] = PROJECT_VERSION_FULL;
   }
 
   // get paths to extra config files

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -70,6 +70,9 @@ int Vocab::loadOrCreate(const std::string& vocabPath,
     if(filesystem::exists(trainPath + ".json")) {
       return load(trainPath + ".json", max);
     }
+    if(filesystem::exists(trainPath + ".yaml")) {
+      return load(trainPath + ".yaml", max);
+    }
     if(filesystem::exists(trainPath + ".yml")) {
       return load(trainPath + ".yml", max);
     }
@@ -92,7 +95,7 @@ Word Vocab::insertWord(Word id, const std::string& str) {
 };
 
 int Vocab::load(const std::string& vocabPath, int max) {
-  bool isJson = regex::regex_search(vocabPath, regex::regex("\\.(json|yml)$"));
+  bool isJson = regex::regex_search(vocabPath, regex::regex("\\.(json|yaml|yml)$"));
   LOG(info,
       "[data] Loading vocabulary from {} file {}",
       isJson ? "JSON/Yaml" : "text",


### PR DESCRIPTION
Changes:
* Fixing the message "Model created with Marian false"
* Logging Marian version for newly started training
* Adding .yaml as a supported vocab extension