### PR TITLE
Fix compilation on gcc 8

### DIFF
--- a/src/3rd_party/zstr/strict_fstream.hpp
+++ b/src/3rd_party/zstr/strict_fstream.hpp
@@ -125,7 +125,7 @@ struct static_method_holder
             is_p->peek();
             peek_failed = is_p->fail();
         }
-        catch (std::ios_base::failure e) {}
+        catch (const std::ios_base::failure &e) {}
         if (peek_failed)
         {
             throw Exception(std::string("strict_fstream: open('")


### PR DESCRIPTION
Compilation is broken with gcc 8.3.0 due to
```
In file included from /home/dheart/uni_stuff/postdoc/marian-dev-master/src/3rd_party/zstr/zstr.hpp:16,
                 from /home/dheart/uni_stuff/postdoc/marian-dev-master/src/common/file_stream.h:11,
                 from /home/dheart/uni_stuff/postdoc/marian-dev-master/src/common/config.cpp:2:
/home/dheart/uni_stuff/postdoc/marian-dev-master/src/3rd_party/zstr/strict_fstream.hpp: In static member function ‘static void strict_fstream::detail::static_method_holder::check_peek(std::istream*, const string&, std::ios_base::openmode)’:
/home/dheart/uni_stuff/postdoc/marian-dev-master/src/3rd_party/zstr/strict_fstream.hpp:128:39: error: catching polymorphic type ‘class std::ios_base::failure’ by value [-Werror=catch-value=]
         catch (std::ios_base::failure e) {}
```
C++ best practices recommend catching by constant reference.

Cheers,

Nick