### PR TITLE
Remove duplicated EXT_LIBS in src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,7 @@ if(APPLE) # This is a dependency of pathie but I can't seem to link it into that
 endif()
 
 # Add external libs to the public interface of the library
-target_link_libraries(marian ${EXT_LIBS} ${EXT_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(marian ${EXT_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 set_target_properties(marian PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 set_target_properties(marian PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")


### PR DESCRIPTION
### Description
This change seems to fix the bug introduced after merging 5c45a37 that causes a CPU-only compilation with marian-server fails, e.g.:

    cmake -DCOMPILE_CPU=ON -DCOMPILE_CUDA=OFF -DCOMPILE_SERVER=on ..

Related issues: #726, #725 and https://github.com/marian-nmt/marian-dev/runs/1094611881

The duplication of `${EXT_LIBS}` has been introduced to solve [linking issues for static compilation](https://github.com/marian-nmt/marian-dev/commit/15f780ec91ff9daf626dfb95481fba73e1c6783f), but the following command works with the proposed change too:

    cmake -DCOMPILE_CPU=ON -DCOMPILE_CUDA=ON -DCOMPILE_SERVER=ON -DUSE_FBGEMM=ON -DUSE_SENTENCEPIECE=ON \
      -DCOMPILE_TESTS=ON -DCOMPILE_EXAMPLES=ON  -DUSE_STATIC_LIBS=ON ..

Added dependencies: none

### How to test

Commands above. The build-ubuntu check should succeed.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md

