### PR TITLE
Early stopping on multiple validation metrics

### DIFF
--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -437,9 +437,10 @@ void ConfigParser::addOptionsValidation(cli::CLIWrapper& cli) {
       "Metric to use during validation: cross-entropy, ce-mean-words, perplexity, valid-script, "
       "translation, bleu, bleu-detok. Multiple metrics can be specified",
       {"cross-entropy"});
-  cli.add<size_t>("--early-stopping",
-     "Stop if the first validation metric does not improve for  arg  consecutive validation steps",
-     10);
+  cli.add<std::vector<size_t>>("--early-stopping",
+     "Stop if the corresponding validation metrics do not improve for  arg  consecutive validation steps. "
+     "At most one per metric",
+     {10});
 
   // decoding options
   cli.add<size_t>("--beam-size,-b",


### PR DESCRIPTION
Following a discussion with @snukky , this should let us early stop on multiple validation metrics.
* For example `--validation-metrics cross-entropy bleu --early-stopping 10 20`
* The previous behaviour is still the default, and specifying fewer arguments for `--early-stopping` will only apply it to the corresponding metrics in order: `--validation-metrics cross-entropy bleu --early-stopping 10` is the same as before.
* We can use `0` to not early stop on one of the metrics: `--validation-metrics cross-entropy bleu translation --early-stopping 10 0 20`