### PR TITLE
Add a warning message for an incorrect use of output sampling

### DIFF
--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -114,11 +114,11 @@ public:
       if(options_->get<size_t>("beam-size") > 1)
         LOG(warn,
             "[warning] Output sampling and beam search (beam-size > 1) are contradictory methods "
-            "and using them together is highly not recommended. Set beam-size to 1");
+            "and using them together is not recommended. Set beam-size to 1");
       if(options_->get<std::vector<std::string>>("models").size() > 1)
         LOG(warn,
             "[warning] Output sampling and model ensembling are contradictory methods and using "
-            "them together is highly not recommended. Use a single model");
+            "them together is not recommended. Use a single model");
     }
   }
 

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -109,6 +109,17 @@ public:
 
       threadPool.enqueue(task, device, id++);
     }
+
+    if(options_->get<bool>("output-sampling", false)) {
+      if(options_->get<size_t>("beam-size") > 1)
+        LOG(warn,
+            "[warning] Output sampling and beam search (beam-size > 1) are contradictory methods "
+            "and using them together is highly not recommended. Set beam-size to 1");
+      if(options_->get<std::vector<std::string>>("models").size() > 1)
+        LOG(warn,
+            "[warning] Output sampling and model ensembling are contradictory methods and using "
+            "them together is highly not recommended. Use a single model");
+    }
   }
 
   void run() override {


### PR DESCRIPTION
The warning is printed after the config options are printed if `--output-sampling` is used with `--beam-size > 1` or model ensembles.