### PR TITLE
fix Windows MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(COMPILE_EXAMPLES "Compile examples" OFF)
 option(COMPILE_TESTS "Compile tests" OFF)
 option(COMPILE_SERVER "Compile marian-server" ON)
 option(USE_FBGEMM "Use FBGEMM" ON)
+option(USE_MKL "Use MKL" ON)
 
 # Project versioning
 find_package(Git QUIET)
@@ -43,10 +44,15 @@ if(MSVC)
 # These are used in src/CMakeLists.txt on a per-target basis
   list(APPEND ALL_WARNINGS /WX; /W4;)
 
-  # Disabled bogus warnings for CPU intrincics:
+  # Disabled bogus warnings for CPU intrinsics:
   # C4310: cast truncates constant value
   # C4324: 'marian::cpu::int16::`anonymous-namespace'::ScatterPut': structure was padded due to alignment specifier
-  set(DISABLE_GLOBALLY "/wd\"4310\" /wd\"4324\"")
+  # Disable specific MSVC warnings that occur:
+  # C4100:'identifier' : unreferenced formal parameter
+  set(DISABLE_GLOBALLY "/wd\"4310\" /wd\"4324\" /wd\"4100\"")
+
+  # C4702: unreachable code
+  set(DISABLE_GLOBALLY_DEBUG "/wd\"4702\"")
 
   set(INTRINSICS "/arch:AVX")
 
@@ -56,7 +62,7 @@ if(MSVC)
 
   set(CMAKE_CXX_FLAGS           "/EHsc /DWIN32 /D_WINDOWS /DUNICODE /D_UNICODE /D_CRT_NONSTDC_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS ${DISABLE_GLOBALLY}")
   set(CMAKE_CXX_FLAGS_RELEASE   "${CMAKE_CXX_FLAGS} /MT /O2 ${INTRINSICS} /Zi /MP /GL /DNDEBUG")
-  set(CMAKE_CXX_FLAGS_DEBUG     "${CMAKE_CXX_FLAGS} /MTd /Od /Ob0 ${INTRINSICS} /RTC1 /Zi /D_DEBUG")
+  set(CMAKE_CXX_FLAGS_DEBUG     "${CMAKE_CXX_FLAGS} ${DISABLE_GLOBALLY_DEBUG} /MTd /Od /Ob0 ${INTRINSICS} /RTC1 /Zi /D_DEBUG")
 
   # ignores warning LNK4049: locally defined symbol free imported - this comes from zlib
   set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /LTCG:incremental /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT /ignore:4049")
@@ -172,12 +178,21 @@ if(CUDA_FOUND)
   endif()
 
   if(USE_STATIC_LIBS)
-    find_library(CUDA_culibos_LIBRARY NAMES culibos PATHS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
-    set(EXT_LIBS ${EXT_LIBS} ${CUDA_curand_LIBRARY} ${CUDA_cusparse_LIBRARY} ${CUDA_culibos_LIBRARY} ${CUDA_CUBLAS_LIBRARIES})
-    set(CUDA_LIBS ${CUDA_curand_LIBRARY} ${CUDA_cusparse_LIBRARY} ${CUDA_culibos_LIBRARY} ${CUDA_CUBLAS_LIBRARIES})
+    set(EXT_LIBS ${EXT_LIBS} ${CUDA_curand_LIBRARY} ${CUDA_cusparse_LIBRARY} ${CUDA_CUBLAS_LIBRARIES})
+    set(CUDA_LIBS ${CUDA_curand_LIBRARY} ${CUDA_cusparse_LIBRARY} ${CUDA_CUBLAS_LIBRARIES})
+    find_library(CUDA_culibos_LIBRARY NAMES culibos PATHS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64)
+    if (CUDA_culibos_LIBRARY)
+      set(EXT_LIBS ${EXT_LIBS} ${CUDA_culibos_LIBRARY})
+      set(CUDA_LIBS ${CUDA_LIBS} ${CUDA_culibos_LIBRARY})
+    elseif(NOT WIN32)
+      message(FATAL_ERROR "cuLIBOS library not found")
+    endif()
     # CUDA 10.1 introduces cublasLt library that is required on static build
     if ((CUDA_VERSION VERSION_EQUAL "10.1" OR CUDA_VERSION VERSION_GREATER "10.1"))
-      find_library(CUDA_cublasLt_LIBRARY NAMES cublasLt PATHS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
+      find_library(CUDA_cublasLt_LIBRARY NAMES cublasLt PATHS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64)
+      if(NOT CUDA_cublasLt_LIBRARY)
+        message(FATAL_ERROR "cuBLASLt library not found")
+      endif()
       set(EXT_LIBS ${EXT_LIBS} ${CUDA_cublasLt_LIBRARY})
       set(CUDA_LIBS ${CUDA_LIBS} ${CUDA_cublasLt_LIBRARY})
     endif()
@@ -232,7 +247,7 @@ if(NOT MSVC)
   # @TODO: add warnings here too
   list(APPEND CUDA_NVCC_FLAGS -ccbin ${CMAKE_C_COMPILER}; -std=c++11; -Xcompiler\ -fPIC; -Xcompiler\ -Wno-unused-result; -Xcompiler\ -Wno-deprecated; -Xcompiler\ -Wno-pragmas; -Xcompiler\ -Wno-unused-value; -Xcompiler\ -Werror;)
 else()
-  list(APPEND CUDA_NVCC_FLAGS -Xcompiler\ /FS; )
+  list(APPEND CUDA_NVCC_FLAGS -Xcompiler\ /FS; -Xcompiler\ /MT$<$<CONFIG:Debug>:d>; )
 endif()
 
 list(REMOVE_DUPLICATES CUDA_NVCC_FLAGS)
@@ -267,7 +282,9 @@ if(USE_MPI)
 endif(USE_MPI)
 
 if(COMPILE_CPU)
-  find_package(MKL)
+  if(USE_MKL)
+    find_package(MKL)
+  endif()
   if(MKL_FOUND)
     include_directories(${MKL_INCLUDE_DIR})
     set(EXT_LIBS ${EXT_LIBS} ${MKL_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,7 @@ if(MSVC)
   # Disabled bogus warnings for CPU intrinsics:
   # C4310: cast truncates constant value
   # C4324: 'marian::cpu::int16::`anonymous-namespace'::ScatterPut': structure was padded due to alignment specifier
-  # Disable specific MSVC warnings that occur:
-  # C4100:'identifier' : unreferenced formal parameter
-  set(DISABLE_GLOBALLY "/wd\"4310\" /wd\"4324\" /wd\"4100\"")
-
-  # C4702: unreachable code
-  set(DISABLE_GLOBALLY_DEBUG "/wd\"4702\"")
+  set(DISABLE_GLOBALLY "/wd\"4310\" /wd\"4324\"")
 
   set(INTRINSICS "/arch:AVX")
 
@@ -62,10 +57,12 @@ if(MSVC)
 
   set(CMAKE_CXX_FLAGS           "/EHsc /DWIN32 /D_WINDOWS /DUNICODE /D_UNICODE /D_CRT_NONSTDC_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS ${DISABLE_GLOBALLY}")
   set(CMAKE_CXX_FLAGS_RELEASE   "${CMAKE_CXX_FLAGS} /MT /O2 ${INTRINSICS} /Zi /MP /GL /DNDEBUG")
-  set(CMAKE_CXX_FLAGS_DEBUG     "${CMAKE_CXX_FLAGS} ${DISABLE_GLOBALLY_DEBUG} /MTd /Od /Ob0 ${INTRINSICS} /RTC1 /Zi /D_DEBUG")
+  set(CMAKE_CXX_FLAGS_DEBUG     "${CMAKE_CXX_FLAGS} /MTd /Od /Ob0 ${INTRINSICS} /RTC1 /Zi /D_DEBUG")
 
   # ignores warning LNK4049: locally defined symbol free imported - this comes from zlib
-  set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /LTCG:incremental /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT /ignore:4049")
+  set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /LTCG:incremental /INCREMENTAL:NO /ignore:4049")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:MSVCRT")
+  set(CMAKE_EXE_LINKER_FLAGS_DEBUG   "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:MSVCRTD")
   set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /LTCG:incremental")
 
   find_library(SHLWAPI Shlwapi.lib)
@@ -159,7 +156,9 @@ if(COMPILE_CUDA)
 
 if(USE_STATIC_LIBS)
   # link statically to stdlib libraries
-  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+  if(NOT MSVC)
+    set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+  endif()
 
   # look for libraries that have .a suffix
   set(_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -89,10 +89,13 @@ find_library(MKL_CORE_LIBRARY
              NO_DEFAULT_PATH)
 
 set(MKL_INCLUDE_DIRS ${MKL_INCLUDE_DIR})
-# Added -Wl block to avoid circular dependencies.
-# https://stackoverflow.com/questions/5651869/what-are-the-start-group-and-end-group-command-line-options
-# https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor
-set(MKL_LIBRARIES -Wl,--start-group ${MKL_INTERFACE_LIBRARY} ${MKL_SEQUENTIAL_LAYER_LIBRARY} ${MKL_CORE_LIBRARY} -Wl,--end-group)
+set(MKL_LIBRARIES ${MKL_INTERFACE_LIBRARY} ${MKL_SEQUENTIAL_LAYER_LIBRARY} ${MKL_CORE_LIBRARY})
+if(NOT WIN32)
+  # Added -Wl block to avoid circular dependencies.
+  # https://stackoverflow.com/questions/5651869/what-are-the-start-group-and-end-group-command-line-options
+  # https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor
+  set(MKL_LIBRARIES -Wl,--start-group ${MKL_LIBRARIES} -Wl,--end-group)
+endif()
 
 # message("1 ${MKL_INCLUDE_DIR}")
 # message("2 ${MKL_INTERFACE_LIBRARY}")

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -28,18 +28,18 @@ if(USE_SENTENCEPIECE)
     endif()
   endif()
 
-  set(SPM_ENABLE_TCMALLOC ON CACHE BOOL "Enable TCMalloc if available." FORCE)
+  set(SPM_ENABLE_TCMALLOC ON CACHE BOOL "Enable TCMalloc if available.")
 
   if(USE_STATIC_LIBS)
     message(WARNING "You are compiling SentencePiece binaries with -DUSE_STATIC_LIBS=on. \
     This will cause spm_train to segfault. No need to worry if you do not intend to use that binary. \
     Marian support for SentencePiece will work fine.")
     
-    set(SPM_ENABLE_SHARED OFF CACHE BOOL "Builds shared libaries in addition to static libraries." FORCE)
-    set(SPM_TCMALLOC_STATIC ON CACHE BOOL "Link static library of TCMALLOC." FORCE)
+    set(SPM_ENABLE_SHARED OFF CACHE BOOL "Builds shared libaries in addition to static libraries.")
+    set(SPM_TCMALLOC_STATIC ON CACHE BOOL "Link static library of TCMALLOC.")
   else(USE_STATIC_LIBS)
-    set(SPM_ENABLE_SHARED ON CACHE BOOL "Builds shared libaries in addition to static libraries." FORCE)
-    set(SPM_TCMALLOC_STATIC OFF CACHE BOOL "Link static library of TCMALLOC." FORCE)
+    set(SPM_ENABLE_SHARED ON CACHE BOOL "Builds shared libaries in addition to static libraries.")
+    set(SPM_TCMALLOC_STATIC OFF CACHE BOOL "Link static library of TCMALLOC.")
   endif(USE_STATIC_LIBS)
 
   add_subdirectory(./sentencepiece)

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -10,18 +10,20 @@
 namespace marian {
 namespace filesystem {
 
-bool is_fifo(char const* path) {
 #ifdef _MSC_VER
+bool is_fifo(char const* /*path*/) {
   // Pretend that Windows knows no named pipes. It does, by the way, but
   // they seem to be different from pipes on Unix / Linux. See
   // https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
   return false;
+}
 #else
+bool is_fifo(char const* path) {
   struct stat buf;
   stat(path, &buf);
   return S_ISFIFO(buf.st_mode);
-#endif
 }
+#endif
 
 bool is_fifo(std::string const& path) {
   return is_fifo(path.c_str());

--- a/src/common/options.cpp
+++ b/src/common/options.cpp
@@ -52,7 +52,6 @@ namespace marian {
     } catch(const YAML::BadConversion&) {
       ABORT("Option '{}' is neither a sequence nor a text");
     }
-    return false;
   }
 
   bool Options::has(const std::string& key) const {

--- a/src/common/options.cpp
+++ b/src/common/options.cpp
@@ -49,7 +49,7 @@ namespace marian {
     }
     try {
       return !options_[key].as<std::string>().empty();
-    } catch(const YAML::BadConversion& e) {
+    } catch(const YAML::BadConversion&) {
       ABORT("Option '{}' is neither a sequence nor a text");
     }
     return false;

--- a/src/data/batch.h
+++ b/src/data/batch.h
@@ -17,7 +17,7 @@ public:
   virtual size_t wordsTrg() const { return 0; };
   virtual size_t widthTrg() const { return 0; };
 
-  virtual void debug(bool printIndices = false) {};
+  virtual void debug(bool /*printIndices*/ = false) {};
 
   virtual std::vector<Ptr<Batch>> split(size_t n, size_t sizeLimit = SIZE_MAX) = 0;
 

--- a/src/data/factored_vocab.cpp
+++ b/src/data/factored_vocab.cpp
@@ -109,7 +109,6 @@ namespace marian {
           factorMapTokenized.push_back(std::move(tokenizedMapLine));
         continue;
       }
-      ABORT("Malformed .fsv input line {}", line); // we only get here for lines we could not process
     }
     for (auto factorTypeName : deferredFactorVocab)
       factorVocab_.add("|" + factorTypeName, v++);

--- a/src/graph/expression_graph.h
+++ b/src/graph/expression_graph.h
@@ -74,15 +74,19 @@ public:
     if(node->type() != "param" && node->memoize()) {
       auto it = longterm_->find(hash);
       if(it != longterm_->end()) {
+#if 1
+        if(!it->second.empty())
+          return *(it->second.begin());
+#else
+        // @TODO: check why below code does not work for certain nodes and
+        // autotuning.
         for(auto found : it->second) {
-          return found;
-          // @TODO: check why below code does not work for certain nodes and
-          // autotuning.
-          // if(node->equal(found)) {
-          // std::cerr << "found memoized" << std::endl;
-          // return found;
-          //}
+           if(node->equal(found)) {
+             std::cerr << "found memoized" << std::endl;
+             return found;
+          }
         }
+#endif
       }
       (*longterm_)[hash].push_back(node);
     }

--- a/src/layers/loss.cpp
+++ b/src/layers/loss.cpp
@@ -26,8 +26,6 @@ Ptr<MultiRationalLoss> newMultiLoss(Ptr<Options> options) {
       return New<MeanMultiRationalLoss>();
     else
       ABORT("Unknown multi-loss-type {}", multiLossType);
-
-    return nullptr;
 }
 
 }  // namespace marian

--- a/src/rescorer/score_collector.cpp
+++ b/src/rescorer/score_collector.cpp
@@ -74,7 +74,6 @@ std::string ScoreCollector::getAlignment(const data::SoftAlignment& align) {
   } else {
     ABORT("Unrecognized word alignment type");
   }
-  return "";
 }
 
 ScoreCollectorNBest::ScoreCollectorNBest(const Ptr<Options>& options)

--- a/src/tensors/cpu/expanded_gemm.h
+++ b/src/tensors/cpu/expanded_gemm.h
@@ -80,8 +80,8 @@ struct PackNodeOp : public UnaryNodeOp {
 
   const std::string type() override { return "packMat"; }
 
-  Shape newShape(Expr a, bool transpose) {
 #if USE_FBGEMM
+  Shape newShape(Expr a, bool transpose) {
     auto shapeMat = a->shape();
     // Should be 2D - weight matrix
     ABORT_IF(shapeMat.size() != 2,
@@ -101,11 +101,13 @@ struct PackNodeOp : public UnaryNodeOp {
     Shape outShape({(int)packsize_});
 
     return outShape;
+  }
 #else // USE_FBGEMM
+  Shape newShape(Expr /*a*/, bool /*transpose*/) {
     ABORT("Packed GEMM requires a build with USE_FBGEMM enabled");
     return Shape();
-#endif  // USE_FBGEMM
   }
+#endif  // USE_FBGEMM
 };
 
 // Affine transform (matrix multiplication) using packed B matrix

--- a/src/tensors/cpu/int16.h
+++ b/src/tensors/cpu/int16.h
@@ -19,7 +19,6 @@ struct QuantizeNodeOp : public UnaryNodeOp {
 
   NodeOps backwardOps() override {
     ABORT("Only used for inference");
-    return {NodeOp(0)};
   }
 
   const std::string type() override { return "quantizeInt16"; }
@@ -54,7 +53,6 @@ public:
 
   NodeOps backwardOps() override {
     ABORT("Only used for inference");
-    return {NodeOp(0)};
   }
 
   const std::string type() override { return "dotInt16"; }
@@ -92,7 +90,6 @@ public:
 
   NodeOps backwardOps() override {
     ABORT("Only used for inference");
-    return {NodeOp(0)};
   }
 
   const std::string type() override { return "affineInt16"; }

--- a/src/tensors/cpu/sharp/packed_gemm.cpp
+++ b/src/tensors/cpu/sharp/packed_gemm.cpp
@@ -207,28 +207,28 @@ void GemmPackFp32(marian::Tensor C,
   packedPlaceholder.pmat_ = pmat;
 }
 #else // USE_FBGEMM
-void PackFp32(marian::Tensor out,
-              const marian::Tensor in,
-              const bool transpose,
-              const int nrow,
-              const int ncol,
-              const int kernel_ncol_blocks,
-              const int brow,
-              const int bcol,
-              const int last_brow,
-              const int nbrow,
-              const int nbcol,
-              const uint64_t packsize) {
+void PackFp32(marian::Tensor /*out*/,
+              const marian::Tensor /*in*/,
+              const bool /*transpose*/,
+              const int /*nrow*/,
+              const int /*ncol*/,
+              const int /*kernel_ncol_blocks*/,
+              const int /*brow*/,
+              const int /*bcol*/,
+              const int /*last_brow*/,
+              const int /*nbrow*/,
+              const int /*nbcol*/,
+              const uint64_t /*packsize*/) {
                 // does nothing. supports only FBGEMM based packed gemm at this moment.
                 ABORT("FBGEMM is needed to use packed GEMM.");
 }
-void GemmPackFp32(marian::Tensor C,
-                  const marian::Tensor A,
-                  const marian::Tensor B,
-                  const marian::Tensor bias,
-                  const size_t m,
-                  const size_t n,
-                  const int transA) {
+void GemmPackFp32(marian::Tensor /*C*/,
+                  const marian::Tensor /*A*/,
+                  const marian::Tensor /*B*/,
+                  const marian::Tensor /*bias*/,
+                  const size_t /*m*/,
+                  const size_t /*n*/,
+                  const int /*transA*/) {
                 // does nothing. supports only FBGEMM based packed gemm at this moment.
                 ABORT("FBGEMM is needed to use packed GEMM.");
 }


### PR DESCRIPTION
The changes here fix errors in Windows builds using the MSVC compiler.
The MSVC builds fail because of compiler warnings occuring and being treated as errors, because of CUDA libraries not being found (in the case of `USE_STATIC_LIBS=on`), and Debug builds can fail because of a runtime library mismatch with the NVCC-compiled object files, and finally builds can fail because of SentencePiece build flags being forced.

There are several C4100 ('identifier' : unreferenced formal parameter) warnings which arise from preprocessor directives. The change here is to disable this warning.
The code change in `src/common/options.cpp` is for MSVC warning C4101: 'identifier' : unreferenced local variable.

The changes for CUDA library finds with `USE_STATIC_LIBS` include directories of a CUDA toolkit install on Windows as well as an acceptance of not finding the cuLIBOS library (which doesn't seem to exist in Windows CUDA toolkit installs). An alternative to what I did would be to not look for it at all on Windows builds, but I have not tested this with all supported CUDA versions (only 10.1).

There are issues with building SentencePiece shared libraries on Windows, and these changes make it possible to build and use static SentencePiece libraries even if `USE_STATIC_LIBS` is off (by setting `SPM_ENABLE_SHARED` to `off`).

One more change here is to add an option `USE_MKL` to allow for not using MKL even when it is installed/found.