### PR TITLE
combine two for-loops in nth_element.cpp on CPU

### DIFF
--- a/src/translator/nth_element.cpp
+++ b/src/translator/nth_element.cpp
@@ -8,7 +8,6 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
-#include <iostream>
 
 namespace marian {
 

--- a/src/translator/nth_element.cpp
+++ b/src/translator/nth_element.cpp
@@ -44,20 +44,24 @@ public:
 
     for(size_t batchIdx = 0; batchIdx < dimBatch; ++batchIdx) {
 
-      std::partial_sort(
+      std::partial_sort( 
+        // sorts the top N (beam size) idxs by score to the front
         idxs.begin(),
         idxs.begin() + N,
         idxs.end(),
         [&](int a, int b) { return scoresData[a] > scoresData[b]; }
       );
 
-      for(int temp = 0; temp < N; ++temp) {
-        int idx = idxs[temp];
+      // copy top N idxs and scores to return vectors
+      for(size_t i = 0; i < N; ++i) {
+        int idx = idxs[i];
+        // since idxs is re-used for each batch, add batch offset to each idx to get absolute position
         h_res_idx[pos] = idx + batchIdx * batchOffset;
         h_res[pos] = scoresData[idx];
         ++pos;
       }
 
+      // advance pointer to next batch's beginning
       scoresData += batchOffset;
     }
     getPairs(/*cumulativeBeamSizes.back(),*/ outKeys, outPathScores);

--- a/src/translator/nth_element.cpp
+++ b/src/translator/nth_element.cpp
@@ -43,12 +43,12 @@ public:
     for(size_t batchIdx = 0; batchIdx < dimBatch; ++batchIdx) {
 
       std::vector<int>::iterator begin = idxs.begin() + batchIdx * inputN * vocabSize;
-      std::vector<int>::iterator middle = begin + (int)N;
+      std::vector<int>::iterator middle = begin + N;
       std::vector<int>::iterator end = idxs.begin() + (batchIdx + 1) * inputN * vocabSize;
       std::partial_sort(
           begin, middle, end, [&](int a, int b) { return scoresData[a] > scoresData[b]; });
 
-      int pos = batchIdx * (int)N;
+      size_t pos = batchIdx * N;
       while(begin != middle) {
         int idx = *begin++;
         h_res_idx[pos] = idx;


### PR DESCRIPTION
Original `nth_element.cpp` fills a vector with (accumulative) beam sizes and vocab indices for different batches/sentences. Then it uses a different for loop to read them and sort n-best scores. Since beam size is fixed, this commit combines the two for-loops to improve efficiency.