### PR TITLE
Use relative paths in decoder config files

### DIFF
--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -78,6 +78,11 @@ namespace filesystem {
     return p.getImpl().absolute(base.getImpl()).expand();
   }
 
+  static inline Path relative(const Path& p, const Path& base) {
+    // create a path relative to the base path
+    return p.getImpl().absolute().expand().relative(base.getImpl().absolute().expand());
+  }
+
   static inline bool exists(const Path& p) {
     return p.getImpl().exists();
   }

--- a/src/models/amun.h
+++ b/src/models/amun.h
@@ -185,16 +185,26 @@ private:
   void createAmunConfig(const std::string& name) {
     Config::YamlNode amun;
     auto vocabs = options_->get<std::vector<std::string>>("vocabs");
-    amun["source-vocab"] = vocabs[0];
-    amun["target-vocab"] = vocabs[1];
+
+    if(options_->get<bool>("relative-paths")) {
+      amun["relative-paths"] = true;
+      auto dirPath = filesystem::Path{name}.parentPath();
+      amun["source-vocab"] = filesystem::relative(filesystem::Path{vocabs[0]}, dirPath).string();
+      amun["target-vocab"] = filesystem::relative(filesystem::Path{vocabs[1]}, dirPath).string();
+      amun["scorers"]["F0"]["path"] = filesystem::Path{name}.filename().string();
+    } else {
+      amun["relative-paths"] = false;
+      amun["source-vocab"] = vocabs[0];
+      amun["target-vocab"] = vocabs[1];
+      amun["scorers"]["F0"]["path"] = name;
+    }
+
+    amun["scorers"]["F0"]["type"] = "Nematus";
+    amun["weights"]["F0"] = 1.0f;
+
     amun["devices"] = options_->get<std::vector<size_t>>("devices");
     amun["normalize"] = opt<float>("normalize") > 0;
     amun["beam-size"] = opt<size_t>("beam-size");
-    amun["relative-paths"] = false;
-
-    amun["scorers"]["F0"]["path"] = name;
-    amun["scorers"]["F0"]["type"] = "Nematus";
-    amun["weights"]["F0"] = 1.0f;
 
     io::OutputFileStream out(name + ".amun.yml");
     out << amun;

--- a/src/models/amun.h
+++ b/src/models/amun.h
@@ -201,8 +201,6 @@ private:
 
     amun["scorers"]["F0"]["type"] = "Nematus";
     amun["weights"]["F0"] = 1.0f;
-
-    amun["devices"] = options_->get<std::vector<size_t>>("devices");
     amun["normalize"] = opt<float>("normalize") > 0;
     amun["beam-size"] = opt<size_t>("beam-size");
 


### PR DESCRIPTION
This fixes #460. 

If `--relative-paths` is used, model and vocab paths in `marian.npz.*{decoder,amun}.yml` will be relative.