### PR TITLE
Fix latex generation in doxygen.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1592,7 +1592,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         =
+EXTRA_PACKAGES         = amsmath
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first


### PR DESCRIPTION
Doxygen fails unless amsmath is speficied as an extra package to load during latex documentation generation.