### PR TITLE
increase bumpVal.

### DIFF
--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -155,11 +155,7 @@ public:
       return;
     for(auto node : *currTrieNode) {
       auto index = node.id_ + rowNum*nColumns; //node.id_ is a vocab ID
-      //if (in[index] >= -15){
-        //std::cout << in[index] << " | ";
-        in[index] += bumpVal;
-        //std::cout << in[index] << " || ";
-      //}
+      in[index] += bumpVal;
     }
   }
 
@@ -172,11 +168,7 @@ public:
       return;
     for(auto node : *currTrieNode) {
       auto index = node.id_ + batchID*nColumns*beamSize + rowNum*nColumns; //node.id_ is a vocab ID
-      //if (in[index] >= -15){
-        //std::cout << in[index] << " | ";
-        in[index] += bumpVal;
-        //std::cout << in[index] << " || ";
-      //}
+      in[index] += bumpVal;
     }
   }
 
@@ -186,7 +178,7 @@ public:
       Beam newBeam;
       bool allFake = true; /* Keep track if all hypothesis we have are placeholders
                             * if that happens we should end search prematurely
-                            * by setting the beam to empty */
+                            * by setting the beam to empty*/
       for (auto hyp : beam) {
         if (hyp->hasTrieContinuatuions()) {
           newBeam.push_back(hyp);
@@ -333,16 +325,13 @@ public:
       if (!first && triePrune_) {
         for (int i = 0; i < beams.size(); i++) {
           for (size_t j = 0; j < beams[i].size(); j++) {
-            //beams[i][j]->hasTrieContinuatuions();  //Advance the trie after the first step.
             if (dimBatch > 1) {
               bumpScoresBatch(pathScores->val(), i, j, beams[i][j]->GetTrieNode(), 10000000.0f);
             } else {
               bumpScores(pathScores->val(), j, beams[i][j]->GetTrieNode(), 10000000.0f);
             }
           }
-        // std::cout << "\n-----\n";
         }
-        // std::cout << "==========\n";
       }
 
       getNBestList(beamSizes, pathScores->val(), outPathScores, outKeys, first);

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -329,7 +329,7 @@ public:
       if (!first && triePrune_) {
         for (int i = 0; i < beams.size(); i++) {
           for (size_t j = 0; j < beams[i].size(); j++) {
-            beams[i][j]->hasTrieContinuatuions();  //Advance the trie after the first step.
+            //beams[i][j]->hasTrieContinuatuions();  //Advance the trie after the first step.
             if (dimBatch > 1) {
               bumpScoresBatch(pathScores->val(), i, j, beams[i][j]->GetTrieNode(), 100.0f);
             } else {
@@ -361,9 +361,9 @@ public:
                      first,
                      batch);
 
-      //if (triePrune_) {
-      //   beams = filterForContinuations(beams);
-      //}
+      if (triePrune_) {
+         beams = filterForContinuations(beams);
+      }
 
       auto prunedBeams = pruneBeam(beams);
       for(int i = 0; i < dimBatch; ++i) {

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -356,6 +356,10 @@ public:
                      first,
                      batch);
 
+      if (triePrune_) {
+         beams = filterForContinuations(beams);
+      }
+
       auto prunedBeams = pruneBeam(beams);
       for(int i = 0; i < dimBatch; ++i) {
         if(!beams[i].empty()) {

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -351,9 +351,9 @@ public:
         //Everything that came out of the trie will have a score >1
         //Hence fix the scores
         for (auto&& score : outPathScores) {
-          if (score > 1) {
+          //if (score > 1) {
           score -= 10000000.0f;
-          }
+          //}
         }
       }
 

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -351,9 +351,9 @@ public:
         //Everything that came out of the trie will have a score >1
         //Hence fix the scores
         for (auto&& score : outPathScores) {
-          //if (score > 1) {
+          if (score > 1) {
           score -= 10000000.0f;
-          //}
+          }
         }
       }
 

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -155,9 +155,9 @@ public:
       return;
     for(auto node : *currTrieNode) {
       auto index = node.id_ + rowNum*nColumns; //node.id_ is a vocab ID
-      if (in[index] >= -7){
+      //if (in[index] >= -15){
         in[index] += bumpVal;
-      }
+      //}
     }
   }
 
@@ -170,9 +170,9 @@ public:
       return;
     for(auto node : *currTrieNode) {
       auto index = node.id_ + batchID*nColumns*beamSize + rowNum*nColumns; //node.id_ is a vocab ID
-      if (in[index] >= -7){
+      //if (in[index] >= -15){
         in[index] += bumpVal;
-      }
+      //}
     }
   }
 
@@ -346,7 +346,7 @@ public:
         //Hence fix the scores
         for (auto&& score : outPathScores) {
           if (score > 1) {
-            score -= 100.0f;
+          score -= 100.0f;
           }
         }
       }

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -155,7 +155,9 @@ public:
       return;
     for(auto node : *currTrieNode) {
       auto index = node.id_ + rowNum*nColumns; //node.id_ is a vocab ID
+      if (in[index] >= -7){
         in[index] += bumpVal;
+      }
     }
   }
 
@@ -168,7 +170,9 @@ public:
       return;
     for(auto node : *currTrieNode) {
       auto index = node.id_ + batchID*nColumns*beamSize + rowNum*nColumns; //node.id_ is a vocab ID
+      if (in[index] >= -7){
         in[index] += bumpVal;
+      }
     }
   }
 
@@ -178,7 +182,7 @@ public:
       Beam newBeam;
       bool allFake = true; /* Keep track if all hypothesis we have are placeholders
                             * if that happens we should end search prematurely
-                            * by setting the beam to empty*/
+                            * by setting the beam to empty */
       for (auto hyp : beam) {
         if (hyp->hasTrieContinuatuions()) {
           newBeam.push_back(hyp);
@@ -321,10 +325,11 @@ public:
       std::vector<size_t> beamSizes(dimBatch, localBeamSize);
       //Pathscores if of shape {12, 1, 1, 36000}} AFTER the first step, otherwise it's {1, 1, 1, 36000}
       //UNLESS It's batched then DIM0 is the batch size and DIM2 is the TrieSize
+
       if (!first && triePrune_) {
         for (int i = 0; i < beams.size(); i++) {
           for (size_t j = 0; j < beams[i].size(); j++) {
-            beams[i][j]->hasTrieContinuatuions(); //Advance the trie after the first step.
+            beams[i][j]->hasTrieContinuatuions();  //Advance the trie after the first step.
             if (dimBatch > 1) {
               bumpScoresBatch(pathScores->val(), i, j, beams[i][j]->GetTrieNode(), 100.0f);
             } else {
@@ -341,7 +346,7 @@ public:
         //Hence fix the scores
         for (auto&& score : outPathScores) {
           if (score > 1) {
-            score -= 100.0f; 
+            score -= 100.0f;
           }
         }
       }
@@ -356,9 +361,9 @@ public:
                      first,
                      batch);
 
-      if (triePrune_) {
-         beams = filterForContinuations(beams);
-      }
+      //if (triePrune_) {
+      //   beams = filterForContinuations(beams);
+      //}
 
       auto prunedBeams = pruneBeam(beams);
       for(int i = 0; i < dimBatch; ++i) {

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -156,7 +156,9 @@ public:
     for(auto node : *currTrieNode) {
       auto index = node.id_ + rowNum*nColumns; //node.id_ is a vocab ID
       //if (in[index] >= -15){
+        //std::cout << in[index] << " | ";
         in[index] += bumpVal;
+        //std::cout << in[index] << " || ";
       //}
     }
   }
@@ -171,7 +173,9 @@ public:
     for(auto node : *currTrieNode) {
       auto index = node.id_ + batchID*nColumns*beamSize + rowNum*nColumns; //node.id_ is a vocab ID
       //if (in[index] >= -15){
+        //std::cout << in[index] << " | ";
         in[index] += bumpVal;
+        //std::cout << in[index] << " || ";
       //}
     }
   }
@@ -331,12 +335,14 @@ public:
           for (size_t j = 0; j < beams[i].size(); j++) {
             //beams[i][j]->hasTrieContinuatuions();  //Advance the trie after the first step.
             if (dimBatch > 1) {
-              bumpScoresBatch(pathScores->val(), i, j, beams[i][j]->GetTrieNode(), 100.0f);
+              bumpScoresBatch(pathScores->val(), i, j, beams[i][j]->GetTrieNode(), 10000000.0f);
             } else {
-              bumpScores(pathScores->val(), j, beams[i][j]->GetTrieNode(), 100.0f);
+              bumpScores(pathScores->val(), j, beams[i][j]->GetTrieNode(), 10000000.0f);
             }
           }
+        // std::cout << "\n-----\n";
         }
+        // std::cout << "==========\n";
       }
 
       getNBestList(beamSizes, pathScores->val(), outPathScores, outKeys, first);
@@ -346,7 +352,7 @@ public:
         //Hence fix the scores
         for (auto&& score : outPathScores) {
           if (score > 1) {
-          score -= 100.0f;
+          score -= 10000000.0f;
           }
         }
       }


### PR DESCRIPTION
@XapaJIaMnu 
1) advance trie pointers outside for-loops while filtering beams
2) Use larger BumpVal, because larger beam sizes result in much smaller scores (<-1000)
3) comment out thresholding word probabilities for now.