### PR TITLE
Fix unwanted validation after async training is finished

### DIFF
--- a/src/training/scheduler.h
+++ b/src/training/scheduler.h
@@ -94,7 +94,8 @@ public:
 
   bool validating() {
     return (!validators_.empty()
-            && state_->batches % options_->get<size_t>("valid-freq") == 0);
+            && state_->batches % options_->get<size_t>("valid-freq") == 0
+            && keepGoing());
   }
 
   bool saving() {


### PR DESCRIPTION
This change prevents freezing async training if validation happens after the training has finished during a few extra updates performed waiting for `finalize()`.