### PR TITLE
Hotfix: crash when --quantize-optimization-steps is set to 0

### DIFF
--- a/src/optimizers/quantizer.cpp
+++ b/src/optimizers/quantizer.cpp
@@ -90,6 +90,8 @@ void ModelQuantizer::quantize(Ptr<ExpressionGraph> graph) {
     allocator->reserveExact(graph->params()->vals()->memory()->size());
     allocator->allocate(errorResidual_, {1, numElements});
 
+    errorResidual_->set(0);
+
     allocators_.push_back(allocator);
     isFirstError_ = true;
   }

--- a/src/optimizers/quantizer.cpp
+++ b/src/optimizers/quantizer.cpp
@@ -140,7 +140,6 @@ void ModelQuantizer::quantizeImpl(Tensor t) {
     allocators_.push_back(allocator);
   }
   
-  Tensor q = delta_->subtensor(0, t->size());  // to store the quantized t
   Tensor tflat = t->subtensor(0, t->size());   // flatten t for reduce
 
   float S = 0.0f; // scaling factor S
@@ -153,6 +152,8 @@ void ModelQuantizer::quantizeImpl(Tensor t) {
 
   // optimize the scaling factor S
   for(int i = 0; i < optSteps_; i++) {
+    Tensor q = delta_->subtensor(0, t->size());  // to store the quantized t
+    
     // let t be the original tensor, and q be the quantized tensor, and q = S*a where S is the
     // scaling factor. we want to optimize S to minimize MSE(S*a - t) therefore, S =
     // sum(a*t)/sum(a*a) see https://www.aclweb.org/anthology/2020.ngt-1.4.pdf for more details.


### PR DESCRIPTION
### Description
crash when --quantize-optimization-steps is set to 0

The reason is that if optimization-steps is set to 0, the `delta` Tensor is undefined.

- [v] I have tested the code manually
- [v] I have run regression tests
- [v] I have read and followed CONTRIBUTING.md
- [v] I have updated CHANGELOG.md
