### PR TITLE
Abort if shapes aren't the same in reshape() or concatenate()

### DIFF
--- a/src/graph/expression_operators.cpp
+++ b/src/graph/expression_operators.cpp
@@ -185,6 +185,9 @@ Expr operator/(float a, Expr b) {
 /*********************************************************/
 
 Expr concatenate(const std::vector<Expr>& concats, int ax) {
+  auto shape = concats[0]->shape();
+  for (auto& e : concats)
+    ABORT_IF(e->shape() != shape, "You cannot concatenate tensors of different shapes.");
   return Expression<ConcatenateNodeOp>(concats, ax);
 }
 
@@ -195,6 +198,7 @@ Expr repeat(Expr a, size_t repeats, int ax) {
 }
 
 Expr reshape(Expr a, Shape shape) {
+  ABORT_IF(a->shape().elements() != shape.elements(), "You cannot reshape a tensor to one with a different number of elements.");
   return Expression<ReshapeNodeOp>(a, shape);
 }
 


### PR DESCRIPTION
I just added to ABORT_IF statements in operators to avoid confusing myself anymore when I try to modify Expr in a wrong way and I catch it much later.
No idea how Marian behaves when trying reshaping/concatenating with different elements/shapes, probably takes a chunk of memory it shouldn't and calculates with it.