### PR TITLE
Make use of InputFileStream and OutputFileStream consistent

### DIFF
--- a/src/command/marian_vocab.cpp
+++ b/src/command/marian_vocab.cpp
@@ -25,8 +25,8 @@ int main(int argc, char** argv) {
   LOG(info, "Creating vocabulary...");
 
   auto vocab = New<Vocab>();
-  InputFileStream corpusStrm(std::cin);
-  OutputFileStream vocabStrm(std::cout);
+  io::InputFileStream corpusStrm(std::cin);
+  io::OutputFileStream vocabStrm(std::cout);
   vocab->create(corpusStrm, vocabStrm, options->get<size_t>("max-size"));
 
   LOG(info, "Finished");

--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -69,7 +69,7 @@ void loadItems(const std::string& fileName, std::vector<io::Item>& items) {
   // Read file into buffer
   size_t fileSize = filesystem::fileSize(fileName);
   char* ptr = new char[fileSize];
-  InputFileStream in(fileName);
+  io::InputFileStream in(fileName);
   in.read(ptr, fileSize);
 
   // Load items from buffer without mapping
@@ -103,7 +103,7 @@ io::Item getItem(const std::string& fileName, const std::string& varName) {
 
 void saveItems(const std::string& fileName,
                const std::vector<io::Item>& items) {
-  OutputFileStream out(fileName);
+  io::OutputFileStream out(fileName);
   size_t pos = 0;
 
   size_t binaryFileVersion = BINARY_FILE_VERSION;

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -110,8 +110,8 @@ const std::vector<DeviceId>& Config::getDevices() {
 }
 
 void Config::save(const std::string& name) {
-  OutputFileStream out(name);
-  (std::ostream&)out << *this;
+  io::OutputFileStream out(name);
+  out << *this;
 }
 
 void Config::loadModelParameters(const std::string& name) {

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -702,7 +702,7 @@ YAML::Node ConfigParser::loadConfigFiles(
 
   for(auto& path : paths) {
     // later file overrides earlier
-    for(const auto& it : YAML::Load(InputFileStream(path))) {
+    for(const auto& it : YAML::Load(io::InputFileStream(path))) {
       config[it.first.as<std::string>()] = YAML::Clone(it.second);
     }
   }

--- a/src/common/file_stream.h
+++ b/src/common/file_stream.h
@@ -180,7 +180,8 @@ public:
   template <typename T>
   friend InputFileStream& operator>>(InputFileStream& stream, T& t) {
     stream.istream_ >> t;
-    ABORT_IF(stream.fail(),
+    // bad() seems to be correct here. Should not abort on EOF.
+    ABORT_IF(stream.bad(),
              "Error reading from file '{}'",
              stream.path());
     return stream;
@@ -189,6 +190,7 @@ public:
   template <typename T>
   size_t read(T* ptr, size_t num = 1) {
     istream_.read((char*)ptr, num * sizeof(T));
+    // fail() seems to be correct here. Failure to read should abort.
     ABORT_IF(fail(),
              "Error reading from file '{}'",
              path());
@@ -206,7 +208,8 @@ private:
 // chars at the line end
 static InputFileStream& getline(InputFileStream& in, std::string& line) {
   std::getline((std::istream&)in, line);
-  ABORT_IF(in.fail(),
+  // bad() seems to be correct here. Should not abort on EOF.
+  ABORT_IF(in.bad(),
            "Error reading from file '{}'",
            in.path());
   // strip terminal CR if present
@@ -219,7 +222,8 @@ static InputFileStream& getline(InputFileStream& in, std::string& line) {
 // chars at the line end
 static InputFileStream& getline(InputFileStream& in, std::string& line, char delim) {
   std::getline((std::istream&)in, line, delim);
-  ABORT_IF(in.fail(),
+  // bad() seems to be correct here. Should not abort on EOF.
+  ABORT_IF(in.bad(),
            "Error reading from file '{}'",
            in.path());
   // strip terminal CR if present
@@ -262,6 +266,7 @@ public:
   template <typename T>
   friend OutputFileStream& operator<<(OutputFileStream& stream, const T& t) {
     stream.ostream_ << t;
+    // fail() seems to be correct here. Failure to write should abort.
     ABORT_IF(stream.fail(),
              "Error writing to file '{}'",
              stream.path());
@@ -271,6 +276,7 @@ public:
   // handle things like std::endl which is actually a function not a value
   friend OutputFileStream& operator<<(OutputFileStream& stream, std::ostream& (*var)(std::ostream&)) {
     stream.ostream_ << var;
+    // fail() seems to be correct here. Failure to write should abort.
     ABORT_IF(stream.fail(),
              "Error writing to file '{}'",
              stream.path());
@@ -280,6 +286,7 @@ public:
   template <typename T>
   size_t write(const T* ptr, size_t num = 1) {
     ostream_.write((char*)ptr, num * sizeof(T));
+    // fail() seems to be correct here. Failure to write should abort.
     ABORT_IF(fail(),
              "Error writing to file '{}'",
              path());

--- a/src/common/file_stream.h
+++ b/src/common/file_stream.h
@@ -160,7 +160,7 @@ public:
   template <typename T>
   friend InputFileStream& operator>>(InputFileStream& stream, T& t) {
     stream.istream_ >> t;
-    ABORT_IF(stream.bad(),
+    ABORT_IF(stream.fail(),
              "Exception reading from file '{}'",
              stream.path());
     return stream;
@@ -169,7 +169,7 @@ public:
   template <typename T>
   size_t read(T* ptr, size_t num = 1) {
     istream_.read((char*)ptr, num * sizeof(T));
-    ABORT_IF(bad(),
+    ABORT_IF(fail(),
              "Exception reading from file '{}'",
              path());
     return num * sizeof(T);
@@ -177,6 +177,10 @@ public:
 
   bool bad() const {
     return istream_.bad();
+  }
+
+  bool fail() const {
+    return istream_.fail();
   }
 
   char widen(char c) {
@@ -202,7 +206,7 @@ private:
 // chars at the line end
 static InputFileStream& getline(InputFileStream& in, std::string& line) {
   std::getline((std::istream&)in, line);
-  ABORT_IF(in.bad(),
+  ABORT_IF(in.fail(),
            "Exception reading from file '{}'",
            in.path());
   // strip terminal CR if present
@@ -215,7 +219,7 @@ static InputFileStream& getline(InputFileStream& in, std::string& line) {
 // chars at the line end
 static InputFileStream& getline(InputFileStream& in, std::string& line, char delim) {
   std::getline((std::istream&)in, line, delim);
-  ABORT_IF(in.bad(),
+  ABORT_IF(in.fail(),
            "Exception reading from file '{}'",
            in.path());
   // strip terminal CR if present

--- a/src/common/io.cpp
+++ b/src/common/io.cpp
@@ -8,7 +8,6 @@
 #include "common/io_item.h"
 
 namespace marian {
-
 namespace io {
 
 bool isNpz(const std::string& fileName) {

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -34,32 +34,5 @@ std::string join(const std::vector<std::string>& words,
 
 std::string exec(const std::string& cmd);
 
-// wrapper around std::getline() that handles Windows input files with extra CR
-// chars at the line end
-template <class CharT, class Traits, class Allocator>
-std::basic_istream<CharT, Traits>& getline(
-    std::basic_istream<CharT, Traits>& in,
-    std::basic_string<CharT, Traits, Allocator>& line) {
-  std::getline(in, line);
-  // strip terminal CR if present
-  if(in && !line.empty() && line.back() == in.widen('\r'))
-    line.pop_back();
-  return in;
-}
-
-// wrapper around std::getline() that handles Windows input files with extra CR
-// chars at the line end
-template <class CharT, class Traits, class Allocator>
-std::basic_istream<CharT, Traits>& getline(
-    std::basic_istream<CharT, Traits>& in,
-    std::basic_string<CharT, Traits, Allocator>& line,
-    CharT delim) {
-  std::getline(in, line, delim);
-  // strip terminal CR if present
-  if(in && !line.empty() && line.back() == in.widen('\r'))
-    line.pop_back();
-  return in;
-}
-
 }  // namespace utils
 }  // namespace marian

--- a/src/data/corpus.h
+++ b/src/data/corpus.h
@@ -18,7 +18,7 @@ namespace data {
 
 class Corpus : public CorpusBase {
 private:
-  std::vector<UPtr<TemporaryFile>> tempFiles_;
+  std::vector<UPtr<io::TemporaryFile>> tempFiles_;
   std::vector<size_t> ids_;
 
   void shuffleFiles(const std::vector<std::string>& paths);

--- a/src/data/corpus_base.cpp
+++ b/src/data/corpus_base.cpp
@@ -41,7 +41,7 @@ CorpusBase::CorpusBase(std::vector<std::string> paths,
            "Number of corpus files and vocab files does not agree");
 
   for(auto path : paths_) {
-    files_.emplace_back(new InputFileStream(path));
+    files_.emplace_back(new io::InputFileStream(path));
     ABORT_IF(files_.back()->empty(), "File '{}' is empty", path);
   }
 }
@@ -132,9 +132,9 @@ CorpusBase::CorpusBase(Ptr<Config> options, bool translate)
 
   for(auto path : paths_) {
     if(path == "stdin")
-      files_.emplace_back(new InputFileStream(std::cin));
+      files_.emplace_back(new io::InputFileStream(std::cin));
     else {
-      files_.emplace_back(new InputFileStream(path));
+      files_.emplace_back(new io::InputFileStream(path));
       ABORT_IF(files_.back()->empty(), "File '{}' is empty", path);
     }
   }
@@ -153,7 +153,7 @@ CorpusBase::CorpusBase(Ptr<Config> options, bool translate)
 
     alignFileIdx_ = paths_.size();
     paths_.emplace_back(path);
-    files_.emplace_back(new InputFileStream(path));
+    files_.emplace_back(new io::InputFileStream(path));
     ABORT_IF(files_.back()->empty(), "File with alignments '{}' is empty", path);
   }
 
@@ -165,7 +165,7 @@ CorpusBase::CorpusBase(Ptr<Config> options, bool translate)
 
     weightFileIdx_ = paths_.size();
     paths_.emplace_back(path);
-    files_.emplace_back(new InputFileStream(path));
+    files_.emplace_back(new io::InputFileStream(path));
     ABORT_IF(files_.back()->empty(), "File with weights '{}' is empty", path);
   }
 }

--- a/src/data/corpus_base.h
+++ b/src/data/corpus_base.h
@@ -496,7 +496,7 @@ public:
   virtual std::vector<Ptr<Vocab>>& getVocabs() = 0;
 
 protected:
-  std::vector<UPtr<InputFileStream>> files_;
+  std::vector<UPtr<io::InputFileStream>> files_;
   std::vector<Ptr<Vocab>> vocabs_;
 
   size_t pos_{0};

--- a/src/data/corpus_nbest.cpp
+++ b/src/data/corpus_nbest.cpp
@@ -51,13 +51,13 @@ SentenceTuple CorpusNBest::next() {
     lastLines_.resize(files_.size() - 1);
     size_t last = files_.size() - 1;
 
-    if(utils::getline((std::istream&)*files_[last], line)) {
+    if(io::getline(*files_[last], line)) {
       int curr_num = numFromNbest(line);
       std::string curr_text = lineFromNbest(line);
 
       for(size_t i = 0; i < last; ++i) {
         if(curr_num > lastNum_) {
-          ABORT_IF(!utils::getline((std::istream&)*files_[i], lastLines_[i]),
+          ABORT_IF(!io::getline(*files_[i], lastLines_[i]),
                    "Too few lines in input {}",
                    i);
         }
@@ -88,9 +88,9 @@ void CorpusNBest::reset() {
   lastNum_ = -1;
   for(auto& path : paths_) {
     if(path == "stdin")
-      files_.emplace_back(new InputFileStream(std::cin));
+      files_.emplace_back(new io::InputFileStream(std::cin));
     else
-      files_.emplace_back(new InputFileStream(path));
+      files_.emplace_back(new io::InputFileStream(path));
   }
 }
 }  // namespace data

--- a/src/data/corpus_nbest.h
+++ b/src/data/corpus_nbest.h
@@ -18,7 +18,7 @@ namespace data {
 
 class CorpusNBest : public CorpusBase {
 private:
-  std::vector<UPtr<TemporaryFile>> tempFiles_;
+  std::vector<UPtr<io::TemporaryFile>> tempFiles_;
   std::vector<size_t> ids_;
   int lastNum_{-1};
   std::vector<std::string> lastLines_;

--- a/src/data/corpus_sqlite.cpp
+++ b/src/data/corpus_sqlite.cpp
@@ -80,7 +80,7 @@ void CorpusSQLite::fillSQLite() {
 
       std::string line;
       for(size_t i = 0; i < files_.size(); ++i) {
-        cont = cont && utils::getline((std::istream&)*files_[i], line);
+        cont = cont && io::getline(*files_[i], line);
         if(cont)
           ps.bind((int)(i + 2), line);
       }

--- a/src/data/shortlist.h
+++ b/src/data/shortlist.h
@@ -131,7 +131,7 @@ private:
   std::vector<std::unordered_map<size_t, float>> data_;
 
   void load(const std::string& fname) {
-    InputFileStream in(fname);
+    io::InputFileStream in(fname);
 
     std::string src, trg;
     float prob;
@@ -212,16 +212,16 @@ public:
   void dump(const std::string& prefix) {
     // Dump top most frequent words from target vocabulary
     LOG(info, "[data] Saving shortlist dump to {}.top", prefix + ".{top,dic}");
-    OutputFileStream outTop(prefix + ".top");
+    io::OutputFileStream outTop(prefix + ".top");
     for(Word i = 0; i < firstNum_ && i < trgVocab_->size(); ++i)
-      (std::ostream&)outTop << (*trgVocab_)[i] << std::endl;
+      outTop << (*trgVocab_)[i] << std::endl;
 
     // Dump translation pairs from dictionary
-    OutputFileStream outDic(prefix + ".dic");
+    io::OutputFileStream outDic(prefix + ".dic");
     for(size_t srcId = 0; srcId < data_.size(); srcId++) {
       for(auto& it : data_[srcId]) {
         size_t trgId = it.first;
-        (std::ostream&)outDic << (*srcVocab_)[srcId] << "\t" << (*trgVocab_)[trgId] << std::endl;
+        outDic << (*srcVocab_)[srcId] << "\t" << (*trgVocab_)[trgId] << std::endl;
       }
     }
   }

--- a/src/data/text_input.cpp
+++ b/src/data/text_input.cpp
@@ -44,7 +44,8 @@ SentenceTuple TextInput::next() {
     SentenceTuple tup(curId);
     for(size_t i = 0; i < files_.size(); ++i) {
       std::string line;
-      if(utils::getline(*files_[i], line)) {
+      io::InputFileStream dummyStream(*files_[i]);
+      if(io::getline(dummyStream, line)) {
         Words words = (*vocabs_[i])(line);
         if(words.empty())
           words.push_back(0);

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -107,15 +107,15 @@ int Vocab::load(const std::string& vocabPath, int max) {
   std::map<std::string, Word> vocab;
   // read from JSON (or Yaml) file
   if(isJson) {
-    YAML::Node vocabNode = YAML::Load(InputFileStream(vocabPath));
+    YAML::Node vocabNode = YAML::Load(io::InputFileStream(vocabPath));
     for(auto&& pair : vocabNode)
       vocab.insert({pair.first.as<std::string>(), pair.second.as<Word>()});
   }
   // read from flat text file
   else {
-    std::ifstream in(vocabPath);
+    io::InputFileStream in(vocabPath);
     std::string line;
-    while(utils::getline(in, line)) {
+    while(io::getline(in, line)) {
       ABORT_IF(line.empty(),
                "Vocabulary file {} must not contain empty lines",
                vocabPath);
@@ -234,13 +234,13 @@ void Vocab::create(const std::string& vocabPath, const std::string& trainPath) {
            "Vocab file '{}' exists. Not overwriting",
            (std::string)vocabPath);
 
-  InputFileStream trainStrm(trainPath);
-  OutputFileStream vocabStrm(vocabPath);
+  io::InputFileStream trainStrm(trainPath);
+  io::OutputFileStream vocabStrm(vocabPath);
   create(trainStrm, vocabStrm);
 }
 
-void Vocab::create(InputFileStream& trainStrm,
-                   OutputFileStream& vocabStrm,
+void Vocab::create(io::InputFileStream& trainStrm,
+                   io::OutputFileStream& vocabStrm,
                    size_t maxSize) {
   std::string line;
   std::unordered_map<std::string, size_t> counter;
@@ -290,6 +290,6 @@ void Vocab::create(InputFileStream& trainStrm,
   for(size_t i = 0; i < vocabSize; ++i)
     vocabYaml.force_insert(vocabVec[i], i + maxSpec + 1);
 
-  (std::ostream&)vocabStrm << vocabYaml;
+  vocabStrm << vocabYaml;
 }
 }  // namespace marian

--- a/src/data/vocab.h
+++ b/src/data/vocab.h
@@ -32,8 +32,8 @@ public:
                    int max = 0);
   int load(const std::string& vocabPath, int max = 0);
   void create(const std::string& vocabPath, const std::string& trainPath);
-  void create(InputFileStream& trainStrm,
-              OutputFileStream& vocabStrm,
+  void create(io::InputFileStream& trainStrm,
+              io::OutputFileStream& vocabStrm,
               size_t maxSize = 0);
 
   Word GetEosId() const { return eosId_; }

--- a/src/examples/iris/helper.cpp
+++ b/src/examples/iris/helper.cpp
@@ -26,10 +26,10 @@ void readIrisData(const std::string fileName,
   }
   std::string line;
   std::string value;
-  while(marian::utils::getline(in, line)) {
+  while(marian::io::getline(in, line)) {
     std::stringstream ss(line);
     int i = 0;
-    while(marian::utils::getline(ss, value, ',')) {
+    while(marian::io::getline(ss, value, ',')) {
       if(++i == 5)
         labels.emplace_back(CLASSES[value]);
       else

--- a/src/examples/iris/helper.cpp
+++ b/src/examples/iris/helper.cpp
@@ -26,10 +26,10 @@ void readIrisData(const std::string fileName,
   }
   std::string line;
   std::string value;
-  while(marian::io::getline(in, line)) {
+  while(std::getline(in, line)) {
     std::stringstream ss(line);
     int i = 0;
-    while(marian::io::getline(ss, value, ',')) {
+    while(std::getline(ss, value, ',')) {
       if(++i == 5)
         labels.emplace_back(CLASSES[value]);
       else

--- a/src/layers/word2vec_reader.h
+++ b/src/layers/word2vec_reader.h
@@ -17,8 +17,8 @@ public:
   std::vector<float> read(const std::string& fileName, int dimVoc, int dimEmb) {
     LOG(info, "[data] Loading embedding vectors from {}", fileName);
 
-    std::ifstream embFile(fileName);
-    ABORT_IF(!embFile.is_open(),
+    io::InputFileStream embFile(fileName);
+    ABORT_IF(!embFile.isOpen(),
              "Unable to open file with embeddings: " + fileName);
 
     std::string line;
@@ -27,7 +27,7 @@ public:
 
     // The first line contains two values: the number of words in the
     // vocabulary and the length of embedding vectors
-    utils::getline(embFile, line);
+    io::getline(embFile, line);
     utils::split(line, values);
     ABORT_IF(values.size() != 2,
              "Unexpected format of the first line of the embedding file");
@@ -36,7 +36,7 @@ public:
 
     // Read embedding vectors into a map
     std::unordered_map<Word, std::vector<float>> word2vec;
-    while(utils::getline(embFile, line)) {
+    while(io::getline(embFile, line)) {
       values.clear();
       utils::split(line, values);
 

--- a/src/models/amun.h
+++ b/src/models/amun.h
@@ -166,8 +166,8 @@ private:
     amun["scorers"]["F0"]["type"] = "Nematus";
     amun["weights"]["F0"] = 1.0f;
 
-    OutputFileStream out(name + ".amun.yml");
-    (std::ostream&)out << amun;
+    io::OutputFileStream out(name + ".amun.yml");
+    out << amun;
   }
 };
 }  // namespace marian

--- a/src/models/encoder_decoder.cpp
+++ b/src/models/encoder_decoder.cpp
@@ -75,8 +75,8 @@ void EncoderDecoder::createDecoderConfig(const std::string& name) {
 
   decoder["relative-paths"] = false;
 
-  OutputFileStream out(name + ".decoder.yml");
-  (std::ostream&)out << decoder;
+  io::OutputFileStream out(name + ".decoder.yml");
+  out << decoder;
 }
 
 Config::YamlNode EncoderDecoder::getModelParameters() {

--- a/src/models/nematus.h
+++ b/src/models/nematus.h
@@ -148,8 +148,8 @@ private:
     amun["scorers"]["F0"]["type"] = "nematus2";
     amun["weights"]["F0"] = 1.0f;
 
-    OutputFileStream out(name + ".amun.yml");
-    (std::ostream&)out << amun;
+    io::OutputFileStream out(name + ".amun.yml");
+    out << amun;
   }
 };
 }  // namespace marian

--- a/src/rescorer/score_collector.cpp
+++ b/src/rescorer/score_collector.cpp
@@ -9,14 +9,14 @@ namespace marian {
 
 ScoreCollector::ScoreCollector(const Ptr<Config>& options)
     : nextId_(0),
-      outStrm_(new OutputFileStream(std::cout)),
+      outStrm_(new io::OutputFileStream(std::cout)),
       alignment_(options->get<std::string>("alignment", "")),
       alignmentThreshold_(getAlignmentThreshold(alignment_)) {}
 
 void ScoreCollector::Write(long id, const std::string& message) {
   std::lock_guard<std::mutex> lock(mutex_);
   if(id == nextId_) {
-    ((std::ostream&)*outStrm_) << message << std::endl;
+    *outStrm_ << message << std::endl;
 
     ++nextId_;
 
@@ -27,7 +27,7 @@ void ScoreCollector::Write(long id, const std::string& message) {
 
       if(currId == nextId_) {
         // 1st element in the map is the next
-        ((std::ostream&)*outStrm_) << iter->second << std::endl;
+        *outStrm_ << iter->second << std::endl;
 
         ++nextId_;
 
@@ -76,7 +76,7 @@ ScoreCollectorNBest::ScoreCollectorNBest(const Ptr<Config>& options)
     : ScoreCollector(options),
       nBestList_(options->get<std::vector<std::string>>("train-sets").back()),
       fname_(options->get<std::string>("n-best-feature")) {
-  file_.reset(new InputFileStream(nBestList_));
+  file_.reset(new io::InputFileStream(nBestList_));
 }
 
 void ScoreCollectorNBest::Write(long id,
@@ -91,7 +91,7 @@ void ScoreCollectorNBest::Write(long id,
                "Entry {} < {} already read but not in buffer",
                id,
                lastRead_);
-      while(lastRead_ < id && utils::getline((std::istream&)*file_, line)) {
+      while(lastRead_ < id && io::getline(*file_, line)) {
         lastRead_++;
         iter = buffer_.emplace(lastRead_, line).first;
       }

--- a/src/rescorer/score_collector.h
+++ b/src/rescorer/score_collector.h
@@ -21,7 +21,7 @@ public:
 
 protected:
   long nextId_{0};
-  UPtr<OutputFileStream> outStrm_;
+  UPtr<io::OutputFileStream> outStrm_;
   std::mutex mutex_;
 
   typedef std::map<long, std::string> Outputs;
@@ -56,7 +56,7 @@ private:
   std::string nBestList_;
   std::string fname_;
   long lastRead_{-1};
-  UPtr<InputFileStream> file_;
+  UPtr<io::InputFileStream> file_;
   std::map<long, std::string> buffer_;
 
   std::string addToNBest(const std::string nbest,

--- a/src/tests/sqlite_test.cpp
+++ b/src/tests/sqlite_test.cpp
@@ -29,8 +29,8 @@ int main(int argc, char** argv) {
     std::ifstream file1(argv[2]);
 
     db.exec("begin;");
-    while(marian::utils::getline(file0, line0)
-          && marian::utils::getline(file1, line1)) {
+    while(marian::io::getline(file0, line0)
+          && marian::io::getline(file1, line1)) {
       ps.bind(1, (int)lines);
       ps.bind(2, line0);
       ps.bind(3, line1);

--- a/src/tests/sqlite_test.cpp
+++ b/src/tests/sqlite_test.cpp
@@ -1,6 +1,7 @@
-#include "common/utils.h"
-#include "common/timer.h"
 #include "SQLiteCpp/SQLiteCpp.h"
+#include "common/file_stream.h"
+#include "common/timer.h"
+#include "common/utils.h"
 
 #include <iostream>
 #include <memory>
@@ -25,8 +26,8 @@ int main(int argc, char** argv) {
 
     std::cerr << "Reading from " << argv[1] << " and " << argv[2] << std::endl;
 
-    std::ifstream file0(argv[1]);
-    std::ifstream file1(argv[2]);
+    marian::io::InputFileStream file0(argv[1]);
+    marian::io::InputFileStream file1(argv[2]);
 
     db.exec("begin;");
     while(marian::io::getline(file0, line0)

--- a/src/training/validator.h
+++ b/src/training/validator.h
@@ -275,13 +275,13 @@ public:
 
     // Set up output file
     std::string fileName;
-    Ptr<TemporaryFile> tempFile;
+    Ptr<io::TemporaryFile> tempFile;
 
     if(options_->has("valid-translation-output")) {
       fileName = options_->get<std::string>("valid-translation-output");
     } else {
       tempFile.reset(
-          new TemporaryFile(options_->get<std::string>("tempdir"), false));
+          new io::TemporaryFile(options_->get<std::string>("tempdir"), false));
       fileName = tempFile->getFileName();
     }
 

--- a/src/translator/output_collector.cpp
+++ b/src/translator/output_collector.cpp
@@ -8,7 +8,7 @@ namespace marian {
 
 OutputCollector::OutputCollector()
     : nextId_(0),
-      outStrm_(new OutputFileStream(std::cout)),
+      outStrm_(new io::OutputFileStream(std::cout)),
       printing_(new DefaultPrinting()) {}
 
 void OutputCollector::Write(long sourceId,
@@ -21,9 +21,9 @@ void OutputCollector::Write(long sourceId,
       LOG(info, "Best translation {} : {}", sourceId, best1);
 
     if(nbest)
-      ((std::ostream&)*outStrm_) << bestn << std::endl;
+      *outStrm_ << bestn << std::endl;
     else
-      ((std::ostream&)*outStrm_) << best1 << std::endl;
+      *outStrm_ << best1 << std::endl;
 
     ++nextId_;
 
@@ -38,9 +38,9 @@ void OutputCollector::Write(long sourceId,
         if(printing_->shouldBePrinted(currId))
           LOG(info, "Best translation {} : {}", currId, currOutput.first);
         if(nbest)
-          ((std::ostream&)*outStrm_) << currOutput.second << std::endl;
+          *outStrm_ << currOutput.second << std::endl;
         else
-          ((std::ostream&)*outStrm_) << currOutput.first << std::endl;
+          *outStrm_ << currOutput.first << std::endl;
 
         ++nextId_;
 
@@ -59,7 +59,7 @@ void OutputCollector::Write(long sourceId,
     // for 1-best, flush stdout so that we can consume this immediately from an
     // external process
     if(!nbest)
-      ((std::ostream&)*outStrm_) << std::flush;
+      *outStrm_ << std::flush;
 
   } else {
     // save for later

--- a/src/translator/output_collector.h
+++ b/src/translator/output_collector.h
@@ -48,7 +48,7 @@ public:
   OutputCollector();
 
   template <class T>
-  OutputCollector(T&& arg) : nextId_(0), outStrm_(new OutputFileStream(arg)) {}
+  OutputCollector(T&& arg) : nextId_(0), outStrm_(new io::OutputFileStream(arg)) {}
 
   OutputCollector(const OutputCollector&) = delete;
 
@@ -65,7 +65,7 @@ protected:
   typedef std::map<long, std::pair<std::string, std::string>> Outputs;
   Outputs outputs_;
   long nextId_;
-  UPtr<OutputFileStream> outStrm_;
+  UPtr<io::OutputFileStream> outStrm_;
   Ptr<PrintingStrategy> printing_;
   std::mutex mutex_;
 };


### PR DESCRIPTION
Make use of InputFileStream and OutputFileStream consistent

* Moved to namespace `io`
* Disallow other file and stream IO besides Input/OutputFileStream
* Add error handling for stream, now aborts instead of failing silently
* Add a number of missing functions like `bad()` and `widen()`
* Fix `operator<<` for `OutputFileStream` with `std::endl`