### PR TITLE
Support tab-separated inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.9.0] - 2020-03-10
 
 ### Added
+- Training and scoring from STDIN
+- Support for tab-separated inputs, added ptions --tsv and --tsv-fields
 - An option to print cached variables from CMake
 - Add support for compiling on Mac (and clang)
 - An option for resetting stalled validation metrics
@@ -34,15 +36,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for 16-bit packed models with FBGEMM
 - Multiple separated parameter types in ExpressionGraph, currently inference-only
 - Safe handling of sigterm signal
-- Automatic vectorization of elementwise operations on CPU for tensors dims that 
+- Automatic vectorization of elementwise operations on CPU for tensors dims that
   are divisible by 4 (AVX) and 8 (AVX2)
-- Replacing std::shared_ptr<T> with custom IntrusivePtr<T> for small objects like 
+- Replacing std::shared_ptr<T> with custom IntrusivePtr<T> for small objects like
   Tensors, Hypotheses and Expressions.
 - Fp16 inference working for translation
 - Gradient-checkpointing
 
 ### Fixed
-- Replace value for INVALID_PATH_SCORE with std::numer_limits<float>::lowest() 
+- Replace value for INVALID_PATH_SCORE with std::numer_limits<float>::lowest()
   to avoid overflow with long sequences
 - Break up potential circular references for GraphGroup*
 - Fix empty source batch entries with batch purging
@@ -53,16 +55,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - FastOpt now reads "n" and "y" values as strings, not as boolean values
 - Fixed multiple reduction kernels on GPU
 - Fixed guided-alignment training with cross-entropy
-- Replace IntrusivePtr with std::uniq_ptr in FastOpt, fixes random segfaults 
+- Replace IntrusivePtr with std::uniq_ptr in FastOpt, fixes random segfaults
   due to thread-non-safty of reference counting.
 - Make sure that items are 256-byte aligned during saving
 - Make explicit matmul functions respect setting of cublasMathMode
 - Fix memory mapping for mixed paramter models
 - Removed naked pointer and potential memory-leak from file_stream.{cpp,h}
 - Compilation for GCC >= 7 due to exception thrown in destructor
-- Sort parameters by lexicographical order during allocation to ensure consistent 
+- Sort parameters by lexicographical order during allocation to ensure consistent
   memory-layout during allocation, loading, saving.
-- Output empty line when input is empty line. Previous behavior might result in 
+- Output empty line when input is empty line. Previous behavior might result in
   hallucinated outputs.
 - Compilation with CUDA 10.1
 
@@ -73,7 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Return error signal on SIGTERM
 - Dropped support for CUDA 8.0, CUDA 9.0 is now minimal requirement
 - Removed autotuner for now, will be switched back on later
-- Boost depdendency is now optional and only required for marian_server 
+- Boost depdendency is now optional and only required for marian_server
 - Dropped support for g++-4.9
 - Simplified file stream and temporary file handling
 - Unified node intializers, same function API.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,9 @@ add_library(marian STATIC
   common/io.cpp
   common/filesystem.cpp
   common/file_stream.cpp
+  common/file_utils.cpp
   common/types.cpp
-  
+
   data/alignment.cpp
   data/vocab.cpp
   data/default_vocab.cpp
@@ -139,7 +140,7 @@ cuda_add_library(marian_cuda
   tensors/gpu/algorithm.cu
   tensors/gpu/prod.cpp
   tensors/gpu/element.cu
-  tensors/gpu/add.cu  
+  tensors/gpu/add.cu
   tensors/gpu/add_all.cu
   tensors/gpu/tensor_operators.cu
   tensors/gpu/cudnn_wrappers.cu

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -49,11 +49,12 @@ void Config::initialize(ConfigParser const& cp) {
   }
 
   // load model parameters
+  bool loaded = false;
   if(mode == cli::mode::translation || mode == cli::mode::server) {
     auto model = get<std::vector<std::string>>("models")[0];
     try {
       if(!get<bool>("ignore-model-config"))
-        loadModelParameters(model);
+        loaded = loadModelParameters(model);
     } catch(std::runtime_error& ) {
       LOG(info, "[config] No model configuration found in model file");
     }
@@ -64,23 +65,38 @@ void Config::initialize(ConfigParser const& cp) {
     if(filesystem::exists(model) && !get<bool>("no-reload")) {
       try {
         if(!get<bool>("ignore-model-config"))
-          loadModelParameters(model);
+          loaded = loadModelParameters(model);
       } catch(std::runtime_error&) {
         LOG(info, "[config] No model configuration found in model file");
       }
     }
   }
 
-  // guess --tsv-fields if not set
+  // guess --tsv-fields (the number of streams) if not set
   if(get<bool>("tsv") && get<size_t>("tsv-fields") == 0) {
-    auto modelType = get<std::string>("type");
+    size_t tsvFields = 0;
+    if(loaded) {
+      // model.npz has properly set vocab dimensions in special:model.yml,
+      // so we may use them to determine the number of streams
+      for(auto dim : get<std::vector<size_t>>("dim-vocabs"))
+        if(dim != 0)  // language models have a fake extra vocab
+          ++tsvFields;
+      // For translation there is no target stream
+      if((mode == cli::mode::translation || mode == cli::mode::server) && tsvFields > 1)
+        --tsvFields;
+    } else {
+      // TODO: This is very britle, find a better solution
+      // If parameters from model.npz special:model.yml were not loaded,
+      // guess the number of inputs and outputs based on the model type name.
+      auto modelType = get<std::string>("type");
 
-    size_t tsvFields = 1;
-    if(modelType.find("multi-", 0) != std::string::npos) // is a dual-source model
-      tsvFields += 1;
-    if(mode == cli::mode::training || mode == cli::mode::scoring)
-      if(modelType.rfind("lm", 0) != 0) // unless it is a language model
+      tsvFields = 1;
+      if(modelType.find("multi-", 0) != std::string::npos)  // is a dual-source model
         tsvFields += 1;
+      if(mode == cli::mode::training || mode == cli::mode::scoring)
+        if(modelType.rfind("lm", 0) != 0)  // unless it is a language model
+          tsvFields += 1;
+    }
 
     config_["tsv-fields"] = tsvFields;
   }
@@ -138,16 +154,18 @@ void Config::save(const std::string& name) {
   out << *this;
 }
 
-void Config::loadModelParameters(const std::string& name) {
+bool Config::loadModelParameters(const std::string& name) {
   YAML::Node config;
   io::getYamlFromModel(config, "special:model.yml", name);
   override(config);
+  return true;
 }
 
-void Config::loadModelParameters(const void* ptr) {
+bool Config::loadModelParameters(const void* ptr) {
   YAML::Node config;
   io::getYamlFromModel(config, "special:model.yml", ptr);
   override(config);
+  return true;
 }
 
 void Config::override(const YAML::Node& params) {

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -71,6 +71,20 @@ void Config::initialize(ConfigParser const& cp) {
     }
   }
 
+  // guess --tsv-size if not set
+  if(get<bool>("tsv") && get<size_t>("tsv-size") == 0) {
+    auto modelType = get<std::string>("type");
+
+    size_t tsvSize = 1;
+    if(modelType.find("multi-", 0) != std::string::npos) // is a dual-source model
+      tsvSize += 1;
+    if(mode == cli::mode::training || mode == cli::mode::scoring)
+      if(modelType.rfind("lm", 0) != 0) // unless it is a language model
+        tsvSize += 1;
+
+    config_["tsv-size"] = tsvSize;
+  }
+
   // echo full configuration
   log();
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -71,18 +71,18 @@ void Config::initialize(ConfigParser const& cp) {
     }
   }
 
-  // guess --tsv-size if not set
-  if(get<bool>("tsv") && get<size_t>("tsv-size") == 0) {
+  // guess --tsv-fields if not set
+  if(get<bool>("tsv") && get<size_t>("tsv-fields") == 0) {
     auto modelType = get<std::string>("type");
 
-    size_t tsvSize = 1;
+    size_t tsvFields = 1;
     if(modelType.find("multi-", 0) != std::string::npos) // is a dual-source model
-      tsvSize += 1;
+      tsvFields += 1;
     if(mode == cli::mode::training || mode == cli::mode::scoring)
       if(modelType.rfind("lm", 0) != 0) // unless it is a language model
-        tsvSize += 1;
+        tsvFields += 1;
 
-    config_["tsv-size"] = tsvSize;
+    config_["tsv-fields"] = tsvFields;
   }
 
   // echo full configuration

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -77,8 +77,8 @@ public:
   }
 
   YAML::Node getModelParameters();
-  void loadModelParameters(const std::string& name);
-  void loadModelParameters(const void* ptr);
+  bool loadModelParameters(const std::string& name);
+  bool loadModelParameters(const void* ptr);
 
   std::vector<DeviceId> getDevices(size_t myMPIRank = 0, size_t numRanks = 1);
 

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -800,7 +800,7 @@ void ConfigParser::addSuboptionsTSV(cli::CLIWrapper& cli) {
   // clang-format off
   cli.add<bool>("--tsv",
       "Tab-separated input");
-  cli.add<size_t>("--tsv-size",
+  cli.add<size_t>("--tsv-fields",
       "Number of fields in the TSV input, guessed based on the model type");
   // clang-format on
 }

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -883,7 +883,7 @@ Ptr<Options> ConfigParser::parseOptions(int argc, char** argv, bool doValidate){
     if(get<bool>("tsv") && trainSets.empty()) {
       config["train-sets"].push_back("stdin");
     // Assume the input is in TSV format if --train-sets is set to "stdin"
-    } else if(trainSets.size() == 1 && trainSets[0] == "stdin") {
+    } else if(trainSets.size() == 1 && (trainSets[0] == "stdin" || trainSets[0] == "-")) {
       config["tsv"] = true;
     }
     if(!config.IsNull())

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -801,7 +801,7 @@ void ConfigParser::addSuboptionsTSV(cli::CLIWrapper& cli) {
   cli.add<bool>("--tsv",
       "Tab-separated input");
   cli.add<size_t>("--tsv-size",
-      "Number of fields in the TSV input");
+      "Number of fields in the TSV input, guessed based on the model type");
   // clang-format on
 }
 

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -375,6 +375,7 @@ void ConfigParser::addOptionsTraining(cli::CLIWrapper& cli) {
       "10000u");
 
   addSuboptionsInputLength(cli);
+  addSuboptionsTSV(cli);
 
   // data management options
   cli.add<std::string>("--shuffle",
@@ -497,8 +498,10 @@ void ConfigParser::addOptionsTraining(cli::CLIWrapper& cli) {
       {"float32", "float32", "float32"});
   cli.add<std::vector<std::string>>("--cost-scaling",
       "Dynamic cost scaling for mixed precision training: "
-      "power of 2, scaling window, scaling factor, tolerance, range, minimum factor")->implicit_val("7.f 2000 2.f 0.05f 10 1.f");
-  cli.add<bool>("--normalize-gradient", "Normalize gradient by multiplying with no. devices / total labels");
+      "power of 2, scaling window, scaling factor, tolerance, range, minimum factor")
+    ->implicit_val("7.f 2000 2.f 0.05f 10 1.f");
+  cli.add<bool>("--normalize-gradient",
+      "Normalize gradient by multiplying with no. devices / total labels");
 
   // multi-node training
   cli.add<bool>("--multi-node",
@@ -623,8 +626,9 @@ void ConfigParser::addOptionsTranslation(cli::CLIWrapper& cli) {
       "Keep the output segmented into SentencePiece subwords");
 #endif
 
-  addSuboptionsDevices(cli);
   addSuboptionsInputLength(cli);
+  addSuboptionsTSV(cli);
+  addSuboptionsDevices(cli);
   addSuboptionsBatching(cli);
 
   cli.add<bool>("--optimize",
@@ -684,6 +688,7 @@ void ConfigParser::addOptionsScoring(cli::CLIWrapper& cli) {
      ->implicit_val("1"),
 
   addSuboptionsInputLength(cli);
+  addSuboptionsTSV(cli);
   addSuboptionsDevices(cli);
   addSuboptionsBatching(cli);
 
@@ -788,6 +793,15 @@ void ConfigParser::addSuboptionsInputLength(cli::CLIWrapper& cli) {
       defaultMaxLength);
   cli.add<bool>("--max-length-crop",
       "Crop a sentence to max-length instead of omitting it if longer than max-length");
+  // clang-format on
+}
+
+void ConfigParser::addSuboptionsTSV(cli::CLIWrapper& cli) {
+  // clang-format off
+  cli.add<bool>("--tsv",
+      "Tab-separated input");
+  cli.add<size_t>("--tsv-size",
+      "Number of fields in the TSV input");
   // clang-format on
 }
 

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -875,6 +875,21 @@ Ptr<Options> ConfigParser::parseOptions(int argc, char** argv, bool doValidate){
     cli::processPaths(config_, cli::InterpolateEnvVars, PATHS);
   }
 
+  // Option shortcuts for input from STDIN for trainer and scorer
+  if(mode_ == cli::mode::training || mode_ == cli::mode::scoring) {
+    auto trainSets = get<std::vector<std::string>>("train-sets");
+    YAML::Node config;
+    // Assume the input will come from STDIN if --tsv is set but no --train-sets are given
+    if(get<bool>("tsv") && trainSets.empty()) {
+      config["train-sets"].push_back("stdin");
+    // Assume the input is in TSV format if --train-sets is set to "stdin"
+    } else if(trainSets.size() == 1 && trainSets[0] == "stdin") {
+      config["tsv"] = true;
+    }
+    if(!config.IsNull())
+      cli_.updateConfig(config, cli::OptionPriority::CommandLine, "A shortcut for STDIN failed.");
+  }
+
   if(doValidate) {
     ConfigValidator(config_).validateOptions(mode_);
   }

--- a/src/common/config_parser.h
+++ b/src/common/config_parser.h
@@ -135,6 +135,7 @@ private:
   void addSuboptionsDevices(cli::CLIWrapper&);
   void addSuboptionsBatching(cli::CLIWrapper&);
   void addSuboptionsInputLength(cli::CLIWrapper&);
+  void addSuboptionsTSV(cli::CLIWrapper&);
   void addSuboptionsULR(cli::CLIWrapper&);
 
   // Extract paths to all config files found in the config object.

--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -70,9 +70,14 @@ void ConfigValidator::validateOptionsParallelData() const {
   auto trainSets = get<std::vector<std::string>>("train-sets");
   ABORT_IF(trainSets.empty(), "No train sets given in config file or on command line");
 
-  auto vocabs = get<std::vector<std::string>>("vocabs");
-  ABORT_IF(!vocabs.empty() && vocabs.size() != trainSets.size(),
+  auto numVocabs = get<std::vector<std::string>>("vocabs").size();
+  auto numStreams = get<bool>("tsv") ? get<size_t>("tsv-size") : trainSets.size();
+
+  ABORT_IF(numVocabs > 0 && numVocabs != numStreams,
            "There should be as many vocabularies as training sets");
+
+  ABORT_IF(get<bool>("tsv") && trainSets.size() != 1,
+      "A single file can be provided with --train-sets (or stdin) for a tab-separated input");
 }
 
 void ConfigValidator::validateOptionsScoring() const {

--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -72,17 +72,18 @@ void ConfigValidator::validateOptionsParallelData() const {
 
   auto numVocabs = get<std::vector<std::string>>("vocabs").size();
   ABORT_IF(!get<bool>("tsv") && numVocabs > 0 && numVocabs != trainSets.size(),
-           "There should be as many vocabularies as training sets");
+           "There should be as many vocabularies as training files");
 
   // disallow, for example --tsv --train-sets file1.tsv file2.tsv
   ABORT_IF(get<bool>("tsv") && trainSets.size() != 1,
-      "A single file can be provided with --train-sets (or stdin) for a tab-separated input");
+      "A single file must be provided with --train-sets (or stdin) for a tab-separated input");
 
   // disallow, for example --train-sets stdin stdin or --train-sets stdin file.tsv
-  ABORT_IF(trainSets.size() > 1 && std::any_of(trainSets.begin(),
-                                               trainSets.end(),
-                                               [](const std::string& s) { return s == "stdin"; }),
-           "Only one 'stdin' in --train-sets is allowed");
+  ABORT_IF(trainSets.size() > 1
+               && std::any_of(trainSets.begin(),
+                              trainSets.end(),
+                              [](const std::string& s) { return (s == "stdin") || (s == "-"); }),
+           "Only one 'stdin' or '-' in --train-sets is allowed");
 }
 
 void ConfigValidator::validateOptionsScoring() const {
@@ -104,7 +105,7 @@ void ConfigValidator::validateOptionsTraining() const {
   ABORT_IF(has("embedding-vectors")
                && get<std::vector<std::string>>("embedding-vectors").size() != trainSets.size()
                && !get<std::vector<std::string>>("embedding-vectors").empty(),
-           "There should be as many embedding vector files as training sets");
+           "There should be as many embedding vector files as training files");
 
   filesystem::Path modelPath(get<std::string>("model"));
 
@@ -115,15 +116,14 @@ void ConfigValidator::validateOptionsTraining() const {
   ABORT_IF(!modelDir.empty() && !filesystem::isDirectory(modelDir),
            "Model directory does not exist");
 
-  std::string errorMessage = get<bool>("tsv")
-            ? "There should be as many validation sets as training sets. "
-              "If the training set is in the TSV format, validation sets have to also be a TSV file"
-            : "There should be as many validation sets as training sets";
+  std::string errorMsg = "There should be as many validation files as training files";
+  if(get<bool>("tsv"))
+    errorMsg += ". If the training set is in the TSV format, validation sets have to also be a single TSV file";
 
   ABORT_IF(has("valid-sets")
                && get<std::vector<std::string>>("valid-sets").size() != trainSets.size()
                && !get<std::vector<std::string>>("valid-sets").empty(),
-           errorMessage);
+           errorMsg);
 
   // validations for learning rate decaying
   ABORT_IF(get<float>("lr-decay") > 1.f, "Learning rate decay factor greater than 1.0 is unusual");

--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -115,10 +115,15 @@ void ConfigValidator::validateOptionsTraining() const {
   ABORT_IF(!modelDir.empty() && !filesystem::isDirectory(modelDir),
            "Model directory does not exist");
 
+  std::string errorMessage = get<bool>("tsv")
+            ? "There should be as many validation sets as training sets. "
+              "If the training set is in the TSV format, validation sets have to also be a TSV file"
+            : "There should be as many validation sets as training sets";
+
   ABORT_IF(has("valid-sets")
                && get<std::vector<std::string>>("valid-sets").size() != trainSets.size()
                && !get<std::vector<std::string>>("valid-sets").empty(),
-           "There should be as many validation sets as training sets");
+           errorMessage);
 
   // validations for learning rate decaying
   ABORT_IF(get<float>("lr-decay") > 1.f, "Learning rate decay factor greater than 1.0 is unusual");

--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -74,8 +74,15 @@ void ConfigValidator::validateOptionsParallelData() const {
   ABORT_IF(!get<bool>("tsv") && numVocabs > 0 && numVocabs != trainSets.size(),
            "There should be as many vocabularies as training sets");
 
+  // disallow, for example --tsv --train-sets file1.tsv file2.tsv
   ABORT_IF(get<bool>("tsv") && trainSets.size() != 1,
       "A single file can be provided with --train-sets (or stdin) for a tab-separated input");
+
+  // disallow, for example --train-sets stdin stdin or --train-sets stdin file.tsv
+  ABORT_IF(trainSets.size() > 1 && std::any_of(trainSets.begin(),
+                                               trainSets.end(),
+                                               [](const std::string& s) { return s == "stdin"; }),
+           "Only one 'stdin' in --train-sets is allowed");
 }
 
 void ConfigValidator::validateOptionsScoring() const {

--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -71,9 +71,7 @@ void ConfigValidator::validateOptionsParallelData() const {
   ABORT_IF(trainSets.empty(), "No train sets given in config file or on command line");
 
   auto numVocabs = get<std::vector<std::string>>("vocabs").size();
-  auto numStreams = get<bool>("tsv") ? get<size_t>("tsv-size") : trainSets.size();
-
-  ABORT_IF(numVocabs > 0 && numVocabs != numStreams,
+  ABORT_IF(!get<bool>("tsv") && numVocabs > 0 && numVocabs != trainSets.size(),
            "There should be as many vocabularies as training sets");
 
   ABORT_IF(get<bool>("tsv") && trainSets.size() != 1,

--- a/src/common/file_stream.cpp
+++ b/src/common/file_stream.cpp
@@ -22,7 +22,7 @@ InputFileStream::InputFileStream(const std::string &file)
   ABORT_IF(!marian::filesystem::exists(file_), "File '{}' does not exist", file);
 
   streamBuf1_.reset(new std::filebuf());
-  auto ret = static_cast<std::filebuf*>(streamBuf1_.get())->open(file.c_str(), std::ios::in | std::ios::binary); 
+  auto ret = static_cast<std::filebuf*>(streamBuf1_.get())->open(file.c_str(), std::ios::in | std::ios::binary);
   ABORT_IF(!ret, "File cannot be opened", file);
   ABORT_IF(ret != streamBuf1_.get(), "Return value is not equal to streambuf pointer, that is weird");
 
@@ -82,6 +82,10 @@ OutputFileStream::OutputFileStream()
 
 OutputFileStream::~OutputFileStream() {
   this->flush();
+}
+
+std::string OutputFileStream::getFileName() const {
+  return file_.string();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/common/file_stream.h
+++ b/src/common/file_stream.h
@@ -62,6 +62,8 @@ public:
   explicit OutputFileStream(const std::string& file);
   virtual ~OutputFileStream();
 
+  std::string getFileName() const;
+
   template <typename T>
   size_t write(const T* ptr, size_t num = 1) {
     std::ostream::write((char*)ptr, num * sizeof(T));

--- a/src/common/file_utils.cpp
+++ b/src/common/file_utils.cpp
@@ -9,10 +9,11 @@ void cut(const std::string& tsvIn,
          const std::vector<size_t>& fields,
          size_t numFields,
          const std::string& sep /*= "\t"*/) {
-  io::InputFileStream ioIn(tsvIn);
+  std::vector<std::string> tsvFields(numFields);
   std::string line;
+  io::InputFileStream ioIn(tsvIn);
   while(getline(ioIn, line)) {
-    std::vector<std::string> tsvFields(numFields);
+    tsvFields.clear();
     utils::splitTsv(line, tsvFields, numFields);  // split tab-separated fields
     for(size_t i = 0; i < fields.size(); ++i) {
       *tsvOut << tsvFields[fields[i]];

--- a/src/common/file_utils.cpp
+++ b/src/common/file_utils.cpp
@@ -1,0 +1,27 @@
+#include "common/file_utils.h"
+#include "common/utils.h"
+
+namespace marian {
+namespace fileutils {
+
+void cut(const std::string& tsvIn,
+         Ptr<io::TemporaryFile> tsvOut,
+         const std::vector<size_t>& fields,
+         size_t numFields,
+         const std::string& sep /*= "\t"*/) {
+  io::InputFileStream ioIn(tsvIn);
+  std::string line;
+  while(getline(ioIn, line)) {
+    std::vector<std::string> tsvFields(numFields);
+    utils::splitTsv(line, tsvFields, numFields);  // split tab-separated fields
+    for(size_t i = 0; i < fields.size(); ++i) {
+      *tsvOut << tsvFields[fields[i]];
+      if(i < fields.size() - 1)
+        *tsvOut << sep;  // concatenating fields with the custom separator
+    }
+    *tsvOut << std::endl;
+  }
+};
+
+}  // namespace fileutils
+}  // namespace marian

--- a/src/common/file_utils.h
+++ b/src/common/file_utils.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "common/file_stream.h"
+
+namespace marian {
+namespace fileutils {
+
+void cut(const std::string& tsvIn,
+         Ptr<io::TemporaryFile> tsvOut,
+         const std::vector<size_t>& fields,
+         size_t numFields,
+         const std::string& sep = "\t");
+
+}  // namespace utils
+}  // namespace marian

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -115,5 +115,5 @@ namespace filesystem {
 
   using FilesystemError = Pathie::PathieError;
 
-}
-}
+}  // namespace filesystem
+}  // namespace marian

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -67,10 +67,9 @@ void split(const std::string& line,
   }
 }
 
+// the function guarantees that the output has as many elements as requested
 void splitTsv(const std::string& line, std::vector<std::string>& fields, size_t numFields) {
   fields.clear();
-  if(fields.capacity() != numFields) // make sure the number of fields is always as requested
-    fields.resize(numFields);
 
   size_t begin = 0;
   size_t pos = 0;
@@ -83,6 +82,12 @@ void splitTsv(const std::string& line, std::vector<std::string>& fields, size_t 
     fields.push_back(line.substr(begin, pos - begin));
     begin = pos + 1;
   }
+
+  if(fields.size() < numFields)  // make sure there is as many elements as requested
+    fields.resize(numFields);
+
+  if(pos != std::string::npos)
+    LOG(warn, "[warning] Excessive field(s) in the tab-separated line: '{}'", line);
 }
 
 std::vector<std::string> split(const std::string& line,

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -86,8 +86,7 @@ void splitTsv(const std::string& line, std::vector<std::string>& fields, size_t 
   if(fields.size() < numFields)  // make sure there is as many elements as requested
     fields.resize(numFields);
 
-  if(pos != std::string::npos)
-    LOG(warn, "[warning] Excessive field(s) in the tab-separated line: '{}'", line);
+  ABORT_IF(pos != std::string::npos, "Excessive field(s) in the tab-separated line: '{}'", line);
 }
 
 std::vector<std::string> split(const std::string& line,

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -121,6 +121,12 @@ std::string join(const std::vector<std::string>& words, const std::string& del /
   return ss.str();
 }
 
+std::string join(const std::vector<size_t>& nums, const std::string& del /*= " "*/) {
+  std::vector<std::string> words(nums.size());
+  std::transform(nums.begin(), nums.end(), words.begin(), [](int i) { return std::to_string(i); });
+  return join(words, del);
+}
+
 // escapes a string for passing to popen, which uses /bin/sh to parse its argument string
 static std::string escapeForPOpen(const std::string& arg) {
   // e.g. abc -> 'abc'; my file.txt -> 'my file.txt'; $10 -> '$10'; it's -> 'it'\''s'

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -67,6 +67,24 @@ void split(const std::string& line,
   }
 }
 
+void splitTsv(const std::string& line, std::vector<std::string>& fields, size_t numFields){
+  fields.clear();
+  if(fields.capacity() != numFields) // make sure the number of fields is always as requested
+    fields.resize(numFields);
+
+  size_t begin = 0;
+  size_t pos = 0;
+  for(size_t i = 0; i < numFields; ++i) {
+    pos = line.find('\t', begin);
+    if(pos == std::string::npos) {
+      fields.push_back(line.substr(begin));
+      break;
+    }
+    fields.push_back(line.substr(begin, pos - begin));
+    begin = pos + 1;
+  }
+}
+
 std::vector<std::string> split(const std::string& line,
                                const std::string& del /*= " "*/,
                                bool keepEmpty /*= false*/,

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -67,7 +67,7 @@ void split(const std::string& line,
   }
 }
 
-void splitTsv(const std::string& line, std::vector<std::string>& fields, size_t numFields){
+void splitTsv(const std::string& line, std::vector<std::string>& fields, size_t numFields) {
   fields.clear();
   if(fields.capacity() != numFields) // make sure the number of fields is always as requested
     fields.resize(numFields);

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -32,6 +32,7 @@ std::vector<std::string> splitAny(const std::string& line,
                                   bool keepEmpty = false);
 
 std::string join(const std::vector<std::string>& words, const std::string& del = " ");
+std::string join(const std::vector<size_t>& words, const std::string& del = " ");
 
 std::string exec(const std::string& cmd, const std::vector<std::string>& args = {}, const std::string& arg = "");
 

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -20,6 +20,9 @@ void splitAny(const std::string& line,
               const std::string& del = " ",
               bool keepEmpty = false);
 
+// Split tab-separated line into the specified number of fields
+void splitTsv(const std::string& line, std::vector<std::string>& fields, size_t numFields);
+
 std::vector<std::string> split(const std::string& line,
                                const std::string& del = " ",
                                bool keepEmpty = false,

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -121,7 +121,8 @@ void Corpus::shuffle() {
 
 // reset to regular, non-shuffled reading
 // Call either reset() or shuffle().
-// @TODO: make shuffle() private, instad pass a shuffle() flag to reset(), to clarify mutual exclusiveness with shuffle()
+// @TODO: make shuffle() private, instad pass a shuffle() flag to reset(), to clarify mutual
+// exclusiveness with shuffle()
 void Corpus::reset() {
   corpusInRAM_.clear();
   ids_.clear();
@@ -151,6 +152,10 @@ void Corpus::restore(Ptr<TrainingState> ts) {
 
 void Corpus::shuffleData(const std::vector<std::string>& paths) {
   LOG(info, "[data] Shuffling data");
+
+  ABORT_IF(tsv_ && paths[0] == "stdin",
+           "Shuffling training data from STDIN is not supported. Remove the --shuffle option or "
+           "provide training sets using --train-sets");
 
   size_t numStreams = paths.size();
 

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -78,13 +78,22 @@ SentenceTuple Corpus::next() {
         }
       }
 
-      if(i > 0 && i == alignFileIdx_) { // @TODO: alignFileIdx == 0 possible?
+      if(i > 0 && i == alignFileIdx_) {
         addAlignmentToSentenceTuple(line, tup);
       } else if(i > 0 && i == weightFileIdx_) {
         addWeightsToSentenceTuple(line, tup);
       } else {
-        preprocessLine(line, i);
-        addWordsToSentenceTuple(line, i, tup);
+        if(tsv_) {  // split TSV input and add each field into the sentence tuple
+          std::vector<std::string> fields(tsvNumFields_);
+          utils::splitTsv(line, fields, tsvNumFields_);
+          for(size_t j = 0; j < tsvNumFields_; ++j) {
+            preprocessLine(fields[j], j);
+            addWordsToSentenceTuple(fields[j], j, tup);
+          }
+        } else {
+          preprocessLine(line, i);
+          addWordsToSentenceTuple(line, i, tup);
+        }
       }
     }
 

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -154,8 +154,8 @@ void Corpus::shuffleData(const std::vector<std::string>& paths) {
   LOG(info, "[data] Shuffling data");
 
   ABORT_IF(tsv_ && paths[0] == "stdin",
-           "Shuffling training data from STDIN is not supported. Remove the --shuffle option or "
-           "provide training sets using --train-sets");
+           "Shuffling training data from STDIN is not supported. Add --no-shuffle or provide "
+           "training sets with --train-sets");
 
   size_t numStreams = paths.size();
 

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -46,6 +46,8 @@ void Corpus::preprocessLine(std::string& line, size_t streamId) {
 }
 
 SentenceTuple Corpus::next() {
+  std::vector<std::string> fields(tsvNumFields_);  // used for handling TSV inputs
+
   for(;;) { // (this is a retry loop for skipping invalid sentences)
     // get index of the current sentence
     size_t curId = pos_; // note: at end, pos_  == total size
@@ -84,7 +86,6 @@ SentenceTuple Corpus::next() {
         addWeightsToSentenceTuple(line, tup);
       } else {
         if(tsv_) {  // split TSV input and add each field into the sentence tuple
-          std::vector<std::string> fields(tsvNumFields_);
           utils::splitTsv(line, fields, tsvNumFields_);
           for(size_t j = 0; j < tsvNumFields_; ++j) {
             preprocessLine(fields[j], j);
@@ -130,7 +131,7 @@ void Corpus::reset() {
     return;
   pos_ = 0;
   for (size_t i = 0; i < paths_.size(); ++i) {
-      if(paths_[i] == "stdin") {
+      if(paths_[i] == "stdin" || paths_[i] == "-") {
         files_[i].reset(new std::istream(std::cin.rdbuf()));
         // Probably not necessary, unless there are some buffers
         // that we want flushed.
@@ -153,7 +154,7 @@ void Corpus::restore(Ptr<TrainingState> ts) {
 void Corpus::shuffleData(const std::vector<std::string>& paths) {
   LOG(info, "[data] Shuffling data");
 
-  ABORT_IF(tsv_ && paths[0] == "stdin",
+  ABORT_IF(tsv_ && (paths[0] == "stdin" || paths[0] == "-"),
            "Shuffling training data from STDIN is not supported. Add --no-shuffle or provide "
            "training sets with --train-sets");
 

--- a/src/data/corpus_base.cpp
+++ b/src/data/corpus_base.cpp
@@ -40,6 +40,7 @@ CorpusBase::CorpusBase(const std::vector<std::string>& paths,
       rightLeft_(options_->get<bool>("right-left")),
       tsv_(options_->get<bool>("tsv", false)),
       tsvNumFields_(options->get<size_t>("tsv-fields", 0)) {
+  // TODO: support passing only one vocab file if we have fully-tied embeddings
   if(tsv_) {
     ABORT_IF(tsvNumFields_ != vocabs_.size(),
              "Number of TSV fields and vocab files does not agree");

--- a/src/data/corpus_base.cpp
+++ b/src/data/corpus_base.cpp
@@ -92,8 +92,10 @@ CorpusBase::CorpusBase(Ptr<Options> options, bool translate)
   // training or scoring
   if(training) {
     if(vocabPaths.empty()) {
-      // TODO: implement
-      ABORT_IF(tsv_, "Creating vocabularies from a TSV input is not yet supported.");
+      // Creating a vocabulary from stdin is not supported
+      ABORT_IF(tsv_ && paths_[0] == "stdin",
+               "Creating vocabularies automatically from a data stream from STDIN is not supported. "
+               "Create vocabularies first and provide them with --vocabs");
 
       if(maxVocabs.size() < paths_.size())
         maxVocabs.resize(paths_.size(), 0);
@@ -145,10 +147,10 @@ CorpusBase::CorpusBase(Ptr<Options> options, bool translate)
       auto vocabDims = options_->get<std::vector<int>>("dim-vocabs");
       vocabDims.resize(numVocs, 0);
       for(size_t i = 0; i < numVocs; ++i) {
-        // Creating the vocabulary from TSV input is not supported
-        // TODO: support the case for joint/separate vocabs unless -t stdin
-        ABORT_IF(tsv_ && (vocabPaths[i].empty() || !filesystem::exists(vocabPaths[i])),
-            "Creating vocabulary automatically from a TSV input is currently not supported. "
+        // Creating a vocabulary from stdin is not supported
+        ABORT_IF(tsv_ && paths_[0] == "stdin"
+                 && (vocabPaths[i].empty() || !filesystem::exists(vocabPaths[i])),
+            "Creating vocabulary automatically from a data stream from STDIN is not supported. "
             "Create vocabularies first and provide them using --vocabs");
 
         Ptr<Vocab> vocab = New<Vocab>(options_, i);

--- a/src/data/corpus_base.cpp
+++ b/src/data/corpus_base.cpp
@@ -38,7 +38,7 @@ CorpusBase::CorpusBase(const std::vector<std::string>& paths,
       maxLengthCrop_(options_->get<bool>("max-length-crop")),
       rightLeft_(options_->get<bool>("right-left")),
       tsv_(options_->get<bool>("tsv", false)),
-      tsvNumFields_(options->get<size_t>("tsv-size", 0)) {
+      tsvNumFields_(options->get<size_t>("tsv-fields", 0)) {
   if(tsv_) {
     ABORT_IF(tsvNumFields_ != vocabs_.size(),
              "Number of TSV fields and vocab files does not agree");
@@ -62,7 +62,7 @@ CorpusBase::CorpusBase(Ptr<Options> options, bool translate)
       maxLengthCrop_(options_->get<bool>("max-length-crop")),
       rightLeft_(options_->get<bool>("right-left")),
       tsv_(options_->get<bool>("tsv", false)),
-      tsvNumFields_(options->get<size_t>("tsv-size", 0)) {
+      tsvNumFields_(options->get<size_t>("tsv-fields", 0)) {
   bool training = !translate;
 
   if(training)

--- a/src/data/corpus_base.cpp
+++ b/src/data/corpus_base.cpp
@@ -220,18 +220,20 @@ CorpusBase::CorpusBase(Ptr<Options> options, bool translate)
           ABORT_IF(groupedPaths.size() > 1, "There should not be multiple TSV input files!");
 
           tsvTempFile.reset(new io::TemporaryFile(options_->get<std::string>("tempdir"), false));
-          fileutils::cut(groupedPaths[0],  // 0 is safe because there is always a single TSV file
+          LOG(info,
+              "[data] Cutting field(s) {} from {} into a temporary file {}",
+              utils::join(vocabDetails.positions, ", "),
+              groupedPaths[0],
+              tsvTempFile->getFileName());
+
+          fileutils::cut(groupedPaths[0],  // Index 0 because there is only one TSV file
                          tsvTempFile,
                          vocabDetails.positions,
                          tsvNumFields_,
-                         " ");  // merge tab-separated fields
+                         " ");  // Notice that tab-separated fields are joined with a whitespace
+
           groupedPaths.clear();
           groupedPaths.push_back(tsvTempFile->getFileName());
-
-          LOG(info,
-              "[data] Cutting fields {} into a temporary file {}",
-              vocabDetails.positions[0],  // TODO print all
-              tsvTempFile->getFileName());
         }
 
         // Load or create the vocabulary

--- a/src/data/corpus_base.h
+++ b/src/data/corpus_base.h
@@ -533,7 +533,7 @@ protected:
   std::vector<Ptr<Vocab>> vocabs_;
 
   /**
-   * brief Determines if a EOS symbol should be added. By default this is true for any sequence,
+   * @brief Determines if a EOS symbol should be added. By default this is true for any sequence,
    * but should be false for instance for classifier labels. This is set per input stream, hence a
    * vector.
    */
@@ -544,6 +544,9 @@ protected:
   size_t maxLength_{0};
   bool maxLengthCrop_{false};
   bool rightLeft_{false};
+
+  bool tsv_{false};          // if the input is a single file with tab-separated values
+  size_t tsvNumFields_{0};   // number of fields in the TSV input
 
   /**
    * @brief Index of the file with weights in paths_ and files_; zero means no

--- a/src/data/corpus_base.h
+++ b/src/data/corpus_base.h
@@ -545,8 +545,8 @@ protected:
   bool maxLengthCrop_{false};
   bool rightLeft_{false};
 
-  bool tsv_{false};          // if the input is a single file with tab-separated values
-  size_t tsvNumFields_{0};   // number of fields in the TSV input
+  bool tsv_{false};          // true if the input is a single file with tab-separated values
+  size_t tsvNumFields_{0};   // number of fields in the TSV input (only if tsv_)
 
   /**
    * @brief Index of the file with weights in paths_ and files_; zero means no

--- a/src/data/default_vocab.cpp
+++ b/src/data/default_vocab.cpp
@@ -217,7 +217,6 @@ private:
     std::string line;
     while(getline(*trainStrm, line)) {
       auto toks = utils::split(line, " ");
-
       for(const std::string& tok : toks) {
         auto iter = counter.find(tok);
         if(iter == counter.end())

--- a/src/tests/units/CMakeLists.txt
+++ b/src/tests/units/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UNIT_TESTS
     rnn_tests
     attention_tests
     fastopt_tests
+    utils_tests
 )
 
 foreach(test ${UNIT_TESTS})

--- a/src/tests/units/utils_tests.cpp
+++ b/src/tests/units/utils_tests.cpp
@@ -1,0 +1,40 @@
+#include "catch.hpp"
+#include "common/utils.h"
+
+using namespace marian;
+
+TEST_CASE("utils::splitTsv", "[utils]") {
+  std::string line1 = "foo bar";
+  std::string line2 = "foo bar\tbazz";
+  std::string line3 = "foo bar\tbazz\tfoo quux";
+
+  std::vector<std::string> fields;
+
+  SECTION("the tab-separated input is split") {
+    utils::splitTsv(line1, fields, 1);
+    CHECK( fields.size() == 1 );
+    CHECK( fields[0] == "foo bar" );
+
+    utils::splitTsv(line3, fields, 3);
+    CHECK( fields == std::vector<std::string>({"foo bar", "bazz", "foo quux"}) );
+  }
+
+  SECTION("the output has at least as many elements as requested") {
+    utils::splitTsv(line1, fields, 1);
+    CHECK( fields.size() == 1 );
+
+    utils::splitTsv(line1, fields, 3);
+    CHECK( fields.size() == 3 );
+    CHECK( fields == std::vector<std::string>({"foo bar", "", ""}) );
+
+    utils::splitTsv(line1, fields, 2);
+    CHECK( fields.size() == 2 );
+    CHECK( fields == std::vector<std::string>({"foo bar", ""}) );
+  }
+
+  SECTION("excessive tab-separated fields are ignored") {
+    utils::splitTsv(line3, fields, 2);
+    CHECK( fields.size() == 2 );
+    CHECK( fields == std::vector<std::string>({"foo bar", "bazz"}) );
+  }
+}

--- a/src/tests/units/utils_tests.cpp
+++ b/src/tests/units/utils_tests.cpp
@@ -32,9 +32,5 @@ TEST_CASE("utils::splitTsv", "[utils]") {
     CHECK( fields == std::vector<std::string>({"foo bar", ""}) );
   }
 
-  SECTION("excessive tab-separated fields are ignored") {
-    utils::splitTsv(line3, fields, 2);
-    CHECK( fields.size() == 2 );
-    CHECK( fields == std::vector<std::string>({"foo bar", "bazz"}) );
-  }
+  //SECTION("excessive tab-separated fields abort the execution") {}
 }

--- a/src/training/graph_group.h
+++ b/src/training/graph_group.h
@@ -60,7 +60,9 @@ public:
                                      double multiplier = 1.) {
     auto stats = New<data::BatchStats>();
 
-    size_t numFiles = options_->get<std::vector<std::string>>("train-sets").size();
+    size_t numFiles = options_->get<bool>("tsv", false)
+                          ? options_->get<size_t>("tsv-size")
+                          : options_->get<std::vector<std::string>>("train-sets").size();
 
     // Initialize first batch to step size
     size_t first = options_->get<size_t>("mini-batch-fit-step");

--- a/src/training/graph_group.h
+++ b/src/training/graph_group.h
@@ -61,7 +61,7 @@ public:
     auto stats = New<data::BatchStats>();
 
     size_t numFiles = options_->get<bool>("tsv", false)
-                          ? options_->get<size_t>("tsv-size")
+                          ? options_->get<size_t>("tsv-fields")
                           : options_->get<std::vector<std::string>>("train-sets").size();
 
     // Initialize first batch to step size

--- a/src/training/scheduler.h
+++ b/src/training/scheduler.h
@@ -153,7 +153,6 @@ public:
   }
 
   bool keepGoing() {
-
     if(getSigtermFlag()) // received signal SIGERM => exit gracefully
       return false;
 
@@ -169,8 +168,13 @@ public:
 
     // stop if the first validator did not improve for a given number of checks
     size_t stopAfterStalled = options_->get<size_t>("early-stopping");
-    if(stopAfterStalled > 0 && !validators_.empty()
-       && stalled() >= stopAfterStalled)
+    if(stopAfterStalled > 0 && !validators_.empty() && stalled() >= stopAfterStalled)
+      return false;
+
+    // stop if data streaming from STDIN is stopped for a TSV input
+    bool tsvFromStdin = options_->get<bool>("tsv", false)
+                        && (options_->get<std::vector<std::string>>("train-sets")[0] == "stdin");
+    if(tsvFromStdin && state_->epochs > 1)
       return false;
 
     return true;

--- a/src/training/scheduler.h
+++ b/src/training/scheduler.h
@@ -17,11 +17,15 @@ private:
   Ptr<TrainingState> state_;
   std::vector<Ptr<ValidatorBase>> validators_;
 
-  bool first_{true};
-  bool endOfStdin_{false};
+  bool first_{true};        // true if this is the first update after renewing the training
 
   timer::Timer timer_;
   timer::Timer heartBeatTimer_;
+
+  // The variable helps to keep track of the end of the current epoch
+  // (regardless if it's the 1st or nth epoch and if it's a new or continued training),
+  // which indicates the end of the training data stream from STDIN
+  bool endOfStdin_{false};  // true at the end of the epoch if training from STDIN;
 
   // determine scheduled LR decay factor (--lr-decay-inv-sqrt option)
   float getScheduledLRDecayFactor(const TrainingState& state) const {
@@ -169,7 +173,8 @@ public:
 
     // stop if the first validator did not improve for a given number of checks
     size_t stopAfterStalled = options_->get<size_t>("early-stopping");
-    if(stopAfterStalled > 0 && !validators_.empty() && stalled() >= stopAfterStalled)
+    if(stopAfterStalled > 0 && !validators_.empty()
+       && stalled() >= stopAfterStalled)
       return false;
 
     // stop if data streaming from STDIN is stopped
@@ -409,8 +414,8 @@ public:
 
   void actAfterEpoch(TrainingState& state) override {
     // stop if data streaming from STDIN is stopped for a TSV input
-    if(options_->get<bool>("tsv", false)
-       && (options_->get<std::vector<std::string>>("train-sets")[0] == "stdin"))
+    std::string firstPath = options_->get<std::vector<std::string>>("train-sets")[0];
+    if(options_->get<bool>("tsv", false) && (firstPath == "stdin" || firstPath == "-"))
       endOfStdin_ = true;
 
     float factor = options_->get<float>("lr-decay");

--- a/src/training/training_state.h
+++ b/src/training/training_state.h
@@ -14,7 +14,7 @@ class TrainingState;
 class TrainingObserver {
 public:
   virtual ~TrainingObserver() {}
-  
+
   virtual void init(TrainingState&) {}
   virtual void actAfterEpoch(TrainingState&) {}
   virtual void actAfterBatches(TrainingState&) {}


### PR DESCRIPTION
### Description

This PR adds support for TSV inputs in the trainer, scorer and decoder.
Examples:

	marian -c train.yml --tsv -t file.ende --valid-sets 
    marian-scorer -c score.yml --tsv -t file.ende > scores.txt
	marian-decoder -c ape.yml --tsv < file.srcmt > file.pe

Examples for stdin (`--tsv` is automatically added for `-t stdin`):

    cat file.ende | marian -c train.yml --no-shuffle -t stdin
	cat file.ende | marian-scorer -c score.yml -t stdin > scores.txt

List of changes:
- Added the `--tsv` option for marian and marian-scorer (`-t`), and marian-decoder (`-i`)
- Added the `--tsv-fields` for setting the number of fields in the TSV file
- --tsv-fields is guessed based on the model type, so usually it does not need to be set
- For training with TSV, if vocab(s) does not exist, it is created from appropriate fields in the TSV file (all cases described here: https://github.com/marian-nmt/marian-dev/blob/1d6da8be0cfad2366d866c370d9156402411af41/src/data/corpus_base.cpp#L98 )
- For training with TSV, if no vocab paths are given, a common vocabulary is created (this is different than providing separate training files for source and target)
- For training with TSV, validation sets also have to be in TSV format
- Added support for `-t stdin` in marian and marian-scorer
- For training from stdin, `--no-shuffle` is required, otherwise an appropriate error message is displayed
- For training from stdin, creating vocabs automatically is disabled and an appropriate error message is displayed
- If `-t stdin` is provided, `--tsv` is automatically added
- If `--tsv` is provided and `-t` is empty, `-t stdin` is assumed

Added dependencies: none

### How to test

Run example commands above.
Tested manually and added several regression tests: https://github.com/marian-nmt/marian-regression-tests/pull/45

Tested on Ubuntu 16.04, compiling with:

    cmake .. -DUSE_SENTENCEPIECE=on -DCOMPILE_EXAMPLES=on -DCOMPILE_TESTS=on -DCOMPILE_SERVER=on -DCMAKE_BUILD_TYPE=Release -DUSE_CCACHE=on

The new option potentially does not work with (1) BERT models, (2) factored vocabs, and (3) multi-node training. I don't know how to test these properly.

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
