### PR TITLE
rm aliases, added corresponding targets, and removed duplicate

### DIFF
--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -66,7 +66,7 @@ if(USE_SENTENCEPIECE)
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    foreach(t sentencepiece sentencepiece_train sentencepiece_train-static
+    foreach(t sentencepiece-static sentencepiece_train-static
         spm_decode spm_encode spm_export_vocab spm_normalize spm_train)
       set_property(TARGET ${t} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-tautological-compare -Wno-unused")
       if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0)


### PR DESCRIPTION
### Description
rm aliases, added corresponding targets, and removed duplicate

This PR fixes a bug It is related to issue #668

List of changes:
- Removed aliases in foreach
- Added corresponding targets
- Removed duplicate, and alias and its target were in the foreach

Added dependencies: none

### How to test
Run cmake on macOS

I tested this by running cmake on macOS. Previous to this commit it failed as a result of this commit it did not fail

### Checklist

- [X] I have tested _running cmake manually on macOS_
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
