### PR TITLE
Return exit code 15 (SIGTERM) after SIGTERM.

### DIFF
--- a/src/command/marian_train.cpp
+++ b/src/command/marian_train.cpp
@@ -68,5 +68,5 @@ int main(int argc, char** argv) {
     }
   }
 
-  return 0;
+  return getSigtermFlag() ? 15 : 0;
 }

--- a/src/command/marian_train.cpp
+++ b/src/command/marian_train.cpp
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include "marian.h"
 
 #include "training/graph_group_async.h"
@@ -68,5 +69,13 @@ int main(int argc, char** argv) {
     }
   }
 
-  return getSigtermFlag() ? 15 : 0;
+  // If we exit due to SIGTERM, exit with 128 + the signal number, as suggested
+  // for bash in http://tldp.org/LDP/abs/html/exitcodes.html. This allows parent
+  // scripts to determine if training terminated naturally or via SIGTERM.
+  // Whith this approach we can accommodate additional signals in the future.
+  // An alternative would be to return 124, which is what the timeout command
+  // returns for timeout -s SIGTERM <seconds> ...., because exiting after SIGTERM
+  // is not technically a fatal error (which is what the 128+x convention usually
+  // stands for).
+  return getSigtermFlag() ? (128 + SIGTERM) : 0;
 }


### PR DESCRIPTION
When marian receives signal SIGTERM and exits gracefully (save model & exit),
it should then exit with a non-zero exit code, to signal to any parent process
that it did not exit "naturally".