### PR TITLE
Remove unused variables

### DIFF
--- a/src/graph/expression_graph.h
+++ b/src/graph/expression_graph.h
@@ -130,9 +130,6 @@ class ExpressionGraph : public std::enable_shared_from_this<ExpressionGraph> {
 
   bool inferenceOnly_{false};
 
-  // during inference, use optimizations that might lead to precision loss, e.g. 8-bit MatMul.
-  // At this moment, this is used for int16 qunatized Matmul - 11/1/2019
-  bool optimized_{false};
   bool checkpointing_{false}; // use gradient checkpointing if true
 
   bool reloaded_{false};
@@ -177,9 +174,6 @@ public:
 
   void setInference(bool inference) { inferenceOnly_ = inference; }
   bool isInference() { return inferenceOnly_; }
-
-  void setOptimized(bool optimized) { optimized_ = optimized; }
-  bool isOptimized() { return (optimized_ && inferenceOnly_); }
 
   void setCheckpointing(bool checkpointing) { checkpointing_ = checkpointing; }
   bool isCheckpointing() { return checkpointing_; }


### PR DESCRIPTION
graph_->setOptimized/isOptimized is no longer used. This functionality has moved to the Backend, but the methods still exist in the graph_ which always return false
```
grep -R "Optimized("
translator/translator.h:          graph->getBackend()->setOptimized(options_->get<bool>("optimize"));
translator/translator.h:        graph->getBackend()->setOptimized(options_->get<bool>("optimize"));
tests/prod.cpp:        g->getBackend()->setOptimized(false);
tests/prod.cpp:        g->getBackend()->setOptimized(true);
tensors/gpu/backend.h:  // for GPU, this is invalid. for gpu, isOptimized() function always returns false.
tensors/gpu/backend.h:  void setOptimized(bool optimize) override {
tensors/gpu/backend.h:    LOG_ONCE(info, "setOptimized() not supported for GPU_{}", optimize);
tensors/gpu/backend.h:  bool isOptimized() override {
tensors/cpu/backend.h:  void setOptimized(bool optimize) override { optimized_ = optimize; }
tensors/cpu/backend.h:  bool isOptimized() override { return optimized_; }
tensors/backend.h:  // for GPU, this is invalid. for gpu, isOptimized() function always returns false.
tensors/backend.h:  virtual void setOptimized(bool optimize) = 0;
tensors/backend.h:  virtual bool isOptimized() = 0;
rescorer/rescorer.h:        graph->getBackend()->setOptimized(options_->get<bool>("optimize"));
microsoft/quicksand.cpp:  graph->getBackend()->setOptimized(false);
graph/expression_graph.h:  void setOptimized(bool optimized) { optimized_ = optimized; }
graph/expression_graph.h:  bool isOptimized() { return (optimized_ && inferenceOnly_); }
graph/expression_operators.cpp:      if(a->graph()->getBackend()->isOptimized()) {
graph/expression_operators.cpp:      if(a->graph()->getBackend()->isOptimized()) {
command/marian_conv.cpp:  graph->getBackend()->setOptimized(false);
```
This patch removes the unused variable from the graph class.

Cheers,

Nick
