### PR TITLE
Add templates for GitHub issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Bug description
+Please add a clear and concise description of what the bug is, including the actual and expected behavior.
+
+### How to reproduce
+Describe steps and/or add a command to reproduce the behavior.
+
+### Context
+* Marian version: Paste the output of `--version` here
+* CMake command: Type the cmake command you used and/or attach the output of `--build-info`
+* Log file: Attach your training/decoding logs
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,14 +8,14 @@ assignees: ''
 ---
 
 ### Bug description
-Please add a clear and concise description of what the bug is, including the actual and expected behavior.
+Please add a clear and concise description of the bug, including observed and if possible expected behavior.
 
 ### How to reproduce
-Describe steps and/or add a command to reproduce the behavior.
+Describe steps or include command to reproduce the behavior.
 
 ### Context
 * Marian version: Paste the output of `--version` here
-* CMake command: Type the cmake command you used and/or attach the output of `--build-info`
+* CMake command: Type the cmake command you used and attach the output of `--build-info all`
 * Log file: Attach your training/decoding logs
 
-Add any other context about the problem here.
+Add any other information about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,8 +8,8 @@ assignees: ''
 ---
 
 ### Feature description
-Please add a concise description of what the problem is and describe the solution you'd like.
+Please add a concise description of what the problem is and describe the solution you would like to see.
 Add links to a paper, another toolkit, etc. if relevant.
 
 ### Example
-Add usage examples for the new feature, e.g. a command line.
+Add a usage examples for the new feature, e.g. a command line.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+### Feature description
+Please add a concise description of what the problem is and describe the solution you'd like.
+Add links to a paper, another toolkit, etc. if relevant.
+
+### Example
+Add usage examples for the new feature, e.g. a command line.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+### Description
+Please add a clear and concise description of the changes.
+
+This PR fixes a bug/adds a new feature/refactorizes the code/does something else.
+It is related to issues: #998, #999, ...
+
+List of changes:
+- ...
+- ...
+- ...
+
+Added dependencies: none
+
+### How to test
+Describe how to test your changes, adding command line examples and sample input/output files if relevant.
+Point to unit tests or regression tests covering the changes if they have been added.
+
+Describe how you have tested your code, including OS and the cmake command.
+
+### Checklist
+
+- [ ] I've tested the code manually
+- [ ] I've run regression tests
+- [ ] I've read and followed CONTRIBUTING.md
+- [ ] I've updated the CHANGELOG.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Describe how you have tested your code, including OS and the cmake command.
 
 ### Checklist
 
-- [ ] I've tested the code manually
-- [ ] I've run regression tests
-- [ ] I've read and followed CONTRIBUTING.md
-- [ ] I've updated the CHANGELOG.md
+- [ ] I have tested the code manually
+- [ ] I have run regression tests
+- [ ] I have read and followed CONTRIBUTING.md
+- [ ] I have updated CHANGELOG.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,12 @@ How to contribute to Marian
 
 Did you find a bug or want to ask a question? Great!
 
-* Ensure the bug was not already reported or the question was not asked
-* For bugs check the [github
-  issues](https://github.com/marian-nmt/marian-dev/issues)
-* For answers to your question search posts on the [Google discussion
-  group](https://groups.google.com/forum/#!forum/marian-nmt)
-* Open a new issue/question if you're unable to find yours
+* Ensure the bug was not already reported or the question was not asked on
+  [the github issues](https://github.com/marian-nmt/marian-dev/issues) or
+  [the Google discussion group](https://groups.google.com/forum/#!forum/marian-nmt).
+* Open a new issue/question if you're unable to find yours.
 * For bugs please provide as much relevant information as possible, and do not
-  forget to paste a log
+  forget to attach training/decoding logs and your Marian command.
 
 You are also welcome to request a new feature.
 Especially if you plan to help us adding it :)
@@ -22,19 +20,20 @@ Especially if you plan to help us adding it :)
 ## Submitting changes
 
 Whenever possible, please send a Github Pull Request with a clear list of what
-you've done.  Feel free to also update CHANGELOG.md file.  We will love you
+you've done.  Feel free to update CHANGELOG.md file.  We will love you
 forever if you provide unit or regression tests.
 
-Please follow our coding convention (below) and make sure all of your commits
-are atomic (learn more about _git squash_ to merge multiple commits and _git
-rebase -i_ to split a single huge commit into smaller pieces).
+Please follow our coding convention (below) and do not forget to test your
+changes by running unit tests:
 
-Ideally test your changes by running [Marian regression
-tests](http://github.com/marian-nmt/marian-regression-tests.git) locally:
+    cd marian-dev/build
+    cmake .. -DCOMPILE_TESTS=ON
+    make test
 
-    git clone http://github.com/marian-nmt/marian-regression-tests.git
-    cd marian-regression-tests.git
-    make BRANCH=<your_branch_name> install
+and [regression tests](http://github.com/marian-nmt/marian-regression-tests.git):
+
+    cd marian-dev/regression-tests
+    make install
     ./run_mrt.sh
 
 
@@ -43,7 +42,7 @@ tests](http://github.com/marian-nmt/marian-regression-tests.git) locally:
 Main code style rules:
 
 * no tabs, 2 whitespaces instead
-* lines no longer than 80 characters
+* lines no longer than 100 characters
 * no trailing whitespaces
 * no space between control statements and opening brackets
 * `UpperCamelCase` for class names
@@ -51,8 +50,7 @@ Main code style rules:
 * `camelCase` for variables, methods and functions
 * `UPPERCASE_WITH_UNDERSCORES` for constants
 
-Ideally, use the provided `.clang-format` file (in the root directory) for
-[ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to format your code, e.g.
-
-    clang-format-3.8 <path_to_file>
+You may also use [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)
+and the `.clang-format` file provided in the root directory to help you with
+code formatting.
 


### PR DESCRIPTION
### Description
This PR adds templates for issues and pull requests on GitHub. It uses the proposed template for PRs.

List of changes:
- Added templates for bug reports and new feature requests. Creating an issue without any template is still possible.
- Added template for pull requests.
- Simplified CONTRIBUTING.md.

Added dependencies: none

### How to test
See templates in the markdown format in the changed files. 

Tested in a separate repository.

### Checklist
- [x] I've tested the code manually
- [ ] ~~I've run regression tests~~ (not relevant for this PR)
- [x] I've read and followed CONTRIBUTING.md
- [ ] I've updated the CHANGELOG.md

Suggestions and comments are welcome.