### PR TITLE
More readable dumped config files

### DIFF
--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -144,31 +144,30 @@ std::unordered_set<std::string> CLIWrapper::getParsedOptionNames() const {
   return keys;
 }
 
-
-std::string CLIWrapper::dumpConfig(bool skipDefault /*= false*/) const {
-    YAML::Emitter out;
-    out << YAML::Comment("Marian config file generated at " + timer::currentDate() + " with "
-                         + buildVersion());
-    out << YAML::BeginMap;
-    std::string comment;
-    for(const auto &key : order_) {
-      // do not proceed keys that are removed from config_
-      if(!config_[key])
-        continue;
-      auto group = opts_.at(key)->get_group();
-      if(comment != group) {
-        if(!comment.empty())
-          out << YAML::Newline;
-        comment = group;
-        out << YAML::Comment(group);
-      }
-      out << YAML::Key;
-      out << key;
-      out << YAML::Value;
-      cli::OutputYaml(config_[key], out);
+std::string CLIWrapper::dumpConfig() const {
+  YAML::Emitter out;
+  out << YAML::Comment("Marian configuration file generated at " + timer::currentDate()
+                       + " with version " + buildVersion());
+  out << YAML::BeginMap;
+  std::string comment;
+  for(const auto &key : order_) {
+    // do not proceed keys that are removed from config_
+    if(!config_[key])
+      continue;
+    auto group = opts_.at(key)->get_group();
+    if(comment != group) {
+      if(!comment.empty())
+        out << YAML::Newline;
+      comment = group;
+      out << YAML::Comment(group);
     }
-    out << YAML::EndMap;
-    return out.c_str();
+    out << YAML::Key;
+    out << key;
+    out << YAML::Value;
+    cli::OutputYaml(config_[key], out);
+  }
+  out << YAML::EndMap;
+  return out.c_str();
 }
 
 }  // namespace cli

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -130,21 +130,16 @@ std::string CLIWrapper::failureMessage(const CLI::App *app,
                                        const CLI::Error &e) {
   std::string header = "Error: " + std::string(e.what()) + "\n";
   if(app->get_help_ptr() != nullptr)
-    header += "Run with " + app->get_help_ptr()->get_name()
-              + " for more information.\n";
+    header += "Run with " + app->get_help_ptr()->get_name() + " for more information.\n";
   return header;
 }
 
-void CLIWrapper::overwriteDefault(const YAML::Node &node) {
-  // iterate requested default values
-  for(auto it : node) {
-    auto key = it.first.as<std::string>();
-    ABORT_IF(!allVars_.count(key), "The following option was not expected: '{}'", key);
-    // if we have an option but it was not specified on command-line
-    if(allVars_.count(key) > 0 && opts_.at(key)->empty()) {
-      config_[key] = YAML::Clone(it.second);
-    }
-  }
+std::unordered_set<std::string> CLIWrapper::getParsedOptionNames() const {
+  std::unordered_set<std::string> keys;
+  for(const auto &pair : allVars_)
+    if(!opts_.at(pair.first)->empty())
+      keys.emplace(pair.first);
+  return keys;
 }
 
 }  // namespace cli

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -149,18 +149,17 @@ std::string CLIWrapper::dumpConfig(bool skipDefault /*= false*/) const {
     out << YAML::Comment("Marian config file generated with " + buildVersion());
     out << YAML::BeginMap;
     std::string comment;
-    for(const auto &pair : opts_) {
-      auto key = pair.first;
+    for(const auto &key : order_) {
       // do not proceed keys that are removed from config_
       if(!config_[key])
         continue;
-      //auto group = pair.second->get_group();
-      //if(comment != group) {
-        //if(!comment.empty())
-          //out << YAML::Newline;
-        //comment = group;
-        //out << YAML::Comment(group);
-      //}
+      auto group = opts_.at(key)->get_group();
+      if(comment != group) {
+        if(!comment.empty())
+          out << YAML::Newline;
+        comment = group;
+        out << YAML::Comment(group);
+      }
       out << YAML::Key;
       out << key;
       out << YAML::Value;

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -138,9 +138,21 @@ std::string CLIWrapper::failureMessage(const CLI::App *app,
 
 std::unordered_set<std::string> CLIWrapper::getParsedOptionNames() const {
   std::unordered_set<std::string> keys;
-  for(const auto &pair : allVars_)
-    if(!opts_.at(pair.first)->empty())
-      keys.emplace(pair.first);
+  for(const auto &it : options_)
+    if(!it.second.opt->empty())
+      keys.emplace(it.first);
+  return keys;
+}
+
+std::vector<std::string> CLIWrapper::getOrderedOptionNames() const {
+  std::vector<std::string> keys;
+  // extract all option names
+  for(auto const &it : options_)
+    keys.push_back(it.first);
+  // sort option names by creation index
+  sort(keys.begin(), keys.end(), [this](const std::string &a, const std::string &b) {
+    return options_.at(a).idx < options_.at(b).idx;
+  });
   return keys;
 }
 
@@ -150,11 +162,11 @@ std::string CLIWrapper::dumpConfig() const {
                        + " with version " + buildVersion());
   out << YAML::BeginMap;
   std::string comment;
-  for(const auto &key : order_) {
+  for(const auto &key : getOrderedOptionNames()) {
     // do not proceed keys that are removed from config_
     if(!config_[key])
       continue;
-    auto group = opts_.at(key)->get_group();
+    auto group = options_.at(key).opt->get_group();
     if(comment != group) {
       if(!comment.empty())
         out << YAML::Newline;

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -3,6 +3,7 @@
 #include "common/logging.h"
 #include "common/options.h"
 #include "common/version.h"
+#include "common/timer.h"
 
 namespace marian {
 namespace cli {
@@ -146,7 +147,8 @@ std::unordered_set<std::string> CLIWrapper::getParsedOptionNames() const {
 
 std::string CLIWrapper::dumpConfig(bool skipDefault /*= false*/) const {
     YAML::Emitter out;
-    out << YAML::Comment("Marian config file generated with " + buildVersion());
+    out << YAML::Comment("Marian config file generated at " + timer::currentDate() + " with "
+                         + buildVersion());
     out << YAML::BeginMap;
     std::string comment;
     for(const auto &key : order_) {

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -1,4 +1,5 @@
 #include "common/cli_wrapper.h"
+#include "common/cli_helper.h"
 #include "common/logging.h"
 #include "common/options.h"
 #include "common/version.h"
@@ -140,6 +141,33 @@ std::unordered_set<std::string> CLIWrapper::getParsedOptionNames() const {
     if(!opts_.at(pair.first)->empty())
       keys.emplace(pair.first);
   return keys;
+}
+
+
+std::string CLIWrapper::dumpConfig(bool skipDefault /*= false*/) const {
+    YAML::Emitter out;
+    out << YAML::Comment("Marian config file generated with " + buildVersion());
+    out << YAML::BeginMap;
+    std::string comment;
+    for(const auto &pair : opts_) {
+      auto key = pair.first;
+      // do not proceed keys that are removed from config_
+      if(!config_[key])
+        continue;
+      //auto group = pair.second->get_group();
+      //if(comment != group) {
+        //if(!comment.empty())
+          //out << YAML::Newline;
+        //comment = group;
+        //out << YAML::Comment(group);
+      //}
+      out << YAML::Key;
+      out << key;
+      out << YAML::Value;
+      cli::OutputYaml(config_[key], out);
+    }
+    out << YAML::EndMap;
+    return out.c_str();
 }
 
 }  // namespace cli

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -2,8 +2,8 @@
 #include "common/cli_helper.h"
 #include "common/logging.h"
 #include "common/options.h"
-#include "common/version.h"
 #include "common/timer.h"
+#include "common/version.h"
 
 namespace marian {
 namespace cli {
@@ -87,8 +87,7 @@ CLIWrapper::CLIWrapper(YAML::Node &config,
   app_->formatter(fmt);
 
   // add --version option
-  optVersion_
-      = app_->add_flag("--version", "Print the version number and exit");
+  optVersion_ = app_->add_flag("--version", "Print the version number and exit");
   optVersion_->group(defaultGroup_);
 }
 
@@ -98,20 +97,12 @@ CLIWrapper::CLIWrapper(Ptr<marian::Options> options,
                        const std::string &footer,
                        size_t columnWidth,
                        size_t screenWidth)
-    : CLIWrapper(options->getYaml(),
-                 description,
-                 header,
-                 footer,
-                 columnWidth,
-                 screenWidth) {}
+    : CLIWrapper(options->getYaml(), description, header, footer, columnWidth, screenWidth) {}
 
 CLIWrapper::~CLIWrapper() {}
 
 void CLIWrapper::switchGroup(const std::string &name) {
-  if(name.empty())
-    currentGroup_ = defaultGroup_;
-  else
-    currentGroup_ = name;
+  currentGroup_ = name.empty() ? defaultGroup_ : name;
 }
 
 void CLIWrapper::parse(int argc, char **argv) {
@@ -128,8 +119,7 @@ void CLIWrapper::parse(int argc, char **argv) {
   }
 }
 
-std::string CLIWrapper::failureMessage(const CLI::App *app,
-                                       const CLI::Error &e) {
+std::string CLIWrapper::failureMessage(const CLI::App *app, const CLI::Error &e) {
   std::string header = "Error: " + std::string(e.what()) + "\n";
   if(app->get_help_ptr() != nullptr)
     header += "Run with " + app->get_help_ptr()->get_name() + " for more information.\n";

--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -68,6 +68,8 @@ private:
   std::map<std::string, Ptr<any_type>> allVars_;
   // Map with option names and objects
   std::map<std::string, CLI::Option *> opts_;
+  // List of option names in the same order as they are defined
+  std::vector<std::string> order_;
   // Command-line argument parser
   Ptr<CLI::App> app_;
 
@@ -234,6 +236,7 @@ private:
                           T val,
                           bool defaulted,
                           bool addToConfig) {
+    order_.push_back(key);
     // define YAML entry if requested
     if(addToConfig)
       config_[key] = val;
@@ -279,6 +282,7 @@ private:
                           T val,
                           bool defaulted,
                           bool addToConfig) {
+    order_.push_back(key);
     // define YAML entry if requested
     if(addToConfig)
       config_[key] = val;
@@ -334,6 +338,7 @@ private:
                           T val,
                           bool defaulted,
                           bool addToConfig) {
+    order_.push_back(key);
     // define YAML entry if requested
     if(addToConfig)
       config_[key] = val;

--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <unordered_set>
 
 namespace marian {
 
@@ -223,15 +224,11 @@ public:
   void parse(int argc, char **argv);
 
   /**
-   * @brief Overwrite values for unparsed options
+   * @brief Get names of parsed command-line options
    *
-   * Default values are overwritten with the options found in the config
-   * provided as the argument, while parsed command-line options remain
-   * unchanged
-   *
-   * @param node YAML config with new default values for options
+   * @param set of option names that were present at command-line
    */
-  void overwriteDefault(const YAML::Node &node);
+  std::unordered_set<std::string> getParsedOptionNames() const;
 
 private:
   template <

--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -222,7 +222,8 @@ public:
    */
   std::unordered_set<std::string> getParsedOptionNames() const;
 
-  std::string dumpConfig(bool skipDefault = false) const;
+  // Get textual YAML representation of the config
+  std::string dumpConfig() const;
 
 private:
   template <

--- a/src/common/cli_wrapper.h
+++ b/src/common/cli_wrapper.h
@@ -64,7 +64,7 @@ private:
  */
 class CLIWrapper {
 private:
-  // [option name] -> option value
+  // Map with option names and option values
   std::map<std::string, Ptr<any_type>> allVars_;
   // Map with option names and objects
   std::map<std::string, CLI::Option *> opts_;
@@ -120,16 +120,7 @@ public:
    * @brief Create an instance of the command-line argument parser,
    * short-cuft for Options object.
    *
-   * Option --help, -h is automatically added.
-   *
-   * @param options A smart pointer to the Options object containing the
-   *  to-be-wrapped yaml tree
-   * @param description Program description
-   * @param header Header text for the main option group
-   * @param footer Text displayed after the list of options
-   * @param columnWidth Width of the column with option names
-   * @param screenWidth Maximum allowed width for help messages, 0 means no
-   *  limit
+   * @see Other constructor
    */
   CLIWrapper(Ptr<Options> options,
              const std::string &description = "",
@@ -202,8 +193,7 @@ public:
    * have a default value or be non-defaulted
    */
   template <typename T>
-  CLI::Option *add_nondefault(const std::string &args,
-                              const std::string &help) {
+  CLI::Option *add_nondefault(const std::string &args, const std::string &help) {
     return add_option<T>(keyName(args),
                          args,
                          help,
@@ -229,6 +219,8 @@ public:
    * @param set of option names that were present at command-line
    */
   std::unordered_set<std::string> getParsedOptionNames() const;
+
+  std::string dumpConfig(bool skipDefault = false) const;
 
 private:
   template <

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -603,6 +603,37 @@ void ConfigParser::addSuboptionsInputLength(cli::CLIWrapper& cli) {
   // clang-format on
 }
 
+void ConfigParser::addSuboptionsULR(cli::CLIWrapper& cli) {
+  // clang-format off
+  // support for universal encoder ULR https://arxiv.org/pdf/1802.05368.pdf
+  cli.add<bool>("--ulr",
+      "Enable ULR (Universal Language Representation)",
+      false);
+  // reading pre-trained universal embeddings for multi-sources.
+  // Note that source and target here is relative to ULR not the translation langs
+  // queries: EQ in Fig2 : is the unified embeddings projected to one space.
+  cli.add<std::string>("--ulr-query-vectors",
+      "Path to file with universal sources embeddings from projection into universal space",
+      "");
+  // keys: EK in Fig2 : is the keys of the target embbedings projected to unified space (i.e. ENU in
+  // multi-lingual case)
+  cli.add<std::string>("--ulr-keys-vectors",
+      "Path to file with universal sources embeddings of traget keys from projection into universal space",
+      "");
+  cli.add<bool>("--ulr-trainable-transformation",
+      "Make Query Transformation Matrix A trainable",
+      false);
+  cli.add<int>("--ulr-dim-emb",
+      "ULR monolingual embeddings dimension");
+  cli.add<float>("--ulr-dropout",
+      "ULR dropout on embeddings attentions. Default is no dropout",
+      0.0f);
+  cli.add<float>("--ulr-softmax-temperature",
+      "ULR softmax temperature to control randomness of predictions. Deafult is 1.0: no temperature",
+      1.0f);
+  // clang-format on
+}
+
 void ConfigParser::expandAliases(cli::CLIWrapper& cli) {
   YAML::Node config;
 
@@ -711,8 +742,7 @@ std::vector<std::string> ConfigParser::findConfigPaths() {
   return paths;
 }
 
-YAML::Node ConfigParser::loadConfigFiles(
-    const std::vector<std::string>& paths) {
+YAML::Node ConfigParser::loadConfigFiles(const std::vector<std::string>& paths) {
   YAML::Node configAll;
 
   for(auto& path : paths) {
@@ -746,34 +776,5 @@ YAML::Node ConfigParser::loadConfigFiles(
 
 YAML::Node ConfigParser::getConfig() const {
   return config_;
-}
-
-void ConfigParser::addSuboptionsULR(cli::CLIWrapper& cli) {
-  // support for universal encoder ULR https://arxiv.org/pdf/1802.05368.pdf
-  cli.add<bool>("--ulr",
-      "Is ULR (Universal Language Representation) enabled?",
-      false);
-  // reading pre-trained universal embedings for multi-sources
-  // note that source and target here is relative to ULR not the translation  langs
-  //queries: EQ in Fig2 :  is the unified embbedins projected to one space.
-  //"Path to file with universal sources embeddings from projection into universal space")
-  cli.add<std::string>("--ulr-query-vectors",
-      "Path to file with universal sources embeddings from projection into universal space",
-      "");
-  //keys: EK in Fig2 :  is the keys of the target  embbedins projected to unified  space (i.e. ENU in multi-lingual case)
-  cli.add<std::string>("--ulr-keys-vectors",
-      "Path to file with universal sources embeddings of traget keys from projection into universal space",
-      "");
-  cli.add<bool>("--ulr-trainable-transformation",
-      "Is Query Transformation Matrix A trainable ?",
-      false);
-  cli.add<int>("--ulr-dim-emb",
-      "ULR mono embed dim");
-  cli.add<float>("--ulr-dropout",
-      "ULR dropout on embeddings attentions: default is no dropuout",
-      0.0f);
-  cli.add<float>("--ulr-softmax-temperature",
-      "ULR softmax temperature to control randomness of predictions- deafult is 1.0: no temperature ",
-      1.0f);
 }
 }  // namespace marian

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -641,9 +641,7 @@ void ConfigParser::addSuboptionsULR(cli::CLIWrapper& cli) {
 
 void ConfigParser::expandAliases(cli::CLIWrapper& cli) {
   YAML::Node config;
-
-  // @TODO: Aliases should be (?) proceeded in the same order as they were specified via the
-  // command-line, not arbitrary?
+  // The order of aliases does matter as later options overwrite earlier
 
   if(config_["best-deep"].as<bool>()) {
     config["layer-normalization"] = true;
@@ -696,7 +694,7 @@ void ConfigParser::parseOptions(int argc, char** argv, bool doValidate) {
   if(!configPaths.empty()) {
     auto config = loadConfigFiles(configPaths);
     auto success = cli.updateConfig(config);
-    ABORT_IF(!success, "There are option(s) in a config file are not expected");
+    ABORT_IF(!success, "There are option(s) in a config file that are not expected");
   }
 
   if(get<bool>("interpolate-env-vars")) {

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -692,9 +692,7 @@ void ConfigParser::parseOptions(int argc, char** argv, bool doValidate) {
 
   if(get<bool>("dump-config")) {
     config_.remove("dump-config");
-    YAML::Emitter emit;
-    cli::OutputYaml(config_, emit);
-    std::cout << emit.c_str() << std::endl;
+    std::cout << cli.dumpConfig() << std::endl;
     exit(0);
   }
 

--- a/src/common/config_parser.h
+++ b/src/common/config_parser.h
@@ -63,7 +63,7 @@ private:
   // Abort if not set.
   template <typename T>
   T get(const std::string& key) const {
-    ABORT_IF(!has(key), "CLI object has no key {}", key);
+    ABORT_IF(!has(key), "CLI object has no key '{}'", key);
     return config_[key].as<T>();
   }
 

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -12,6 +12,14 @@
 namespace marian {
 namespace timer {
 
+// Helper function to get the current date and time
+static std::string currentDate() {
+  std::time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  char date[100] = {0};
+  std::strftime(date, sizeof(date), "%F %X %z", std::localtime(&now));
+  return date;
+}
+
 // Timer measures elapsed time.
 // This is a wrapper around std::chrono providing wall time only
 class Timer {

--- a/src/common/version.cpp
+++ b/src/common/version.cpp
@@ -1,12 +1,10 @@
 #include "common/version.h"
-#include "common/project_version.h" // cmake-generated file, major/minor/tweak versions
-#include "common/git_revision.h"    // make-generated file, contains git commit info
+#include "common/git_revision.h"     // make-generated file, contains git commit info
+#include "common/project_version.h"  // cmake-generated file, major/minor/tweak versions
 
 namespace marian {
 
-std::string buildVersion()
-{
+std::string buildVersion() {
   return std::string(PROJECT_VERSION) + " " + GIT_REVISION;
 }
-
 }

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -3,5 +3,5 @@
 #include <string>
 
 namespace marian {
-    std::string buildVersion();
+  std::string buildVersion();
 }


### PR DESCRIPTION
This solves #317 and refactorizes CLIWrapper class.

* Creation date and marian version added to dumped config files
* The same order of dumped options as in `--help`
* Group headers as comments
* `--dump-config minimal` dumps options specified in command line or config files

Example:
```
# Marian configuration file generated at 2018-11-25 11:25:14 +0000 with version v1.6.2 a29532f 2018-11-25 10:59:39 +0000
# Model options
type: s2s
dim-emb: 16
dim-rnn: 32
# Training options
train-sets:
  - /fs/zisa0/romang/marian/mrt/data/europarl.de-en/corpus.bpe.de
  - /fs/zisa0/romang/marian/mrt/data/europarl.de-en/corpus.bpe.en
vocabs:
  - vocab.de.yml
  - vocab.en.yml
after-batches: 2
cpu-threads: 0
mini-batch: 8
```

Regression test in https://github.com/marian-nmt/marian-regression-tests/commits/dump-config