### PR TITLE
Deactivating boolean or vector options

### DIFF
--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -348,19 +348,30 @@ private:
 
     // callback function setting the flag
     CLI::callback_t fun = [this, key](CLI::results_t res) {
-      // set boolean variable associated with the option
-      allVars_[key]->as<T>() = !res.empty();
-      // update YAML entry
-      config_[key] = !res.empty();
-      return true;
+      // get parser result, it is safe as boolean options have an implicit value
+      auto val = res[0];
+      auto ret = true;
+      if(val == "true" || val == "on" || val == "yes" || val == "1") {
+        allVars_[key]->as<T>() = true;
+        config_[key] = true;
+      } else if(val == "false" || val == "off" || val == "no" || val == "0") {
+        allVars_[key]->as<T>() = false;
+        config_[key] = false;
+      } else {
+        ret = false;
+      }
+      return ret;
     };
 
     auto opt = app_->add_option(args, fun, help, defaulted);
-    // do not accept any argument for the boolean option
-    opt->type_size(0);
     // set option group
     if(!currentGroup_.empty())
       opt->group(currentGroup_);
+    // set textual representation of the default value for help message
+    if(defaulted)
+      opt->default_str(val ? "true" : "false");
+    // allow to use the flag without any argument
+    opt->implicit_val("true");
 
     // store option object
     opts_.insert(std::make_pair(key, opt));

--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -303,14 +303,20 @@ private:
       auto &vec = allVars_[key]->as<T>();
       vec.clear();
       bool ret = true;
-      // populate the vector with parser results
-      for(const auto &a : res) {
-        vec.emplace_back();
-        ret &= CLI::detail::lexical_cast(a, vec.back());
+      // handle '[]' as an empty vector
+      if(res.size() == 1 && res.front() == "[]") {
+        ret = true;
+      } else {
+        // populate the vector with parser results
+        for(const auto &a : res) {
+          vec.emplace_back();
+          ret &= CLI::detail::lexical_cast(a, vec.back());
+        }
+        ret &= !vec.empty();
       }
       // update YAML entry
       config_[key] = vec;
-      return (!vec.empty()) && ret;
+      return ret;
     };
 
     auto opt = app_->add_option(args, fun, help);

--- a/src/tests/cli_test.cpp
+++ b/src/tests/cli_test.cpp
@@ -45,7 +45,8 @@ int main(int argc, char** argv) {
     w->add<std::vector<float>>("-v,--vec", "help message")->expected(-2);
     w->switchGroup("My group");
     w->add<std::vector<std::string>>("--defvec,-d", "help message")->default_val("foo");
-    w->add<bool>("-b,--bool", "help message");
+    w->add<bool>("-b,--bool", "boolean option");
+    w->add<bool>("-x,--xbool", "false boolean option", true);
     w->add<std::string>("--a-very-long-option-name-for-testing-purposes", "A very long text a very long text a very long text a very long text a very long text a very long text");
     w->switchGroup();
     w->add<std::string>("-f,--file", "help message")->check(validators::file_exists);


### PR DESCRIPTION
Two improvements that allow to turn off a boolean or vector option:
1. Boolean options optionally take arguments, e.g. `--layer-normalization false`
2. '[]' is a special value for vector options that mean an empty vector, e.g. `transformer-tied-layers []`

This will solve #348 and #343 

The following regression tests from https://github.com/marian-nmt/marian-regression-tests/tree/cli-bool-false should be merged before this PR:
- https://github.com/marian-nmt/marian-regression-tests/blob/cli-bool-false/tests/interface/config/test_turn_off_boolean_from_config.sh
- https://github.com/marian-nmt/marian-regression-tests/blob/cli-bool-false/tests/interface/config/test_turn_off_vector_from_config.sh

PR in marian-regression-tests: https://github.com/marian-nmt/marian-regression-tests/pull/17


