### PR TITLE
Error message if decoding with left-to-right and right-to-left models together

### DIFF
--- a/src/translator/scorers.cpp
+++ b/src/translator/scorers.cpp
@@ -56,6 +56,7 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options) {
   if(options->hasAndNotEmpty("weights"))
     weights = options->get<std::vector<float>>("weights");
 
+  bool isPrevRightLeft = false;  // if the previous model was a right-to-left model
   size_t i = 0;
   for(auto model : models) {
     std::string fname = "F" + std::to_string(i);
@@ -70,6 +71,18 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options) {
       }
     } catch(std::runtime_error&) {
       LOG(warn, "No model settings found in model file");
+    }
+
+    // check if there are left-to-right and right-to-left models together
+    if(models.size() > 1 && modelOptions->has("right-left")) {
+      if(i == 0) {
+        isPrevRightLeft = modelOptions->get<bool>("right-left");
+      } else {
+        // abort as soon as there are two consecutive models with opposite directions
+        ABORT_IF(isPrevRightLeft != modelOptions->get<bool>("right-left"),
+                 "A left-to-right and right-to-left model cannot be decoded together");
+        isPrevRightLeft = modelOptions->get<bool>("right-left");
+      }
     }
 
     scorers.push_back(scorerByType(fname, weights[i], model, modelOptions));

--- a/src/translator/scorers.cpp
+++ b/src/translator/scorers.cpp
@@ -80,7 +80,7 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options) {
       } else {
         // abort as soon as there are two consecutive models with opposite directions
         ABORT_IF(isPrevRightLeft != modelOptions->get<bool>("right-left"),
-                 "A left-to-right and right-to-left model cannot be decoded together");
+                 "Left-to-right and right-to-left models cannot be used together in ensembles");
         isPrevRightLeft = modelOptions->get<bool>("right-left");
       }
     }


### PR DESCRIPTION
Fixes https://github.com/marian-nmt/marian/issues/238

An error message is displayed if left-to-right and right-to-left models are decoded together.