### PR TITLE
Disable GitHub check with Ubuntu 20.04 and GCC 9

### DIFF
--- a/.github/workflows/ubuntu-gpu.yml
+++ b/.github/workflows/ubuntu-gpu.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           # Ubuntu 20.04 supports CUDA 11+
-          - os: ubuntu-20.04
-            cuda: "11.0"
-            gcc: 9
-            boost: false        # ubuntu-20.04 image does not have Boost pre-installed yet
-            experimental: true  # continue even if the job fails
+          #- os: ubuntu-20.04
+            #cuda: "11.0"
+            #gcc: 9
+            #boost: false        # ubuntu-20.04 image does not have Boost pre-installed yet
+            #experimental: true  # continue even if the job fails
           # Ubuntu 18.04 supports CUDA 10.1+
           - os: ubuntu-18.04
             cuda: "10.2"

--- a/.github/workflows/windows-cpu.yml
+++ b/.github/workflows/windows-cpu.yml
@@ -19,9 +19,10 @@ jobs:
 
     - name: Download MKL
       run: |
-        Invoke-WebRequest -Uri https://romang.blob.core.windows.net/mariandev/ci/mkl-2020.1-windows-static.zip -TimeoutSec 600 -OutFile mkl.zip
+        # Wget can retry downloading files, so it is used instead of Invoke-WebRequest
+        C:\msys64\usr\bin\wget.exe -nv https://romang.blob.core.windows.net/mariandev/ci/mkl-2020.1-windows-static.zip -O mkl.zip
         Expand-Archive -Force mkl.zip ${{ github.workspace }}/mkl
-        # Set MKLROOT environment variables so that CMake can find MKL.
+        # Set the MKLROOT environment variable so that CMake can find MKL.
         # GITHUB_WORKSPACE is an environment variable available on all GitHub-hosted runners
         echo "::set-env name=MKLROOT::$env:GITHUB_WORKSPACE/mkl"
       shell: powershell

--- a/.github/workflows/windows-gpu.yml
+++ b/.github/workflows/windows-gpu.yml
@@ -27,9 +27,10 @@ jobs:
 
     - name: Download MKL
       run: |
-        Invoke-WebRequest -Uri https://romang.blob.core.windows.net/mariandev/ci/mkl-2020.1-windows-static.zip -TimeoutSec 600 -OutFile mkl.zip
+        # Wget can retry downloading files, so it is used instead of Invoke-WebRequest
+        C:\msys64\usr\bin\wget.exe -nv https://romang.blob.core.windows.net/mariandev/ci/mkl-2020.1-windows-static.zip -O mkl.zip
         Expand-Archive -Force mkl.zip ${{ github.workspace }}/mkl
-        # Set MKLROOT environment variables so that CMake can find MKL.
+        # Set the MKLROOT environment variable so that CMake can find MKL.
         # GITHUB_WORKSPACE is an environment variable available on all GitHub-hosted runners
         echo "::set-env name=MKLROOT::$env:GITHUB_WORKSPACE/mkl"
       shell: powershell


### PR DESCRIPTION
### Description
The GitHub check with Ubuntu 20.04, GCC 9 and FBGEMM fails more often than expected, which is misleading, e.g. https://github.com/marian-nmt/marian-dev/pull/710#issuecomment-687710304

It could be enabled again after fixing #709.

Added dependencies: none