### PR TITLE
Abort if an error occured during an input operation on a stream

### DIFF
--- a/src/common/file_stream.h
+++ b/src/common/file_stream.h
@@ -205,12 +205,16 @@ public:
   template <typename T>
   friend OutputFileStream& operator<<(OutputFileStream& stream, const T& t) {
     stream.ostream_ << t;
+    ABORT_IF(!stream.ostream_,
+             "Exception writing to file '{}'",
+             stream.file_.string());
     return stream;
   }
 
   template <typename T>
   size_t write(const T* ptr, size_t num = 1) {
     ostream_.write((char*)ptr, num * sizeof(T));
+    ABORT_IF(!ostream_, "Exception writing to file '{}'", file_.string());
     return num * sizeof(T);
   }
 


### PR DESCRIPTION
Hopefully, a solution for #240. Not sure if we need to/want to add an explicit message related to shuffling in /tmp for the input operation here: https://github.com/marian-nmt/marian-dev/blob/d82aff455187f1ae741dc8d59e7908515cf5c086/src/data/corpus.cpp#L119