### PR TITLE
reset gradients in default comm.

### DIFF
--- a/src/training/communicator.h
+++ b/src/training/communicator.h
@@ -175,7 +175,17 @@ public:
       }
     };
 
+    // reset gradients outside current shard
+    auto reset = [this, shardSize](size_t idx, size_t begin, size_t end) {
+      auto grad = graphs_[idx]->params()->grads();
+      if (begin > 0)
+        grad->subtensor(0, begin)->set(0);
+      if (end < grad->size())
+        grad->subtensor(end, grad->size()-end)->set(0);
+    };
+
     foreach(scatter);
+    foreach(reset);
   }
 
   void allGatherParams() const override {


### PR DESCRIPTION
default communicator does not reset gradient in scatterReduceAndResetGrads() function.

Do you think it will be clearer if we remove resetGrads functionality in that function, instead just reset the full gradients after update as in https://github.com/marian-nmt/marian-dev/blob/50d64de62cb3e47b912fdd3438ffacb566187263/src/training/graph_group_sync.cpp#L389?