### PR TITLE
Fix Iris example on CPU

### DIFF
--- a/src/examples/iris/iris.cpp
+++ b/src/examples/iris/iris.cpp
@@ -79,7 +79,12 @@ int main() {
     auto graph = New<ExpressionGraph>();
 
     // Set general options
-    graph->setDevice({0, DeviceType::gpu});
+#ifdef CUDA_FOUND
+    auto deviceType = DeviceType::gpu;
+#else
+    auto deviceType = DeviceType::cpu;
+#endif
+    graph->setDevice({0, deviceType});
     graph->reserveWorkspaceMB(128);
 
     // Choose optimizer (Sgd, Adagrad, Adam) and initial learning rate


### PR DESCRIPTION
### Description
This PR fixes a bug reported in https://github.com/marian-nmt/marian-dev/issues/618.

List of changes:
- Use CPU in the Iris example if CUDA is not available

Added dependencies: none

### How to test
Compile a CPU-only version of Marian and run `./iris_example`.

The regression test still does not work with a CPU-only build because the expected output is for GPU. This will be fixed in marian-regression-tests in a separate PR.

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
