### PR TITLE
Allow allocator to increase the workspace size by more than step_

### DIFF
--- a/src/tensors/allocator.h
+++ b/src/tensors/allocator.h
@@ -127,6 +127,10 @@ private:
         throw AllocationException(available_, size);
       }
 
+      // Extend the workspace to fit requested allocation. To avoid lots of small
+      // reallocations, the workspace is extended by at least step_.
+
+      // Find size of the last gap
       size_t last_gap_size = 0;
       for (const auto& gap : gaps_) {
         if (gap.data() + gap.size() == device_->data() + device_->size()) {


### PR DESCRIPTION
For now, if the allocator receives a memory allocation request that doesn't fit to any gap then the workspace is increased by step_. This procedure is repeated until an enough gap occurs so in case of big allocation, the allocator performs a series of workspace reallocations instead of one big reallocation. This commit change policy of allocator in the following way: if an allocation doesn't fit to any gap then the allocator increases workspace size by max(step_, allocation_size).

UPDATE: I forgot about a minor optimization I made. Workspace is increased by max(step_, allocation_size - last_gap_size).