### PR TITLE
Fixed various compile issues on macOS

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -92,7 +92,11 @@ set(MKL_INCLUDE_DIRS ${MKL_INCLUDE_DIR})
 # Added -Wl block to avoid circular dependencies.
 # https://stackoverflow.com/questions/5651869/what-are-the-start-group-and-end-group-command-line-options
 # https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor
-set(MKL_LIBRARIES -Wl,--start-group ${MKL_INTERFACE_LIBRARY} ${MKL_SEQUENTIAL_LAYER_LIBRARY} ${MKL_CORE_LIBRARY} -Wl,--end-group)
+if (APPLE)
+     set(MKL_LIBRARIES -Wl,${MKL_INTERFACE_LIBRARY} ${MKL_SEQUENTIAL_LAYER_LIBRARY} ${MKL_CORE_LIBRARY} -Wl,)
+else()
+     set(MKL_LIBRARIES -Wl,--start-group ${MKL_INTERFACE_LIBRARY} ${MKL_SEQUENTIAL_LAYER_LIBRARY} ${MKL_CORE_LIBRARY} -Wl,--end-group)
+endif()
 
 # message("1 ${MKL_INCLUDE_DIR}")
 # message("2 ${MKL_INTERFACE_LIBRARY}")

--- a/src/3rd_party/cnpy/cnpy.h
+++ b/src/3rd_party/cnpy/cnpy.h
@@ -18,6 +18,10 @@
 #include<map>
 #include <memory>
 
+#ifdef __APPLE__
+#include <unistd.h>
+#endif
+
 namespace cnpy {
 
     struct NpyArray {

--- a/src/3rd_party/faiss/VectorTransform.h
+++ b/src/3rd_party/faiss/VectorTransform.h
@@ -18,6 +18,9 @@
 #include <stdint.h>
 
 #include <faiss/Index.h>
+#ifdef __APPLE__
+#include <x86intrin.h>
+#endif
 
 
 namespace faiss {


### PR DESCRIPTION
### Description
Fixed various compile issues on macOS

This PR fixes a bug/adds a new feature/refactorizes the code/does something else.
It is related to issue: #670

List of changes:
- Removed use of `--start-group` and `--end-group` as macOS doesn't support these options
- Added __APPLE__ guarded include of unistd.h in src/3rd_party/cnpy/cnpy.h 
- Added __APPLE__ guarded include of x86intrin.h in src/3rd_party/faiss/VectorTransform.h

Added dependencies: none

### How to test
Try to compile on macOS with the above changes

Describe how you have tested your code, including OS and the cmake command.

### Checklist

- [x] I have compiled the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
