### PR TITLE
Custom implementation of boost::timer

### DIFF
--- a/src/command/marian_decoder.cpp
+++ b/src/command/marian_decoder.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
 
   timer::Timer timer;
   task->run();
-  LOG(info, "Total time: {}", timer.format());
+  LOG(info, "Total time: {:.5f}s wall", timer.elapsed());
 
   return 0;
 }

--- a/src/command/marian_scorer.cpp
+++ b/src/command/marian_scorer.cpp
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
 
   timer::Timer timer;
   New<Rescore<Rescorer>>(options)->run();
-  LOG(info, "Total time: {}", timer.format());
+  LOG(info, "Total time: {:.5f}s wall", timer.elapsed());
 
   return 0;
 }

--- a/src/command/marian_server.cpp
+++ b/src/command/marian_server.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     auto outputText = task->run(inputText);
     LOG(info, "Best translation: {}", outputText);
     *sendStream << outputText << std::endl;
-    LOG(info, "Translation took: {}", timer.format(5, "%ws"));
+    LOG(info, "Translation took: {:.5f}s", timer.elapsed());
 
     // Send translation back
     connection->send(sendStream, [](const SimpleWeb::error_code &ec) {

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -2,12 +2,82 @@
 
 #include <boost/timer/timer.hpp>
 #ifdef _MSC_VER
-#include <boost/chrono.hpp> // (needed on Windows only to resolve a link error, but causes a warning on Linux)
+// (needed on Windows only to resolve a link error, but causes a warning on Linux)
+#include <boost/chrono.hpp>
 #endif
+
+#include <chrono>
+#include <sstream>
 
 namespace marian {
 namespace timer {
-  using Timer = boost::timer::cpu_timer;
-  using AutoTimer = boost::timer::auto_cpu_timer;
-}
-}
+
+// Timer measures elapsed time.
+// This is a wrapper around std::chrono providing wall time only
+class Timer {
+protected:
+  using clock = std::chrono::steady_clock;
+  using time_point = std::chrono::time_point<clock>;
+  using duration = std::chrono::nanoseconds;
+
+  time_point start_;     // Starting time point
+  bool stopped_{false};  // Indicator if the timer has been stopped
+  duration time_;        // Time duration from start() to stop()
+
+public:
+  // Create and start the timer
+  Timer() : start_(clock::now()) {}
+
+  // Restart the timer. It is not resuming
+  void start() {
+    stopped_ = false;
+    start_ = clock::now();
+  }
+
+  // Stop the timer
+  void stop() {
+    if(stopped_)
+      return;
+    stopped_ = true;
+    time_ = clock::now() - start_;
+  }
+
+  // Check if the timer has been stopped
+  bool stopped() const { return stopped_; }
+
+  // Get the time elapsed without stopping the timer.
+  // If the template type is not specified, it returns the time counts as represented by
+  // std::chrono::seconds
+  template <class Duration = std::chrono::duration<double>>
+  typename Duration::rep elapsed() const {
+    if(stopped_)
+      return std::chrono::duration_cast<Duration>(time_).count();
+    return Duration(clock::now() - start_).count();
+  }
+
+  // Default desctructor
+  virtual ~Timer() {}
+};
+
+// Automatic timer displays timing information on the standard output stream when it is destroyed
+class AutoTimer : public Timer {
+public:
+  // Create and start the timer
+  AutoTimer() : Timer() {}
+
+  // Stop the timer and display time elapsed on std::cout
+  ~AutoTimer() {
+    stop();
+    std::cout << "Time: " << elapsed() << "s wall" << std::endl;
+  }
+};
+
+// @TODO: replace with a timer providing CPU/thread time on both Linux and Windows. This is required
+// for auto-tuner.
+// Check get_clocktime on Linux: https://linux.die.net/man/3/clock_gettime
+// Check GetThreadTimes on Windows:
+// https://docs.microsoft.com/en-gb/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreadtimes
+using CPUTimer = boost::timer::cpu_timer;
+
+}  // namespace timer
+}  // namespace marian

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -48,11 +48,12 @@ public:
   // Get the time elapsed without stopping the timer.
   // If the template type is not specified, it returns the time counts as represented by
   // std::chrono::seconds
-  template <class Duration = std::chrono::duration<double>>
-  typename Duration::rep elapsed() const {
+  template <class Duration = std::chrono::seconds>
+  double elapsed() const {
+    using duration_double = std::chrono::duration<double, typename Duration::period>;
     if(stopped_)
-      return std::chrono::duration_cast<Duration>(time_).count();
-    return Duration(clock::now() - start_).count();
+      return std::chrono::duration_cast<duration_double>(time_).count();
+    return std::chrono::duration_cast<duration_double>(clock::now() - start_).count();
   }
 
   // Default desctructor

--- a/src/graph/auto_tuner.h
+++ b/src/graph/auto_tuner.h
@@ -22,7 +22,7 @@ private:
 
   const size_t max = 100;
 
-  UPtr<timer::Timer> timer_;
+  UPtr<timer::CPUTimer> timer_;
 
   struct HashedAlgorithm {
     size_t hash;
@@ -81,7 +81,7 @@ public:
 
   void start(size_t hash) override {
     if(!timer_ && done_.count(hash) == 0)
-      timer_.reset(new timer::Timer());
+      timer_.reset(new timer::CPUTimer());
   }
 
   void stop(size_t hash, bool stop) override {

--- a/src/tests/logger_test.cpp
+++ b/src/tests/logger_test.cpp
@@ -38,5 +38,5 @@ int main() {
 
   marian::timer::Timer timer;
 
-  info->info("time is {} bla {:.2f}", timer.format(5, "%w"), .7);
+  info->info("time is {:.5f} bla {:.2f}", timer.elapsed(), .7);
 }

--- a/src/training/scheduler.h
+++ b/src/training/scheduler.h
@@ -274,8 +274,7 @@ public:
     // progress heartbeat for MS-internal Philly compute cluster
     // This environment variable exists when running on the cluster.
     if((!mpi || mpi->myMPIRank() == 0) && getenv("PHILLY_JOB_ID")
-        // @TODO: use std::chrono::minutes
-       && heartBeatTimer_.elapsed<std::chrono::duration<double, std::ratio<60>>>() >= 10) {
+       && heartBeatTimer_.elapsed<std::chrono::minutes>() >= 10) {
       printf("PROGRESS: %.2f%%\nEVALERR: %.7f\n", (double)state_->epochs, state_->costSum / state_->costCount), fflush(stdout);
 #if 0
       LOG(info, "heart beat after {} updates", state_->batches);

--- a/src/training/scheduler.h
+++ b/src/training/scheduler.h
@@ -205,8 +205,8 @@ public:
 
     state_->newBatch();
 
-    if(state_->batches %  options_->get<size_t>("disp-freq") == 0 ||
-       state_->batches <= options_->get<size_t>("disp-first")) {
+    if(state_->batches % options_->get<size_t>("disp-freq") == 0
+       || state_->batches <= options_->get<size_t>("disp-first")) {
       // if MPI then aggregate precise cost across workers
       if (mpi) {
         //LOG(info, "all-reducing cost from {}", state_->costSum);
@@ -217,11 +217,9 @@ public:
       if (mpi && mpi->myMPIRank() != 0)
         ; // skip the report on alternate worker processes
       else if(dispLabelCounts) {
-        if(options_->get<bool>(
-               "lr-report")) {  // if true then show the learning rate
+        if(options_->get<bool>("lr-report")) {  // if true then show the learning rate
           LOG(info,
-              "Ep. {} : Up. {} : Sen. {} : Cost {:.8f} * {} after {} : Time {} "
-              ": {:.2f} "
+              "Ep. {} : Up. {} : Sen. {} : Cost {:.8f} * {} after {} : Time {:.2f}s : {:.2f} "
               "words/s : L.r. {:.4e}",
               state_->epochs,
               state_->batches,
@@ -229,13 +227,12 @@ public:
               state_->costSum / state_->costCount,
               state_->costCount,  // show cost as "av * count"
               state_->labelsTotal,
-              timer_.format(2, "%ws"),
-              state_->wordsDisp / std::stof(timer_.format(5, "%w")),
+              timer_.elapsed(),
+              state_->wordsDisp / timer_.elapsed(),
               state_->eta);
         } else {
           LOG(info,
-              "Ep. {} : Up. {} : Sen. {} : Cost {:.8f} * {} after {} : Time {} "
-              ": {:.2f} "
+              "Ep. {} : Up. {} : Sen. {} : Cost {:.8f} * {} after {} : Time {:.2f}s : {:.2f} "
               "words/s",
               state_->epochs,
               state_->batches,
@@ -243,31 +240,30 @@ public:
               state_->costSum / state_->costCount,
               state_->costCount,
               state_->labelsTotal,
-              timer_.format(2, "%ws"),
-              state_->wordsDisp / std::stof(timer_.format(5, "%w")));
+              timer_.elapsed(),
+              state_->wordsDisp / timer_.elapsed());
         }
       } else {
         if(options_->get<bool>("lr-report")) {
           LOG(info,
-              "Ep. {} : Up. {} : Sen. {} : Cost {:.2f} : Time {} : {:.2f} "
-              "words/s : L.r. {:.4e}",
+              "Ep. {} : Up. {} : Sen. {} : Cost {:.2f} : Time {:2f}s : {:.2f} words/s : L.r. "
+              "{:.4e}",
               state_->epochs,
               state_->batches,
               state_->samplesEpoch,
               state_->costSum / state_->costCount,
-              timer_.format(2, "%ws"),
-              state_->wordsDisp / std::stof(timer_.format(5, "%w")),
+              timer_.elapsed(),
+              state_->wordsDisp / timer_.elapsed(),
               state_->eta);
         } else {
           LOG(info,
-              "Ep. {} : Up. {} : Sen. {} : Cost {:.2f} : Time {} : {:.2f} "
-              "words/s",
+              "Ep. {} : Up. {} : Sen. {} : Cost {:.2f} : Time {:.2f}s : {:.2f} words/s",
               state_->epochs,
               state_->batches,
               state_->samplesEpoch,
               state_->costSum / state_->costCount,
-              timer_.format(2, "%ws"),
-              state_->wordsDisp / std::stof(timer_.format(5, "%w")));
+              timer_.elapsed(),
+              state_->wordsDisp / timer_.elapsed());
         }
       }
       timer_.start();
@@ -277,9 +273,9 @@ public:
     }
     // progress heartbeat for MS-internal Philly compute cluster
     // This environment variable exists when running on the cluster.
-    using namespace std::chrono;
-    if((!mpi || mpi->myMPIRank() == 0) && getenv("PHILLY_JOB_ID") &&
-        duration_cast<minutes>(nanoseconds(heartBeatTimer_.elapsed().user)).count() >= 10) {
+    if((!mpi || mpi->myMPIRank() == 0) && getenv("PHILLY_JOB_ID")
+        // @TODO: use std::chrono::minutes
+       && heartBeatTimer_.elapsed<std::chrono::duration<double, std::ratio<60>>>() >= 10) {
       printf("PROGRESS: %.2f%%\nEVALERR: %.7f\n", (double)state_->epochs, state_->costSum / state_->costCount), fflush(stdout);
 #if 0
       LOG(info, "heart beat after {} updates", state_->batches);

--- a/src/training/validator.h
+++ b/src/training/validator.h
@@ -325,7 +325,7 @@ public:
     }
 
     if(!quiet_)
-      LOG(info, "Total translation time: {}", timer.format(5, "%ws"));
+      LOG(info, "Total translation time: {:.5f}s", timer.elapsed());
 
     for(auto graph : graphs)
       graph->setInference(false);
@@ -475,7 +475,7 @@ public:
     }
 
     if(!quiet_)
-      LOG(info, "Total translation time: {}", timer.format(5, "%ws"));
+      LOG(info, "Total translation time: {:.5f}s", timer.elapsed());
 
     for(auto graph : graphs)
       graph->setInference(false);


### PR DESCRIPTION
Boost timer is not removed entirely yet as the custom class misses functionalities of `boost::timer::cpu_timer` that is needed for auto tuner. Those will be implemented later as they need to be cross-platform (see comment for CPUTimer in `common/timer.h`).