### PR TITLE
Fixes bug for certain reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Internal optional parameter in n-best list generation that skips empty hypotheses.
 
 ### Fixed
+- Fix bug causing certain reductions into scalars to be 0 on the GPU backend. Removed unnecessary warp shuffle instructions.
 - Print "server is listening on port" message after it is accepting connections
 - Fix compilation without BLAS installed
 - Providing a single value to vector-like options using the equals sign, e.g. --models=model.npz

--- a/src/3rd_party/reduce_all.h
+++ b/src/3rd_party/reduce_all.h
@@ -129,15 +129,17 @@ __global__ void reduceSinglePass(Functor functor, AccType aggInit, AggFunctor ag
 
   cg::sync(cta);
 
-  cg::thread_block_tile<32> tile32 = cg::tiled_partition<32>(cta);
+  // leverage that blockSize is always pow of 2 so no special logic needed in reduction loop.
+  constexpr int partitionSize = blockSize > 32? 32 : blockSize;
+  cg::thread_block_tile<partitionSize> tile = cg::tiled_partition<partitionSize>(cta);
 
   if (cta.thread_rank() < 32) {
     // Fetch final intermediate sum from 2nd warp
     if (blockSize >= 64) 
       mySum = aggFunctor(mySum, sdata[tid + 32]);
     // reduce final warp using shuffle
-    for (int offset = tile32.size() / 2; offset > 0; offset /= 2) {
-      mySum = aggFunctor(mySum, tile32.shfl_down(mySum, offset));
+    for (int offset = tile.size() / 2; offset > 0; offset /= 2) {
+      mySum = aggFunctor(mySum, tile.shfl_down(mySum, offset));
     }
   }
 

--- a/src/3rd_party/reduce_all.h
+++ b/src/3rd_party/reduce_all.h
@@ -130,7 +130,7 @@ __global__ void reduceSinglePass(Functor functor, AccType aggInit, AggFunctor ag
   cg::sync(cta);
 
   // leverage that blockSize is always pow of 2 so no special logic needed in reduction loop.
-  constexpr int partitionSize = blockSize > 32? 32 : blockSize;
+  constexpr int partitionSize = blockSize > 32 ? 32 : blockSize;
   cg::thread_block_tile<partitionSize> tile = cg::tiled_partition<partitionSize>(cta);
 
   if (cta.thread_rank() < 32) {

--- a/src/tests/units/operator_tests.cpp
+++ b/src/tests/units/operator_tests.cpp
@@ -70,31 +70,55 @@ void tests(DeviceType device, Type floatType = Type::float32) {
     CHECK(compare(rmin2,  [](float a) {return std::min(1.f, a);}));
   }
 
-  SECTION("Max all negative. <= 32 Elements") {
+  SECTION("Scalar reductions <= 32 Elements") {
     graph->clear();
     values.clear();
 
-    std::vector<T> vA({-1, -2, -3, -4});
-    auto a = graph->constant({1, 1, 4}, inits::fromVector(vA));
+    std::vector<T> maxInp({-1, -2, -3, -4});
+    std::vector<T> minInp({4, 100, 42, 420, 3, 14, 15, 926, 53});
+    std::vector<T> prodInp({5, -1, 3, 2, 3, -1, 4, 2, 1});
+    std::vector<T> sumInp({4, 4, 8, 16, 32, 4, 5, 10});
 
-    auto compare = [&](Expr res, std::function<float(float, float)> op) -> bool {
+    std::vector<T> genericInp({8, 8, 16});
+
+    auto maxInpExpr = graph->constant({1, 1, (int)maxInp.size()}, inits::fromVector(maxInp));
+    auto minInpExpr = graph->constant({1, 1, (int)minInp.size()}, inits::fromVector(minInp));
+    auto prodInpExpr = graph->constant({1, 1, (int)prodInp.size()}, inits::fromVector(prodInp));
+    auto sumInpExpr = graph->constant({1, 1, (int)sumInp.size()}, inits::fromVector(sumInp));
+    auto genericInpExpr = graph->constant({1, 1, (int)genericInp.size()}, inits::fromVector(genericInp));
+
+    auto compare = [&](Expr res, std::vector<T> inp, std::function<float(float, float)> op) -> bool {
       if (res->shape().elements() != 1)
           return false;
       float val = res->val()->get(0);
       
-      float reduced = vA[0];
-      for(const auto val : vA) {
-        reduced = op(reduced, val);
+      float reduced = inp[0];
+      for(int i = 1; i < inp.size(); ++i) {
+        reduced = op(reduced, inp[i]);
       }
       return floatApprox(reduced, val);
     };
 
     // @TODO: add all operators here for completeness
-    auto maxReduce = max(a, -1);
+    auto maxReduce = max(maxInpExpr, /*axis*/ -1);
+    auto minReduce = min(minInpExpr, /*axis*/ -1);
+    auto prodReduce = prod(prodInpExpr, /*axis*/ -1);
+    auto sumReduce = sum(sumInpExpr, /*axis*/ -1);
+    auto meanReduce = mean(genericInpExpr, /*axis*/ -1);
+    auto logSumExpReduce = logsumexp(genericInpExpr, /*axis*/ -1);
 
     graph->forward();
+    
+    // All values are computed using numpy 1.19.2 with Python 3.6.9
+    constexpr float expectedMean = 10.66666; // np.mean(genericInp)
+    constexpr float expectedLogSumExp = 16.000670700286076; // np.log(np.sum(np.exp(genericInp)))
 
-    CHECK(compare(maxReduce, [](float a, float b) {return std::max(a, b);}));
+    CHECK(compare(maxReduce, maxInp, [](float a, float b) {return std::max(a, b);}));
+    CHECK(compare(minReduce, minInp, [](float a, float b) {return std::min(a, b);}));
+    CHECK(compare(prodReduce, prodInp, [](float a, float b) {return a * b;}));
+    CHECK(compare(sumReduce, sumInp, [](float a, float b) {return a + b;}));
+    CHECK(floatApprox(expectedMean, meanReduce->val()->get(0)));
+    CHECK(floatApprox(expectedLogSumExp, logSumExpReduce->val()->get(0)));
   }
 
   SECTION("elementwise binary operators with broadcasting") {
@@ -328,6 +352,9 @@ void tests(DeviceType device, Type floatType = Type::float32) {
     s2->val()->get(values); CHECK(values == vS2);
 
     CHECK(m3->val()->scalar() == 9);
+
+    // The two tests below were changed to use this approx function since they originally failed
+    // on a Titan V. The margin was increased to allow the tests to pass.
     auto floatApproxLocal = [](T x, T y) -> bool { return x == Approx(y).margin(0.004); };
 
     s4->val()->get(values); CHECK(std::equal(values.begin(), values.end(), vS4.begin(), floatApproxLocal));


### PR DESCRIPTION
### Description
This PR fixes a bug for reductions when all of the following conditions are met:

1) We are reducing into a scalar variable
2) There are <= 32 elements in the input tensor
3) The identity of the reduction operator is not 0

This bug *may* only be present on Volta architectures and newer. I have not checked older architectures. An example of this is performing a max reduction into a scalar. This will only show up if all of the values in the input are negative due to the 3rd requirement.

List of changes:
- Changes the size of the final cta tile to be the min(32, blockSize) instead of just 32. This caused 0s to flow in from the warp shuffle instructions

### How to test
Run the unit tests. Added a new unit test under operator tests that fails on the original master branch and passes with this commit.

OS and CMake command:

OS: Ubuntu 18.04.3 LTS
gcc 7.5.0
nvcc 10.1.243

Ran with:
cmake .. -DCOMPILE_TESTS=on -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on 

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
