### PR TITLE
clang: Disable unused-function warnings for 3rd-party NCCL library

### DIFF
--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -86,6 +86,12 @@ if(CUDA_FOUND)
     if(COMPILE_CUDA_SM70)
       set(GENCODE "${GENCODE} -gencode=arch=compute_70,code=sm_70")
     endif(COMPILE_CUDA_SM70)
+    # clang generates a lot of unused function warnings for NCCL
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set(NCCL_CXXFLAGS "-Wno-unused-function")
+    else()
+      set(NCCL_CXXFLAGS "")
+    endif()
 
     # install nccl in ${CMAKE_BINARY_DIR}/local similar to /usr/local linux installation
     ExternalProject_Add(nccl_install
@@ -95,7 +101,7 @@ if(CUDA_FOUND)
       BUILD_COMMAND
         $(MAKE) -f ${CMAKE_CURRENT_SOURCE_DIR}/nccl/Makefile src.build
         BUILDDIR=${CMAKE_BINARY_DIR}/local CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}
-        CUDA8_GENCODE=${GENCODE} CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-Wno-unused-function
+        CUDA8_GENCODE=${GENCODE} CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${NCCL_CXXFLAGS}
       INSTALL_COMMAND "")
 
     set_target_properties(nccl PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libnccl_static.a)

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -95,7 +95,7 @@ if(CUDA_FOUND)
       BUILD_COMMAND
         $(MAKE) -f ${CMAKE_CURRENT_SOURCE_DIR}/nccl/Makefile src.build
         BUILDDIR=${CMAKE_BINARY_DIR}/local CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}
-        CUDA8_GENCODE=${GENCODE} CXX=${CMAKE_CXX_COMPILER}
+        CUDA8_GENCODE=${GENCODE} CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-Wno-unused-function
       INSTALL_COMMAND "")
 
     set_target_properties(nccl PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/local/lib/libnccl_static.a)


### PR DESCRIPTION
Actually a lot of warnings from clang are unused functions inside NCCL.  Not all of them, but it's a start.