### PR TITLE
Add information about sentence cropping to the help message for --valid-max-length

### DIFF
--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -553,7 +553,8 @@ void ConfigParser::addOptionsValidation(cli::CLIWrapper& cli) {
       "Size of mini-batch used during validation",
       32);
   cli.add<size_t>("--valid-max-length",
-      "Maximum length of a sentence in a validating sentence pair",
+      "Maximum length of a sentence in a validating sentence pair. "
+      "Sentences longer than valid-max-length are cropped to valid-max-length",
       1000);
 
   // options for validation script


### PR DESCRIPTION
Related to #494, if we want to keep automatic cropping for sentences in the validation set longer than valid-max-length.