### PR TITLE
fix the allocation size for opt-step Tensor

### DIFF
--- a/src/optimizers/quantizer.cpp
+++ b/src/optimizers/quantizer.cpp
@@ -135,8 +135,8 @@ void ModelQuantizer::quantizeImpl(Tensor t) {
 
   // init additional tensor for scaling optimization
   if(!delta_ && optSteps_ > 0) {
-    int msize = (int) t->size();
-    auto allocator = New<TensorAllocator>(t->getBackend());
+    int msize = (int) errorResidual_->size();
+    auto allocator = New<TensorAllocator>(errorResidual_->getBackend());
     allocator->reserveExact(msize * sizeof(float));
     allocator->allocate(delta_, {1, msize});
     allocators_.push_back(allocator);


### PR DESCRIPTION
### Description

A fix to pass the regression test https://github.com/marian-nmt/marian-regression-tests/pull/69

Issue: weird behaviour when opt-step is used and the model is trained with no shared vocabulary.
The reason is the temporary Tensor used for quantization was too small.