### PR TITLE
Don't close named pipes during corpus reset.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(marian STATIC
   common/config_validator.cpp
   common/binary.cpp
   common/io.cpp
+  common/filesystem.cpp
 
   data/alignment.cpp
   data/vocab.cpp

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -1,16 +1,26 @@
 #include "filesystem.h"
 
+#ifndef _MSC_VER
+// don't include these on Windows:
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 namespace marian {
 namespace filesystem {
 
 bool is_fifo(char const* path) {
+#ifdef _MSC_VER
+  // Pretend that Windows knows no named pipes. It does, by the way, but
+  // they seem to be different from pipes on Unix / Linux. See
+  // https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
+  return false;
+#else
   struct stat buf;
   stat(path, &buf);
   return S_ISFIFO(buf.st_mode);
+#endif
 }
 
 bool is_fifo(std::string const& path) {

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -13,5 +13,9 @@ bool is_fifo(char const* path) {
   return S_ISFIFO(buf.st_mode);
 }
 
+bool is_fifo(std::string const& path) {
+  return is_fifo(path.c_str());
+}
+
 } // end of namespace marian::filesystem
 } // end of namespace marian

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -1,0 +1,17 @@
+#include "filesystem.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace marian {
+namespace filesystem {
+
+bool is_fifo(char const* path) {
+  struct stat buf;
+  stat(path, &buf);
+  return S_ISFIFO(buf.st_mode);
+}
+
+} // end of namespace marian::filesystem
+} // end of namespace marian

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -23,6 +23,7 @@ namespace marian {
 namespace filesystem {
 
   bool is_fifo(char const* path);
+  bool is_fifo(std::string const& path);
 
   class Path {
     private:

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -22,6 +22,8 @@
 namespace marian {
 namespace filesystem {
 
+  bool is_fifo(char const* path);
+
   class Path {
     private:
       Pathie::Path path;

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -46,7 +46,6 @@ SentenceTuple Corpus::next() {
       }
       else {
         bool gotLine = io::getline(*files_[i], line);
-        // LOG(debug,"[{}][{}] {}", i, pos_ - 1, line);
         if(!gotLine) {
           eofsHit++;
           continue;

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -92,15 +92,14 @@ void Corpus::reset() {
   if (pos_ == 0) // no data read yet
     return;
   pos_ = 0;
-  for (size_t i = 0; i < paths_.size(); ++i)
-    {
+  for (size_t i = 0; i < paths_.size(); ++i) {
       if(paths_[i] == "stdin") {
         files_[i].reset(new io::InputFileStream(std::cin));
         // Probably not necessary, unless there are some buffers
         // that we want flushed.
       }
       else {
-        ABORT_IF(files_[i] and filesystem::is_fifo(paths_[i]),
+        ABORT_IF(files_[i] && filesystem::is_fifo(paths_[i]),
                  "File '", paths_[i], "' is a pipe and cannot be re-opened.");
         // Do NOT reset named pipes; that closes them and triggers a SIGPIPE
         // (lost pipe) at the writing end, which may do whatever it wants


### PR DESCRIPTION
Corpus::reset() closed and reopened input files for corpora. So files were opened once
during the construction of the Corpus instance, then closed and repopened during
data->reset() in BatchGenerator::prepare(false). With normal files that's not a problem,
but if the "file" is a named pipe, the closing triggers a SIGPIPE (broken pipe) on
the writing end of the pipe. With this commit, Corpus::reset() leaves open pipes
alone.

This resolves #425.