### PR TITLE
Sort custom cmake options alphabetically.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,21 +11,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(BUILD_ARCH native CACHE STRING "Compile for this CPU architecture.")
 
 # Custom CMake options
-option(USE_SENTENCEPIECE "Download and compile SentencePiece" OFF)
-option(USE_FBGEMM "Use FBGEMM" OFF)
-option(USE_NCCL "Use NCCL library" ON)
-option(USE_MPI "Use MPI library" OFF)
-option(USE_CUDNN "Use CUDNN library" OFF)
-
 option(COMPILE_CPU "Compile CPU version" ON)
 option(COMPILE_CUDA "Compile GPU version" ON)
-option(USE_STATIC_LIBS "Link statically against non-system libs" OFF)
 option(COMPILE_EXAMPLES "Compile examples" OFF)
-option(COMPILE_TESTS "Compile tests" OFF)
 option(COMPILE_SERVER "Compile marian-server" OFF)
-
-option(USE_DOXYGEN "Build documentation with Doxygen" ON)
+option(COMPILE_TESTS "Compile tests" OFF)
 option(USE_CCACHE "Use ccache compiler cache (https://ccache.dev)" OFF)
+option(USE_CUDNN "Use CUDNN library" OFF)
+option(USE_DOXYGEN "Build documentation with Doxygen" ON)
+option(USE_FBGEMM "Use FBGEMM" OFF)
+option(USE_MPI "Use MPI library" OFF)
+option(USE_NCCL "Use NCCL library" ON)
+option(USE_SENTENCEPIECE "Download and compile SentencePiece" OFF)
+option(USE_STATIC_LIBS "Link statically against non-system libs" OFF)
 
 # use ccache (https://ccache.dev) for faster compilation if requested and available
 if(USE_CCACHE)


### PR DESCRIPTION
This makes locating options and merging branches a bit easier.