### PR TITLE
Update NCCL version to 2.4.2 - use ExternalProject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/3rd_party/nccl"]
 	path = src/3rd_party/nccl
 	url = https://github.com/marian-nmt/nccl
+[submodule "src/3rd_party/protobuf"]
+	path = src/3rd_party/protobuf
+	url = https://github.com/protocolbuffers/protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ set(BUILD_ARCH native CACHE STRING "Compile for this CPU architecture.")
 # Custom CMake options
 option(COMPILE_CPU "Compile CPU version" ON)
 option(COMPILE_CUDA "Compile GPU version" ON)
-option(USE_SENTENCEPIECE "Download and compile SentencePiece" OFF)
-option(USE_STATIC_LIBS "Link statically against non-system libs" OFF)
+option(USE_SENTENCEPIECE "Download and compile SentencePiece" ON)
+option(USE_STATIC_LIBS "Link statically against non-system libs" ON)
 option(USE_CUDNN "Use CUDNN library" OFF)
 option(USE_NCCL "Use NCCL library" ON)
 option(USE_MPI "Use MPI library" OFF)
@@ -32,7 +32,7 @@ message(STATUS "Project version: ${PROJECT_VERSION_STRING_FULL}")
 
 execute_process(COMMAND git submodule update --init --recursive --no-fetch
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
- 
+
 # Set compilation flags
 if(MSVC)
 # These are used in src/CMakeLists.txt on a per-target basis
@@ -42,7 +42,7 @@ if(MSVC)
   # C4310: cast truncates constant value
   # C4324: 'marian::cpu::int16::`anonymous-namespace'::ScatterPut': structure was padded due to alignment specifier
   set(DISABLE_GLOBALLY "/wd\"4310\" /wd\"4324\"")
-  
+
   set(INTRINSICS "/arch:AVX")
 
   # Or maybe use these?
@@ -57,7 +57,7 @@ if(MSVC)
   set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /LTCG:incremental /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT /ignore:4049")
   set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /LTCG:incremental")
 
-  find_library(SHLWAPI Shlwapi.lib) 
+  find_library(SHLWAPI Shlwapi.lib)
   set(EXT_LIBS ${EXT_LIBS} SHLWAPI)
 else()
 
@@ -118,7 +118,13 @@ list(APPEND ALL_WARNINGS -Wall; -Werror; -Wno-unused-result; -Wno-deprecated; -W
 if(USE_SENTENCEPIECE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_SENTENCEPIECE")
   LIST(APPEND CUDA_NVCC_FLAGS -DUSE_SENTENCEPIECE; )
-  set(EXT_LIBS ${EXT_LIBS} sentencepiece sentencepiece_train)
+
+  # Defined in src/3rd_party/CMakeLists.txt
+  add_library(sentencepiece STATIC IMPORTED)
+  add_library(sentencepiece_train STATIC IMPORTED)
+  add_library(protobuf STATIC IMPORTED)
+
+  set(EXT_LIBS ${EXT_LIBS} protobuf sentencepiece sentencepiece_train)
 endif()
 
 
@@ -172,37 +178,10 @@ endif(USE_STATIC_LIBS)
   # Cmake. This is also fairly untested, let's hope it does not explode.
   # @TODO: Make sure it does not use pre-installed NCCL headers
   if(USE_NCCL)
-    # define and set the include dir for the generated nccl.h header
-    set(NCCL_HEADER_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/nccl/include")
-    include_directories(${NCCL_HEADER_LOCATION})
-
-    # set the path for the generated static lib
-    set(NCCL_LIB_STATIC "${CMAKE_CURRENT_BINARY_DIR}/nccl/lib/libnccl_static.a")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_NCCL")
-
-    LIST(APPEND CUDA_NVCC_FLAGS -DUSE_NCCL; )
-
-    # disables compilation for sm_30 to avoid ptxas warning... that's general Kepler support. But K80s are supported for instance by sm_35
-    set(GENCODE "-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61")
-
-    # We build using NVidia's custom makefile, for that we pass a number of variables from CMake.
-    # Sets output to the chosen build folder, i.e. where the binaries and objects are generated.
-    # Also passes CUDA location from FindCUDA, sets c++ compiler to the same one CMake uses.
-    add_custom_command(OUTPUT ${NCCL_LIB_STATIC}
-                       COMMAND ${CMAKE_MAKE_PROGRAM} src.build
-                       BUILDDIR=${CMAKE_CURRENT_BINARY_DIR}/nccl
-                       CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}
-                       CUDA8_GENCODE=${GENCODE}
-                       CXX=${CMAKE_CXX_COMPILER}
-                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/3rd_party/nccl)
-    add_custom_target(nccl_target DEPENDS ${NCCL_LIB_STATIC})
     add_library(nccl STATIC IMPORTED)
-    set_target_properties(nccl PROPERTIES IMPORTED_LOCATION ${NCCL_LIB_STATIC})
-    add_dependencies(nccl nccl_target)
     set(EXT_LIBS ${EXT_LIBS} nccl)
-
-    # adds the resulting files to be removed by `make clean`
-    set_directory_properties(PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_CURRENT_BINARY_DIR}/nccl)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_NCCL")
+    LIST(APPEND CUDA_NVCC_FLAGS -DUSE_NCCL; )
   endif(USE_NCCL)
 
 if(USE_STATIC_LIBS)

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -23,18 +23,15 @@ if(CUDA_FOUND)
 
     # disables compilation for sm_30 to avoid ptxas warning... that's general Kepler support. But K80s are supported for instance by sm_35
     set(GENCODE "-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61")
-    ExternalProject_Add(
-      nccl_install
+    ExternalProject_Add(nccl_install
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/nccl
       BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/nccl
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
-        make -f ${CMAKE_CURRENT_SOURCE_DIR}/nccl/Makefile src.build
+        $(MAKE) -f ${CMAKE_CURRENT_SOURCE_DIR}/nccl/Makefile src.build
         BUILDDIR=${CMAKE_BINARY_DIR}/local CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}
         CUDA8_GENCODE=${GENCODE} CXX=${CMAKE_CXX_COMPILER}
-      BUILD_ALWAYS 0
-      INSTALL_COMMAND ""
-    )
+      INSTALL_COMMAND "")
 
     set_target_properties(nccl PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libnccl_static.a)
     add_dependencies(nccl nccl_install)
@@ -44,8 +41,8 @@ if(CUDA_FOUND)
 endif(CUDA_FOUND)
 
 if(USE_SENTENCEPIECE)
-  ExternalProject_Add(
-    protobuf_install
+
+  ExternalProject_Add(protobuf_install
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf
     CMAKE_CACHE_ARGS
@@ -56,17 +53,13 @@ if(USE_SENTENCEPIECE)
       "-DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}"
       "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_BINARY_DIR}/local"
     SOURCE_SUBDIR cmake
-    BUILD_ALWAYS 0
-    STEP_TARGETS build
-    INSTALL_COMMAND make install
-  )
+    INSTALL_COMMAND $(MAKE) install --silent)
 
   set_target_properties(protobuf PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libprotobuf.a)
   add_dependencies(protobuf protobuf_install)
   set(INSTALLS ${INSTALLS} protobuf_install)
 
-  ExternalProject_Add(
-    sentencepiece_install
+  ExternalProject_Add(sentencepiece_install
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sentencepiece
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/sentencepiece
     CMAKE_CACHE_ARGS
@@ -76,10 +69,7 @@ if(USE_SENTENCEPIECE)
       "-DSPM_ENABLE_TCMALLOC:BOOL=OFF"
       "-DSPM_TCMALLOC_STATIC:BOOL=ON"
       "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_BINARY_DIR}/local"
-    BUILD_ALWAYS 0
-    STEP_TARGETS build
-    INSTALL_COMMAND make install
-  )
+    INSTALL_COMMAND $(MAKE) install --silent)
 
   add_dependencies(sentencepiece_install protobuf_install)
 

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -2,39 +2,97 @@
 include_directories(.)
 
 add_subdirectory(./yaml-cpp)
+
 add_subdirectory(./SQLiteCpp)
-add_subdirectory(./pathie-cpp)
-add_subdirectory(./zlib)
-
-if(USE_SENTENCEPIECE)
-  if(USE_STATIC_LIBS)
-    set(_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    if(WIN32)
-      list(INSERT CMAKE_FIND_LIBRARY_SUFFIXES 0 .lib .a)
-    else()
-      set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
-    endif()
-  endif()
-
-  set(SPM_ENABLE_SHARED OFF CACHE BOOL "Builds shared libaries in addition to static libraries." FORCE)
-  set(SPM_ENABLE_TCMALLOC ON CACHE BOOL "Enable TCMalloc if available." FORCE)
-  set(SPM_TCMALLOC_STATIC ON CACHE BOOL "Link static library of TCMALLOC." FORCE)
-
-  add_subdirectory(./sentencepiece)
-  include_directories(./sentencepiece)
-
-  set_target_properties(spm_encode spm_decode spm_train spm_normalize spm_export_vocab
-                        PROPERTIES
-                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-
-  if(USE_STATIC_LIBS)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
-  endif()
-endif(USE_SENTENCEPIECE)
-
 include_directories(./SQLiteCpp/include)
-include_directories(./CLI)
+
+add_subdirectory(./pathie-cpp)
 include_directories(./pathie-cpp/include)
 
+add_subdirectory(./zlib)
 include_directories(./zlib)
+
+include_directories(./CLI)
+
+include(ExternalProject)
+
+set(INSTALLS "")
+
+if(CUDA_FOUND)
+  if(USE_NCCL)
+
+    # disables compilation for sm_30 to avoid ptxas warning... that's general Kepler support. But K80s are supported for instance by sm_35
+    set(GENCODE "-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61")
+    ExternalProject_Add(
+      nccl_install
+      SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/nccl
+      BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/nccl
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND
+        make -f ${CMAKE_CURRENT_SOURCE_DIR}/nccl/Makefile src.build
+        BUILDDIR=${CMAKE_BINARY_DIR}/local CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}
+        CUDA8_GENCODE=${GENCODE} CXX=${CMAKE_CXX_COMPILER}
+      BUILD_ALWAYS 0
+      INSTALL_COMMAND ""
+    )
+
+    set_target_properties(nccl PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libnccl_static.a)
+    add_dependencies(nccl nccl_install)
+    set(INSTALLS ${INSTALLS} nccl_install)
+
+  endif(USE_NCCL)
+endif(CUDA_FOUND)
+
+if(USE_SENTENCEPIECE)
+  ExternalProject_Add(
+    protobuf_install
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf
+    CMAKE_CACHE_ARGS
+      "-DCMAKE_BUILD_TYPE:STRING=Release"
+      "-Dprotobuf_BUILD_TESTS:BOOL=OFF"
+      "-Dprotobuf_BUILD_EXAMPLES:BOOL=OFF"
+      "-Dprotobuf_WITH_ZLIB:BOOL=OFF"
+      "-DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}"
+      "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_BINARY_DIR}/local"
+    SOURCE_SUBDIR cmake
+    BUILD_ALWAYS 0
+    STEP_TARGETS build
+    INSTALL_COMMAND make install
+  )
+
+  set_target_properties(protobuf PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libprotobuf.a)
+  add_dependencies(protobuf protobuf_install)
+  set(INSTALLS ${INSTALLS} protobuf_install)
+
+  ExternalProject_Add(
+    sentencepiece_install
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sentencepiece
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/sentencepiece
+    CMAKE_CACHE_ARGS
+      "-DCMAKE_BUILD_TYPE:STRING=Release"
+      "-DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}"
+      "-DSPM_ENABLE_SHARED:BOOL=OFF"
+      "-DSPM_ENABLE_TCMALLOC:BOOL=OFF"
+      "-DSPM_TCMALLOC_STATIC:BOOL=ON"
+      "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_BINARY_DIR}/local"
+    BUILD_ALWAYS 0
+    STEP_TARGETS build
+    INSTALL_COMMAND make install
+  )
+
+  add_dependencies(sentencepiece_install protobuf_install)
+
+  set_target_properties(sentencepiece PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libsentencepiece.a)
+  add_dependencies(sentencepiece sentencepiece_install)
+
+  set_target_properties(sentencepiece_train PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libsentencepiece_train.a)
+  add_dependencies(sentencepiece_train sentencepiece_install)
+  set(INSTALLS ${INSTALLS} sentencepiece_install)
+
+  set_directory_properties(PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_BINARY_DIR}/local)
+
+  add_custom_target(3rd_party_installs DEPENDS ${INSTALLS})
+
+endif(USE_SENTENCEPIECE)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(.)
 include_directories(3rd_party)
 include_directories(3rd_party/SQLiteCpp/include)
 include_directories(3rd_party/sentencepiece)
+include_directories(${CMAKE_BINARY_DIR}/local/include)
 
 add_library(marian STATIC
   common/version.cpp
@@ -98,6 +99,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h
 )
 add_custom_target(marian_version DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h)
 add_dependencies(marian marian_version) # marian must depend on it so that it gets created first
+add_dependencies(marian 3rd_party_installs)
 
 if(CUDA_FOUND)
 cuda_add_library(marian_cuda
@@ -115,6 +117,7 @@ cuda_add_library(marian_cuda
   STATIC)
 
   target_compile_options(marian_cuda PUBLIC ${ALL_WARNINGS})
+  add_dependencies(marian_cuda 3rd_party_installs)
 endif(CUDA_FOUND)
 
 set_target_properties(marian PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")


### PR DESCRIPTION
Small PR:
* Updates NCCL to version 2.4.2
* Starts using CMake's ExternalProject for building NCCL and potentially other external dependencies which is much cleaner than the previous custom command. This also makes the Make build server work with `make -j8`
