### PR TITLE
Intgemm refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Added `intgemm8(ssse3|avx|avx512)?`, `intgemm16(sse2|avx|avx512)?` types to marian-conv with uses intgemm backend. Types intgemm8 and intgemm16 are hardware-agnostic, the other ones hardware-specific.
+- Shortlist is now always multiple-of-eight.
+- Added intgemm 8/16bit integer binary architecture agnostic format.
 - Add --train-embedder-rank for fine-tuning any encoder(-decoder) model for multi-lingual similarity via softmax-margin loss
 - Add --logical-epoch that allows to redefine the displayed epoch counter as a multiple of n data epochs, updates or labels. Also allows to define width of fractional part with second argument.
 - Add --metrics chrf for computing ChrF according to https://www.aclweb.org/anthology/W15-3049/ and SacreBLEU reference implementation
@@ -28,10 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Training and scoring from STDIN
 - Support for reading from TSV files from STDIN and other sources during training
   and translation with options --tsv and --tsv-fields n.
-- Shortlist is now always multiple-of-eight.
-- Changed the `--optimize` switch to `--int16` and replaced the computational backend to intgemm.
-- Added `--gemmm-precision` which specifies the numerical precision used for the GEMM computations. Valid values `float32` (default) `int16`, `int8` and `int8shift`. Also added aliases for the latter three. All integer based GEMM use intgemm as a computational backend.
-- Added intgemm 8/16bit integer binary architecture agnostic format.
 - Internal optional parameter in n-best list generation that skips empty hypotheses.
 - Quantized training (fixed point or log-based quantization) with --quantize-bits N command
 
@@ -58,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improved handling for receiving SIGTERM during training. By default, SIGTERM triggers 'save (now) and exit'. Prior to this fix, batch pre-fetching did not check for this sigal, potentially delaying exit considerably. It now pays attention to that. Also, the default behaviour of save-and-exit can now be disabled on the command line with --sigterm exit-immediately.
 
 ### Changed
+- Removed `--optimize` switch, instead we now determine compute type based on binary model.
 - Updated SentencePiece repository to version 8336bbd0c1cfba02a879afe625bf1ddaf7cd93c5 from https://github.com/google/sentencepiece. 
 - Enabled compilation of SentencePiece by default since no dependency on protobuf anymore. 
 - Changed default value of --sentencepiece-max-lines from 10000000 to 2000000 since apparently the new version doesn't sample automatically anymore (Not quite clear how that affects quality of the vocabulary).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(MSVC)
   # Or maybe use these?
   set(INTRINSICS "/arch:AVX2")
   # set(INTRINSICS "/arch:AVX512")
-                                                                                                        # /bigobj is necessary for expression_operators.cpp. See https://stackoverflow.com/questions/15110580/penalty-of-the-msvs-compiler-flag-bigobj
+  # /bigobj is necessary for expression_operators.cpp. See https://stackoverflow.com/questions/15110580/penalty-of-the-msvs-compiler-flag-bigobj
   set(CMAKE_CXX_FLAGS           "/EHsc /DWIN32 /D_WINDOWS /DUNICODE /D_UNICODE /D_CRT_NONSTDC_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS /bigobj ${DISABLE_GLOBALLY}")
   set(CMAKE_CXX_FLAGS_RELEASE   "${CMAKE_CXX_FLAGS} /MT /O2 ${INTRINSICS} /Zi /MP /GL /DNDEBUG")
   set(CMAKE_CXX_FLAGS_DEBUG     "${CMAKE_CXX_FLAGS} /MTd /Od /Ob0 ${INTRINSICS} /RTC1 /Zi /D_DEBUG")

--- a/src/command/marian_conv.cpp
+++ b/src/command/marian_conv.cpp
@@ -50,6 +50,12 @@ int main(int argc, char** argv) {
     saveGemmType = Type::intgemm8;
   } else if(saveGemmTypeStr == "intgemm16") { // intgemm 16 bit format
     saveGemmType = Type::intgemm16;
+  } else if(saveGemmTypeStr == "intgemm8sse3") { // intgemm 16 bit format
+    saveGemmType = Type::intgemm8sse3;
+  } else if(saveGemmTypeStr == "intgemm8avx2") { // intgemm 16 bit format
+    saveGemmType = Type::intgemm8avx2;
+  } else if(saveGemmTypeStr == "intgemm8avx512") { // intgemm 8 bit format
+    saveGemmType = Type::intgemm8avx512;
   } else {
     ABORT("Unknown gemm-type: {}", saveGemmTypeStr);
   }

--- a/src/command/marian_conv.cpp
+++ b/src/command/marian_conv.cpp
@@ -48,9 +48,6 @@ int main(int argc, char** argv) {
 
   auto load = [&](Ptr<ExpressionGraph> graph) {
     graph->setDevice(CPU0);
-    graph->getBackend()->setInt8(false);  // Since win run graph->forward() we need to make sure it does not get converted to an intgemm format during it.
-    graph->getBackend()->setInt16(false); // We manually do the compression later.
-
     graph->load(modelFrom);
     graph->forward();  // run the initializers
   };

--- a/src/command/marian_conv.cpp
+++ b/src/command/marian_conv.cpp
@@ -36,29 +36,8 @@ int main(int argc, char** argv) {
   auto exportAs = options->get<std::string>("export-as");
   auto vocabPaths = options->get<std::vector<std::string>>("vocabs");// , std::vector<std::string>());
   
-  auto saveGemmTypeStr = options->get<std::string>("gemm-type", "float32");
-  Type saveGemmType;
-  if(saveGemmTypeStr == "float32") {
-    saveGemmType = Type::float32;
-  } else if(saveGemmTypeStr == "packed16") {  // packed16 (fbgemm) only supports AVX2. AVX512 might be added later
-    saveGemmType = Type::packed16;
-  } else if(saveGemmTypeStr == "packed8avx2") { // packed8 for AVX2 (fbgemm)
-    saveGemmType = Type::packed8avx2;
-  } else if(saveGemmTypeStr == "packed8avx512") { // packed8 for AVX512 (fbgemm)
-    saveGemmType = Type::packed8avx512;
-  } else if(saveGemmTypeStr == "intgemm8") { // intgemm 8 bit format
-    saveGemmType = Type::intgemm8;
-  } else if(saveGemmTypeStr == "intgemm16") { // intgemm 16 bit format
-    saveGemmType = Type::intgemm16;
-  } else if(saveGemmTypeStr == "intgemm8sse3") { // intgemm 16 bit format
-    saveGemmType = Type::intgemm8sse3;
-  } else if(saveGemmTypeStr == "intgemm8avx2") { // intgemm 16 bit format
-    saveGemmType = Type::intgemm8avx2;
-  } else if(saveGemmTypeStr == "intgemm8avx512") { // intgemm 8 bit format
-    saveGemmType = Type::intgemm8avx512;
-  } else {
-    ABORT("Unknown gemm-type: {}", saveGemmTypeStr);
-  }
+  // We accept any type here and will later croak during packAndSave if the type cannot be used for conversion
+  Type saveGemmType = typeFromString(options->get<std::string>("gemm-type", "float32"));
 
   LOG(info, "Outputting {}, precision: {}", modelTo, saveGemmType);
 

--- a/src/common/aliases.cpp
+++ b/src/common/aliases.cpp
@@ -225,18 +225,6 @@ void ConfigParser::addAliases(cli::CLIWrapper& cli) {
       config["valid-mini-batch"] = 8;
       config["normalize"] = 1.0;
     });
-  } else { // Only available during translation/scoring or server modes
-    cli.alias("int16", "true", [&](YAML::Node& config) {
-    config["gemm-precision"] = std::string("int16");
-    });
-    
-    cli.alias("int8", "true", [&](YAML::Node& config) {
-      config["gemm-precision"] = std::string("int8");
-    });
-
-    cli.alias("int8shift", "true", [&](YAML::Node& config) {
-      config["gemm-precision"] = std::string("int8shift");
-    });
   }
 }
 

--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -59,7 +59,8 @@ void loadItems(const void* current, std::vector<io::Item>& items, bool mapped) {
 
   for(int i = 0; i < numHeaders; ++i) {
     if(items[i].mapped) { // memory-mapped, hence only set pointer
-      ABORT_IF(isIntgemm(items[i].type), "mmap format not supported for intgemm matrices");
+      // @TOOD: verify this actually works for the hardware-specific ones like intgemm8avx2
+      ABORT_IF(items[i].type == Type::intgemm8 || items[i].type == Type::intgemm16, "mmap format not supported for hardware non-specific intgemm matrices");
       items[i].ptr = get<char>(current, headers[i].dataLength);
     } else { // reading into item data
       size_t len = headers[i].dataLength;

--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -70,9 +70,9 @@ void loadItems(const void* current, std::vector<io::Item>& items, bool mapped) {
       // Reordering depends on the architecture (SSE/AVX2/AVX512) so we read in the quantized matrices and
       // then reorder them before adding them as a parameter in the graph.
       if (matchType<intgemm8>(items[i].type)) {
-        cpu::integer::prepareAndTransposeB<Type::int8>(items[i], ptr);
+        cpu::integer::prepareAndTransposeB<Type::intgemm8>(items[i], ptr);
       } else if (matchType<intgemm16>(items[i].type)) {
-        cpu::integer::prepareAndTransposeB<Type::int16>(items[i], ptr);
+        cpu::integer::prepareAndTransposeB<Type::intgemm16>(items[i], ptr);
       } else {
         std::copy(ptr, ptr + len, items[i].bytes.begin());
       }

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -670,7 +670,6 @@ void ConfigParser::addOptionsTranslation(cli::CLIWrapper& cli) {
   addSuboptionsTSV(cli);
   addSuboptionsDevices(cli);
   addSuboptionsBatching(cli);
-  addSuboptionsIntgemm(cli);
 
   cli.add<bool>("--fp16",
       "Shortcut for mixed precision inference with float16, corresponds to: --precision float16");
@@ -735,10 +734,7 @@ void ConfigParser::addOptionsScoring(cli::CLIWrapper& cli) {
   addSuboptionsTSV(cli);
   addSuboptionsDevices(cli);
   addSuboptionsBatching(cli);
-  addSuboptionsIntgemm(cli);
 
-  cli.add<bool>("--optimize",
-      "Optimize speed aggressively sacrificing memory or precision");
   cli.add<bool>("--fp16",
       "Shortcut for mixed precision inference with float16, corresponds to: --precision float16");
   cli.add<std::vector<std::string>>("--precision",
@@ -775,7 +771,6 @@ void ConfigParser::addOptionsEmbedding(cli::CLIWrapper& cli) {
   addSuboptionsTSV(cli);
   addSuboptionsDevices(cli);
   addSuboptionsBatching(cli);
-  addSuboptionsIntgemm(cli);
 
   cli.add<bool>("--fp16",
       "Shortcut for mixed precision inference with float16, corresponds to: --precision float16");
@@ -915,18 +910,6 @@ void ConfigParser::addSuboptionsULR(cli::CLIWrapper& cli) {
       "ULR softmax temperature to control randomness of predictions. Deafult is 1.0: no temperature",
       1.0f);
   // clang-format on
-}
-
-void ConfigParser::addSuboptionsIntgemm(cli::CLIWrapper& cli) {
-  // clang-format off
-  cli.add<bool>("--int16",
-      "Optimize speed aggressively sacrificing memory or precision by using 16bit integer GEMM with intgemm instead of floats. Only available on CPU. Corresponds to --gemm-precision int16");
-  cli.add<bool>("--int8",
-      "Optimize speed even more aggressively sacrificing memory or precision by using 8bit integer GEMM with intgemm instead of floats. Only available on CPU. Corresponds to --gemm-precision int8");
-  cli.add<bool>("--int8shift",
-      "Use a faster, shifted integer 8bit GEMM implementation. Corresponds to --gemm-precision int8shift");
-  cli.add<std::string>("--gemm-precision",
-      "Use lower precision for the GEMM operations only. Supported values: float32, int16, int8, int8shift", "float32");
 }
 
 void ConfigParser::addSuboptionsQuantization(cli::CLIWrapper& cli) {

--- a/src/common/config_parser.h
+++ b/src/common/config_parser.h
@@ -138,7 +138,6 @@ private:
   void addSuboptionsInputLength(cli::CLIWrapper&);
   void addSuboptionsTSV(cli::CLIWrapper&);
   void addSuboptionsULR(cli::CLIWrapper&);
-  void addSuboptionsIntgemm(cli::CLIWrapper&);
   void addSuboptionsQuantization(cli::CLIWrapper&);
 
   // Extract paths to all config files found in the config object.

--- a/src/embedder/embedder.h
+++ b/src/embedder/embedder.h
@@ -85,11 +85,6 @@ public:
       graph->setDefaultElementType(typeFromString(precison[0])); // only use first type, used for parameter type in graph
       graph->setDevice(device);
       graph->getBackend()->setClip(options_->get<float>("clip-gemm"));
-      if (device.type == DeviceType::cpu) { // Specific GEMM precisions are only supported on the CPU for now.
-          std::string gemmPrecision = options_->get<std::string>("gemm-precision", {"float32"});
-          graph->getBackend()->setGemmPrecision(gemmPrecision);
-        }
-
       graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
       graphs_.push_back(graph);
     }

--- a/src/microsoft/quicksand.cpp
+++ b/src/microsoft/quicksand.cpp
@@ -256,8 +256,6 @@ bool convertModel(std::string inputFile, std::string outputFile, int32_t targetP
 
   auto graph = New<ExpressionGraphPackable>();
   graph->setDevice(CPU0);
-  graph->getBackend()->setInt16(false);
-  graph->getBackend()->setInt8(false);
 
   graph->load(inputFile);
   graph->forward();

--- a/src/rescorer/rescorer.h
+++ b/src/rescorer/rescorer.h
@@ -74,11 +74,6 @@ public:
       graph->setDefaultElementType(typeFromString(precison[0])); // only use first type, used for parameter type in graph
       graph->setDevice(device);
       graph->getBackend()->setClip(options_->get<float>("clip-gemm"));
-      if (device.type == DeviceType::cpu) { // Specific GEMM precisions are only supported on the CPU for now.
-        std::string gemmPrecision = options_->get<std::string>("gemm-precision", {"float32"});
-        graph->getBackend()->setGemmPrecision(gemmPrecision);
-      }
-
       graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
       graphs_.push_back(graph);
     }

--- a/src/tensors/backend.h
+++ b/src/tensors/backend.h
@@ -27,31 +27,6 @@ public:
 
   virtual void setClip(float clipValue) { clipValue_ = clipValue; }
   float getClip() { return clipValue_; }
-
-  // Set the gemm precision
-  virtual void setGemmPrecision(std::string gemmPrec) {
-    if (gemmPrec == "float32") {
-      return; // This is the default precisoin.
-    } else if (gemmPrec == "int16") {
-      setInt16(true);
-    } else if (gemmPrec == "int8") {
-      setInt8(true);
-    } else if (gemmPrec == "int8shift") {
-      setInt8(true);
-      setInt8Shift(true);
-    } else {
-      ABORT("Unsupported GEMM precision type: {}", gemmPrec);
-    }
-  }
-
-  // for CPU, sets the GEMM mode for matrix multiplication. When everything is false, float32 is used
-  // for GPU, this is invalid. for GPU, all the functions below always returns false and the setters abort.
-  virtual void setInt16(bool int16) = 0;
-  virtual bool isInt16() = 0;
-  virtual void setInt8(bool int8) = 0;
-  virtual bool isInt8() = 0;
-  virtual void setInt8Shift(bool shifted) = 0;
-  virtual bool isInt8Shift() = 0;
 };
 
 Ptr<Backend> BackendByDeviceId(DeviceId deviceId, size_t seed);

--- a/src/tensors/cpu/backend.h
+++ b/src/tensors/cpu/backend.h
@@ -10,25 +10,11 @@ namespace marian {
 namespace cpu {
 
 class Backend : public marian::Backend {
-protected:
-  bool int16_{false};
-  bool int8_{false};
-  bool int8shift_{false};
-
 public:
   Backend(DeviceId deviceId, size_t seed) : marian::Backend(deviceId, seed) {}
   void setDevice() override {}
   void synchronize() override {}
-
-  // for CPU & inference only, sets to use optimized code for inference. Does nothing for GPU.
-  void setInt16(bool optimize) override { int16_ = optimize; }
-  bool isInt16() override { return int16_; }
-
-  void setInt8(bool optimize) override { int8_ = optimize; }
-  bool isInt8() override { return int8_; }
-
-  void setInt8Shift(bool shifted) override { int8shift_ = shifted; }
-  bool isInt8Shift() override { return int8shift_ && int8_; }
 };
+
 }  // namespace cpu
 }  // namespace marian

--- a/src/tensors/cpu/expression_graph_packable.h
+++ b/src/tensors/cpu/expression_graph_packable.h
@@ -2,7 +2,7 @@
 
 #include "graph/expression_graph.h"
 #include "fbgemm/packed_gemm.h"
-#include "tensors/cpu/intgemm_interface.h"
+#include "tensors/cpu/integer_common.h"
 
 namespace marian {
   namespace cpu {

--- a/src/tensors/cpu/expression_graph_packable.h
+++ b/src/tensors/cpu/expression_graph_packable.h
@@ -189,7 +189,7 @@ public:
                                                      rows(val),
                                                      cols(val));
           } else {
-            ABORT_IF(gemmElementType != Type::intgemm8, "Type {} is not supported {}", gemmElementType); // shouldn't really happen, but let's make sure
+            ABORT_IF(gemmElementType != Type::intgemm8, "Type {} is not supported", gemmElementType); // shouldn't really happen, but let's make sure
             intgemm::Int8::PrepareA(tmp->data(), /*input*/
                                     paramMat->data<int8_t>(), /*output*/
                                     quantMult, /*Quant Mult*/
@@ -225,7 +225,7 @@ public:
                                                       rows(val),
                                                       cols(val));
           } else {
-            ABORT_IF(gemmElementType != Type::intgemm8, "Type {} is not supported {}", gemmElementType); // shouldn't really happen, but let's make sure
+            ABORT_IF(gemmElementType != Type::intgemm16, "Type {} is not supported", gemmElementType); // shouldn't really happen, but let's make sure
             intgemm::Int16::PrepareA(tmp->data(), /*input*/
                                      paramMat->data<int16_t>(), /*output*/
                                      quantMult, /*Quant Mult*/

--- a/src/tensors/cpu/expression_graph_packable.h
+++ b/src/tensors/cpu/expression_graph_packable.h
@@ -207,19 +207,19 @@ public:
             ABORT("Sse3");
           } else if(isAvx2(gemmElementType)) {
             // @TODO: there should be a way to pass in the expected hardware depdendent type, so the function can abort if mismatch like in FBGEMM
-            intgemm::Int8::PrepareB(tmp->data(), /*input*/
-                                    paramMat->data<int8_t>(), /*output*/
-                                    quantMult, /*Quant Mult*/
-                                    rows(val),
-                                    cols(val));
+            intgemm::AVX2_8bit::PrepareB(tmp->data(), /*input*/
+                                         paramMat->data<int8_t>(), /*output*/
+                                         quantMult, /*Quant Mult*/
+                                         rows(val),
+                                         cols(val));
           } else if(isAvx512(gemmElementType)) {
             ABORT("AVX512");
           } else {
             intgemm::Int8::PrepareA(tmp->data(), /*input*/
-                                  paramMat->data<int8_t>(), /*output*/
-                                  quantMult, /*Quant Mult*/
-                                  rows(val),
-                                  cols(val));
+                                   paramMat->data<int8_t>(), /*output*/
+                                   quantMult, /*Quant Mult*/
+                                   rows(val),
+                                   cols(val));
           }
           //Put the quantMult at the back of the tensor
           *(reinterpret_cast<float *>(paramMat->data<int8_t>() + val->shape().elements())) = quantMult;

--- a/src/tensors/cpu/integer_common.h
+++ b/src/tensors/cpu/integer_common.h
@@ -35,14 +35,59 @@ template <Type type> struct intgemm_;
 template <> struct intgemm_<Type::intgemm8> {
   using width = intgemm::Int8;
   using type = int8_t;
-  constexpr static const Type intgemmType = Type::intgemm8;
+};
+
+template <> struct intgemm_<Type::intgemm8ssse3> {
+  using width = intgemm::SSSE3_8bit;
+  using type = int8_t;
+};
+
+template <> struct intgemm_<Type::intgemm8avx2> {
+  using width = intgemm::AVX2_8bit;
+  using type = int8_t;
+};
+
+template <> struct intgemm_<Type::intgemm8avx512> {
+  using width = intgemm::AVX512_8bit;
+  using type = int8_t;
 };
 
 template <> struct intgemm_<Type::intgemm16> {
   using width = intgemm::Int16;
   using type = int16_t;
-  constexpr static const Type intgemmType = Type::intgemm16;
 };
+
+template <> struct intgemm_<Type::intgemm16sse2> {
+  using width = intgemm::SSE2_16bit;
+  using type = int16_t;
+};
+
+template <> struct intgemm_<Type::intgemm16avx2> {
+  using width = intgemm::AVX2_16bit;
+  using type = int16_t;
+};
+
+template <> struct intgemm_<Type::intgemm16avx512> {
+  using width = intgemm::AVX512_16bit;
+  using type = int16_t;
+};
+
+template <Type vtype>
+static inline float& getQuantMult(marian::Tensor val) {
+  ABORT_IF(!isIntgemm(val->type()), "getQuantMult does not work for type {}", val->type());
+  typedef typename intgemm_<vtype>::type Integer;
+  return *(reinterpret_cast<float*>(val->data<Integer>() + val->shape().elements()));
+}
+
+template <Type vtype>
+static inline float computeQuantMult(marian::Tensor val) {
+  if(sizeOf(vtype) == 1)
+    return 127.0f / intgemm::MaxAbsolute(val->data(), val->data() + val->shape().elements());
+  else if(sizeOf(vtype) == 2)
+    return 1024.0f;
+  else
+    ABORT("Unhandled type size {}", sizeOf(vtype));
+}
 
 // This operates on floats after processing so doesn't care about int8_t vs int16_t.
 void AddBias(marian::Tensor C, const marian::Tensor Bias);

--- a/src/tensors/cpu/integer_common.h
+++ b/src/tensors/cpu/integer_common.h
@@ -30,13 +30,19 @@ inline int rows(Tensor& tensor) { return tensor->shape().elements() / cols(tenso
 inline int cols(Shape& shape) { return shape[-1]; }
 inline int rows(Shape& shape) { return shape.elements() / cols(shape); }
 
-template<Type type> struct intgemm_;
-template <> struct intgemm_<Type::int8> {using width = intgemm::Int8;
-                                         using type = int8_t;
-                                         constexpr static const Type intgemmType = Type::intgemm8;};
-template <> struct intgemm_<Type::int16> {using width = intgemm::Int16;
-                                          using type = int16_t;
-                                          constexpr static const Type intgemmType = Type::intgemm16;};
+template <Type type> struct intgemm_;
+
+template <> struct intgemm_<Type::intgemm8> {
+  using width = intgemm::Int8;
+  using type = int8_t;
+  constexpr static const Type intgemmType = Type::intgemm8;
+};
+
+template <> struct intgemm_<Type::intgemm16> {
+  using width = intgemm::Int16;
+  using type = int16_t;
+  constexpr static const Type intgemmType = Type::intgemm16;
+};
 
 // This operates on floats after processing so doesn't care about int8_t vs int16_t.
 void AddBias(marian::Tensor C, const marian::Tensor Bias);

--- a/src/tensors/cpu/intgemm_interface.h
+++ b/src/tensors/cpu/intgemm_interface.h
@@ -9,7 +9,6 @@ namespace marian {
 namespace cpu {
 namespace integer {
 
-// #define COMPILE_CPU 1
 #if COMPILE_CPU
 
 template <Type vtype>
@@ -41,10 +40,10 @@ static inline Expr prepareA(Expr a) {
     auto quantMult = computeQuantMult<vtype>(in->val());
     typedef typename intgemm_<vtype>::type Integer;
     intgemm_<vtype>::width::PrepareA(in->val()->data(), /*input*/
-                                    out->val()->data<Integer>(), /*output*/
-                                    quantMult, /*Quant Mult*/
-                                    rows(in->val()),
-                                    cols(in->val()));
+                                     out->val()->data<Integer>(), /*output*/
+                                     quantMult, /*Quant Mult*/
+                                     rows(in->val()),
+                                     cols(in->val()));
     getQuantMult<vtype>(out->val()) = quantMult;
   };
 
@@ -98,7 +97,7 @@ static inline Expr affineOrDotTyped(Expr a, Expr bQuant, Expr bias, bool transA,
 
   return lambda(nodes, outShape, Type::float32, dotOrAffineNodeOp);
 #else
-  a, b, bias, transA, transB, scale, clipValue;
+  a, b, bias, transA, scale, clipValue;
   ABORT("You need to enable CPU compilation to use this feature. Use cmake .. -DCOMPILE_CPU=ON");
 #endif
 }

--- a/src/tensors/cpu/intgemm_interface.h
+++ b/src/tensors/cpu/intgemm_interface.h
@@ -9,490 +9,110 @@ namespace marian {
 namespace cpu {
 namespace integer {
 
+// #define COMPILE_CPU 1
 #if COMPILE_CPU
+
+template <Type vtype>
+static inline float& getQuantMult(marian::Tensor val) {
+  ABORT_IF(!isIntgemm(val->type()), "getQuantMult does not work for type {}", val->type());
+  typedef typename intgemm_<vtype>::type Integer;
+  return *(reinterpret_cast<float*>(val->data<Integer>() + val->shape().elements()));
+}
+
+template <Type vtype>
+static inline float computeQuantMult(marian::Tensor val) {
+  if(sizeOf(vtype) == 1)
+    return 127.0f / intgemm::MaxAbsolute(val->data(), val->data() + val->shape().elements());
+  else if(sizeOf(vtype) == 2)
+    return 1024.0f;
+  else
+    ABORT("Unhandled type size {}", sizeOf(vtype));
+}
 
 /*
  * Prepare an activation matrix into intgemm8/16 format. For now the activation matrix is just quantized.
  * Expr input: The input tensor
- * Expr quant_mult: The quantization multiplier used. Produced by QuantMultNodeOp.
- * float clipValue: Not used for now, just forwarded
- * bool shifted: If the shifted version of intgemm is used (Only available with intgemm8), an offset of 127
- * is added to every single element of the input, effectively making it in the unsigned_int range
- * 
- * the template argument controls whether we're doing 16bit integers or 8bit integers. It can be Type::int8 or Type::int16
  */
 
 template<Type vtype>
-struct PrepareANodeOp : public NaryNodeOp {
-float clipValue_;
-float quantMult_;
-bool shifted_;
-  PrepareANodeOp(Expr input, Expr quant_mult, float clipValue, bool shifted)
-      : NaryNodeOp({input, quant_mult}, input->shape(), vtype), clipValue_(clipValue), shifted_(shifted) {
+static inline Expr prepareA(Expr a) {
+  auto nodeOp = [](Expr out, const std::vector<Expr>& nodes) {
+    Expr in = nodes[0];
+    auto quantMult = computeQuantMult<vtype>(in->val());
+    typedef typename intgemm_<vtype>::type Integer;
+    intgemm_<vtype>::width::PrepareA(in->val()->data(), /*input*/
+                                    out->val()->data<Integer>(), /*output*/
+                                    quantMult, /*Quant Mult*/
+                                    rows(in->val()),
+                                    cols(in->val()));
+    getQuantMult<vtype>(out->val()) = quantMult;
+  };
 
-    if (!shifted) {
-      set_name(input->name());
-    } else {
-      set_name(input->name() + "_shifted");
-    }
-    setMemoize(false);
-  }
-
-  NodeOps forwardOps() override {
-    return {NodeOp(
-      quantMult_ = *child(1)->val()->data();
-      typedef typename intgemm_<vtype>::type Integer;
-      if (!shifted_) {
-        intgemm_<vtype>::width::PrepareA(child(0)->val()->data(), /*input*/
-                                      val_->data<Integer>(), /*output*/
-                                      *child(1)->val()->data(), /*Quant Mult*/
-                                      rows(child(0)->val()),
-                                      cols(child(0)->val()));
-      } else {
-        intgemm::Int8Shift::PrepareA(child(0)->val()->data(), /*input*/
-                                      val_->data<int8_t>(), /*output*/
-                                      *child(1)->val()->data(), /*Quant Mult*/
-                                      rows(child(0)->val()),
-                                      cols(child(0)->val()));
-      }
-    )};
-  }
-
-  NodeOps backwardOps() override {
-    ABORT("Only used for inference");
-    return {NodeOp(0)};
-  }
-
-  const std::string type() override { return "intgemmPrepareA"; }
-};
-
-/*
- * Prepare a parameter matrix into intgemm8/16 format. The activation matrix is quantized and reordered and the reodering
- * depends on the architecture
- * Expr input: The input tensor
- * Expr quant_mult: The quantization multiplier used. Produced by QuantMultNodeOp.
- * float clipValue: Not used for now, just forwarded
- * 
- * the template argument controls whether we're doing 16bit integers or 8bit integers. It can be Type::int8 or Type::int16
- */
-
-template<Type vtype>
-struct PrepareBNodeOp : public NaryNodeOp {
-float clipValue_;
-float quantMult_;
-bool transposed_; /*This is only used for the output layer which has a different layout from
-                   *all other matrices in the code. By default we shouldn't do an extra transpose.*/
-  PrepareBNodeOp(Expr input, Expr quant_mult, float clipValue, bool transposed=false)
-      : NaryNodeOp({input, quant_mult}, newShape(input, transposed), intgemm_<vtype>::intgemmType), clipValue_(clipValue), transposed_(transposed) {
-
-    set_name(input->name());
-    // Check if arguments are not null
-    if (!transposed_) {
-      ABORT_IF(input->shape()[-1] %8 != 0, "Columns of matrix: " + input->type() + " must be multiple of 8.");
-    } else {
-      ABORT_IF((input->shape().elements()/input->shape()[-1]) %8 != 0, "Rows of matrix: " + input->type() + " must be multiple of 8.");
-    }
-  }
-
-  NodeOps forwardOps() override {
-   return {NodeOp(
-      quantMult_ = *child(1)->val()->data();
-      typedef typename intgemm_<vtype>::type Integer;
-      if (isIntgemm(child(0)->value_type())) {
-        val_ = child(0)->val();
-      } else if (!transposed_) {
-        intgemm_<vtype>::width::PrepareB(child(0)->val()->data(), /*input*/
-                                      val_->data<Integer>(), /*output*/
-                                      *child(1)->val()->data(), /*Quant Mult*/
-                                      rows(child(0)->val()),
-                                      cols(child(0)->val()));
-      } else {
-        intgemm_<vtype>::width::PrepareBTransposed(child(0)->val()->data(), /*input*/
-                                      val_->data<Integer>(), /*output*/
-                                      *child(1)->val()->data(), /*Quant Mult*/
-                                      cols(child(0)->val()), /*Cols and rows need to be swapped*/
-                                      rows(child(0)->val())); /*Cols and rows need to be swapped*/
-      }
-    )};
-  }
-
-  NodeOps backwardOps() override {
-    ABORT("Only used for inference");
-    return {NodeOp(0)};
-  }
-
-  const std::string type() override { return "intgemmPrepareB"; }
-
-  static Shape newShape(Expr input, bool transposed) {
-    Shape ret = input->shape();
-    if (transposed) {
-      ret.set(0, input->shape()[-1]);
-      ret.set(1, input->shape()[0]);
-    } else {
-      ret = input->shape();
-    }
-    return ret;
-  }
-};
-
-/*
- * This is intgemm's equivalent to marian's index_select for the intgemm format. Used for selecting a shortlist from
- * intgemm formatted matrix.
- * Expr input: The input tensor
- * const std::vector<uint_least32_t>  &indices the indecis of the shortlist
- * float clipValue: Not used for now, just forwarded
- * 
- * the template argument controls whether we're doing 16bit integers or 8bit integers. It can be Type::int8 or Type::int16
- */
-
-template<Type vtype>
-struct SelectColumnsBNodeOp : public UnaryNodeOp {
-public:
-  float clipValue_;
-  float quantMult_;
-  std::vector<uint_least32_t> indices_;
-  SelectColumnsBNodeOp(Expr input, const std::vector<uint_least32_t>  &indices, float clipValue)
-      : UnaryNodeOp(input, newShape(input, indices), intgemm_<vtype>::intgemmType), clipValue_(clipValue), indices_(indices) {
-
-    set_name(input->name());
-    setMemoize(false); // SelectColumnsB is memorised in src/layers/generic.cpp:262
-
-    // Check number of selected columns
-    ABORT_IF(indices.size() % 8 != 0, "Shortlist selected vocabulary must be a multiple of 8.");
-  }
-
-  NodeOps forwardOps() override {
-    return {NodeOp(
-      //We get the quantization multiplier from a PrepareB or directly from the input
-      if (child(0)->type() == "intgemmPrepareB") {
-        auto bPreppedNode = std::static_pointer_cast<PrepareBNodeOp<vtype> >(child(0));
-        quantMult_ = bPreppedNode->quantMult_;
-      } else {
-        typedef typename intgemm_<vtype>::type Integer;
-        quantMult_ = *(reinterpret_cast<float *>(reinterpret_cast<Integer *>(child(0)->val()->data()) + child(0)->val()->shape().elements()));
-      }
-      auto input = child(0)->val();
-      typedef typename intgemm_<vtype>::type Integer;
-      intgemm_<vtype>::width::SelectColumnsB(
-                    reinterpret_cast<Integer *>(input->data()),
-                    val_->data<Integer>(),
-                    rows(input),
-                    &*indices_.begin(),
-                    &*indices_.end());
-    )};
-  }
-
-  const std::string type() override { return "intgemmSelectColumnsB"; }
-
-  // A custom hasher and comparator are necessary to take the shortlist indecis into account.
-  size_t hash() override {
-    if (!hash_) {
-      hash_ = NaryNodeOp::hash();
-      for(auto i : indices_)
-        util::hash_combine(hash_, i);
-    }
-    return hash_;
-  }
-
-  bool equal(Expr node) override {
-    if(!NaryNodeOp::equal(node)) return false;
-    auto cnode = std::dynamic_pointer_cast<SelectColumnsBNodeOp<vtype>>(node);
-    if (!cnode) return false;
-    return indices_ == cnode->indices_;
-  }
-
-private:
-  static Shape newShape(Expr a, const std::vector<uint_least32_t>& indices) {
-    Shape ret = a->shape();
-    ret.set(1, indices.size());
-    return ret;
-  }
-};
-
-/*
- * This node calculates the quantization multiplier
- * Expr input: The input tensor
- * bool isA: Whether the matrix is an Activation or parameter
- * 
- * the template argument controls whether we're doing 16bit integers or 8bit integers. It can be Type::int8 or Type::int16
- */
-template<Type vtype>
-struct QuantMultNodeOp : public UnaryNodeOp {
-  bool isA_;
-  QuantMultNodeOp(Expr input, bool isA) : UnaryNodeOp(input, Shape({1}), Type::float32), isA_(isA) {
-    if (isA_) {
-      setMemoize(false);
-      set_name(input->name() + "_QuantMultA");
-    } else {
-      set_name(input->name() + "_QuantMultB");
-    }
-  }
-
-  /*
-   * We have several cases:
-   * If we are using 16bit ints, the quantization multiplier is hardcoded to 1024
-   * If our input is shortlist (SelectColumnsBNodeOp), it is stored on the node.
-   * If our model is prepared intgemm8/intgemm16 format, the qunatization multiplier is stored at the back of the tensor
-   * Otherwise, we have the 8bit case, in which case we use 127/MaxAbsolute(input)
-   */
-
-#pragma warning(push)
-#pragma warning(disable: 4127) //VSCODE thinks line 222 is constant conditional expression, which it is only after the template resolution, not before.
-  NodeOps forwardOps() override {
-    return {NodeOp(
-      if (vtype == Type::int16) {
-        *val_->data() = 1024.0f;
-      } else if (child(0)->type() == "intgemmSelectColumnsB") {
-        *val_->data() = std::static_pointer_cast<SelectColumnsBNodeOp<vtype> >(child(0))->quantMult_;
-      } else if (isIntgemm(child(0)->value_type())) {                    /* So we can template*/
-        typedef typename intgemm_<vtype>::type Integer;
-        *val_->data() = *(reinterpret_cast<float *>(reinterpret_cast<Integer *>(child(0)->val()->data()) + child(0)->val()->shape().elements()));
-      } else {
-        *val_->data() = 127.0f / intgemm::MaxAbsolute(child(0)->val()->data(),
-                            child(0)->val()->data() + child(0)->val()->shape().elements());
-      }
-    )};
-  }
-#pragma warning(pop)
-  NodeOps backwardOps() override {
-    ABORT("Only used for inference");
-    return {NodeOp(0)};
-  }
-
-  const std::string type() override {
-    if (isA_)
-      return "intgemmQuantMultA";
-    else
-      return "intgemmQuantMultB";
-  }
-};
-
-
-/*
- * This node prepares the bias with the compensation for the intgemm-shifted implementation
- * Expr bias: The input tensor
- * Expr inputB_preppd: The parameter matrix in intgemm8 format.
- * Expr a_quant_mult: The quantization multiplier for the activations matrix.
- * Expr b_quant_mult: The quantization multiplier for the parameter matrix
- */
-
-class PrepareBiasForBNodeOp : public NaryNodeOp {
-public:
-  PrepareBiasForBNodeOp(Expr bias, Expr inputB_preppd, Expr a_quant_mult, Expr b_quant_mult)
-      : NaryNodeOp({bias, inputB_preppd, a_quant_mult, b_quant_mult}, bias->shape(), Type::float32) {
-
-    set_name(bias->name() + "_Prepared");
-    setMemoize(false);
-  }
-
-  NodeOps forwardOps() override {
-    return {NodeOp(
-    auto bias = this->child(0)->val();
-    auto b = this->child(1)->val();
-    auto quant_mult_a = this->child(2)->val();
-    auto quant_mult_b = this->child(3)->val();
-
-    float unquant_mult = (-1)*((127.0f / *quant_mult_a->data())*(127.0f / *quant_mult_b->data()))/(127.0f); //Minus one to invert add_ps later on
-    intgemm::Int8Shift::PrepareBias((const int8_t *)b->data(), rows(b), cols(b), intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_mult, bias->data(), val_->data()));
-    )};
-  }
-
-  const std::string type() override { return "prepareBias"; }
-};
-
-/*
- * This computes A*B in intgemm.
- * Expr a: The activation matrix in intgemm format
- * Expr b: The parameter matrix in intgemm fromat
- * 
- * the template argument controls whether we're doing 16bit integers or 8bit integers. It can be Type::int8 or Type::int16
- */
-
-template<Type vtype>
-class DotNodeOp : public NaryNodeOp {
-private:
-float scalar_;
-
-public:
-  DotNodeOp(Expr a, Expr b, float scalar)
-      : NaryNodeOp({a, b}, newShape(a, b), Type::float32), scalar_(scalar) {
-        setMemoize(false); // AFAIK dot is never called with the same matrices
-      }
-
-  Shape newShape(Expr a, Expr b) {
-    Shape result = a->shape();
-    result.set(-1, b->shape()[-1]);
-    return result;
-  }
-
-  NodeOps forwardOps() override {
-    return {NodeOp(
-          float aQuantMult = std::static_pointer_cast<PrepareANodeOp<vtype> >(child(0))->quantMult_;
-          float bQuantMult;
-          if (child(1)->type() == "intgemmSelectColumnsB") {
-            bQuantMult = std::static_pointer_cast<SelectColumnsBNodeOp<vtype> >(child(1))->quantMult_;
-          } else if (child(1)->type() == "intgemmPrepareB") {
-            bQuantMult = std::static_pointer_cast<PrepareBNodeOp<vtype> >(child(1))->quantMult_;
-          } else {
-            typedef typename intgemm_<vtype>::type Integer;
-            bQuantMult = *(reinterpret_cast<float *>(reinterpret_cast<Integer *>(child(1)->val()->data()) + child(1)->val()->shape().elements()));
-          }
-          float unquant_mult = 1.0f/(aQuantMult*bQuantMult);
-
-          unquant_mult = unquant_mult*scalar_;
-          typedef typename intgemm_<vtype>::type Integer;
-          intgemm_<vtype>::width::Multiply(reinterpret_cast<Integer *>(child(0)->val()->data()), /*A*/
-                                           reinterpret_cast<Integer *>(child(1)->val()->data()), /*B*/
-                                           rows(child(0)->val()),
-                                           cols(child(0)->val()),
-                                           cols(child(1)->val()),
-                                           intgemm::callbacks::UnquantizeAndWrite(unquant_mult, val_->data()));
-    )};
-  }
-
-  NodeOps backwardOps() override {
-    ABORT("Only used for inference");
-    return {NodeOp(0)};
-  }
-
-  const std::string type() override { return "intgemmDot"; }
-};
-
-/*
- * This computes A*B + bias in intgemm.
- * Expr a: The activation matrix in intgemm format
- * Expr b: The parameter matrix in intgemm fromat
- * Expr bias: The bias
- * float scalar: AFAIK, not ever used
- * bool shifted: Use the faster shifted intgemm8 multiplier. Requires special versions of the bias and the activation matrix
- * 
- * the template argument controls whether we're doing 16bit integers or 8bit integers. It can be Type::int8 or Type::int16
- */
-
-template<Type vtype>
-class AffineNodeOp : public NaryNodeOp {
-private:
-  float scalar_;
-  bool shifted_;
-
-public:
-  AffineNodeOp(Expr a, Expr b, Expr Bias, float scalar, bool shifted=false)
-      : NaryNodeOp({a, b, Bias}, newShape(a, b), Type::float32), scalar_(scalar), shifted_(shifted) {
-        setMemoize(false); // AFAIK affine is never called with the same matrices
-      }
-
-  Shape newShape(Expr a, Expr b) {
-    Shape result = a->shape();
-    result.set(-1, b->shape()[-1]);
-    return result;
-  }
-
-  NodeOps forwardOps() override {
-    return {NodeOp(
-          float aQuantMult = std::static_pointer_cast<PrepareANodeOp<vtype> >(child(0))->quantMult_;
-          float bQuantMult;
-          if (child(1)->type() == "intgemmSelectColumnsB") {
-            bQuantMult = std::static_pointer_cast<SelectColumnsBNodeOp<vtype> >(child(1))->quantMult_;
-          } else if (child(1)->type() == "intgemmPrepareB") {
-            bQuantMult = std::static_pointer_cast<PrepareBNodeOp<vtype> >(child(1))->quantMult_;
-          } else {
-            typedef typename intgemm_<vtype>::type Integer;
-            bQuantMult = *(reinterpret_cast<float *>(reinterpret_cast<Integer *>(child(1)->val()->data()) + child(1)->val()->shape().elements()));
-          }
-          float unquant_mult = 1.0f/(aQuantMult*bQuantMult);
-
-          unquant_mult = unquant_mult*scalar_;
-          typedef typename intgemm_<vtype>::type Integer;
-          if (!shifted_) {
-            intgemm_<vtype>::width::Multiply(reinterpret_cast<Integer *>(child(0)->val()->data()), /*A*/
-                                             reinterpret_cast<Integer *>(child(1)->val()->data()), /*B*/
-                                             rows(child(0)->val()),
-                                             cols(child(0)->val()),
-                                             cols(child(1)->val()),                                          /*child(2) is bias*/
-                                             intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_mult, child(2)->val()->data(), val_->data()));
-          } else {
-            intgemm::Int8Shift::Multiply(reinterpret_cast<int8_t *>(child(0)->val()->data()), /*A*/
-                                  reinterpret_cast<int8_t *>(child(1)->val()->data()), /*B*/
-                                  rows(child(0)->val()),
-                                  cols(child(0)->val()),
-                                  cols(child(1)->val()),                                          /*child(2) is bias*/
-                                  intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_mult, child(2)->val()->data(), val_->data()));
-          }
-    )};
-  }
-
-  NodeOps backwardOps() override {
-    ABORT("Only used for inference");
-    return {NodeOp(0)};
-  }
-
-  const std::string type() override { return "intgemmAffine"; }
-};
-
-
-// Wrappers for converting nodes to expression.
-template<Type vtype>
-static inline Expr quantMult(Expr a, bool isA=false) {
-  return Expression<QuantMultNodeOp<vtype> >(a, isA);
-}
-
-template<Type vtype>
-static inline Expr prepareA(Expr a, Expr quantMult, float clipValue, bool shifted=false) {
-  return Expression<PrepareANodeOp<vtype> >(a, quantMult, clipValue, shifted);
-}
-
-template<Type vtype>
-static inline Expr prepareB(Expr b, Expr quantMult, float clipValue, bool transposed=false) {
-  return Expression<PrepareBNodeOp<vtype> >(b, quantMult, clipValue, transposed);
-}
-
-template<Type vtype>
-static inline Expr selectColumnsB(Expr b, const std::vector<uint_least32_t> &cols, float clipValue) {
-  return Expression<SelectColumnsBNodeOp<vtype > >(b, cols, clipValue);
+  return lambda({a}, a->shape(), vtype, nodeOp);
 }
 #endif
 
 template<Type vtype>
-static inline Expr affine(Expr a, Expr b, Expr bias, bool transA, bool transB, float scale, float clipValue=0 /*currently unused*/) {
+static inline Expr affineOrDotTyped(Expr a, Expr bQuant, Expr bias, bool transA, bool /*transB*/, float scale) {
 #if COMPILE_CPU
-  clipValue;
-#if 0 // @TODO to be enabled in the future
-  bool shiftedBias = a->graph()->getBackend()->isInt8Shift() && bias; // Use shifted multiplication if we have a enabled it in the options, and we have a bias
-#else
-  bool shiftedBias = false;
-#endif
+  ABORT_IF(!isFloat(a->value_type()), "Intgemm expects type of A to be float32 not {}", a->value_type());
+  ABORT_IF(!isIntgemm(bQuant->value_type()), "Intgemm expects type of B to be a variant of intgemm not {}", bQuant->value_type());
 
-  Type bElementType = b->value_type();
-  auto aQuantMult = quantMult<vtype>(a, true);
-  auto aQuant = prepareA<vtype>(transA ? transpose(a) : a, aQuantMult, scale, shiftedBias);
-  Expr bQuantMult = quantMult<vtype>(b);
-  Expr bQuant = nullptr;
-  if (isIntgemm(bElementType)) {
-    // This is the case where we already run SelectColumnB or we loaded a prepacked model.
-    // We ignore a transpose argument here, because we should have already transposed the matrix!
-    bQuant = b;
-  } else {
-    bQuant = prepareB<vtype>(b, bQuantMult, scale, transB);
-  }
-  if (shiftedBias) {
-    // Shifted version of intgemm requires a specially prepared bias.
-    bias = Expression<PrepareBiasForBNodeOp>(bias, bQuant, aQuantMult, bQuantMult);
-  }
+  auto aQuant = prepareA<vtype>(transA ? transpose(a) : a); // A should not be quantized yet as seen above, hence quantize here
+  
+  Shape outShape = aQuant->shape();
+  outShape.set(-1, bQuant->shape()[-1]);
 
-  // IF we don't have a bias, do A*B (AKA dot)
-  if (bias)
-    return Expression<AffineNodeOp<vtype> >(aQuant, bQuant, bias, scale, shiftedBias);
-  else
-    return Expression<DotNodeOp<vtype> >(aQuant, bQuant, scale);
+  auto dotOrAffineNodeOp = [=](Expr out, const std::vector<Expr>& nodes) {
+    Expr aQuant = nodes[0];
+    Expr bQuant = nodes[1];
+    Expr bias   = nodes.size() > 2 ? nodes[2] : nullptr;
+
+    float aQuantMult = getQuantMult<vtype>(aQuant->val());
+    float bQuantMult = getQuantMult<vtype>(bQuant->val());
+        
+    float unquant_mult = 1.0f / (aQuantMult * bQuantMult);
+    unquant_mult = unquant_mult * scale;
+
+    typedef typename intgemm_<vtype>::type Integer;
+    if(bias) {
+      intgemm_<vtype>::width::Multiply(/*A=*/aQuant->val()->data<Integer>(),
+                                       /*B=*/bQuant->val()->data<Integer>(),
+                                       rows(aQuant->val()),
+                                       cols(aQuant->val()),
+                                       cols(bQuant->val()),
+                                       intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_mult, /*bias=*/bias->val()->data(), /*output=*/out->val()->data()));
+    } else {
+      intgemm_<vtype>::width::Multiply(/*A=*/aQuant->val()->data<Integer>(),
+                                       /*B=*/bQuant->val()->data<Integer>(),
+                                       rows(aQuant->val()),
+                                       cols(aQuant->val()),
+                                       cols(bQuant->val()),
+                                       intgemm::callbacks::UnquantizeAndWrite(unquant_mult, /*output=*/out->val()->data()));
+    }
+  };
+
+  std::vector<Expr> nodes = {aQuant, bQuant};
+  if(bias)
+    nodes.push_back(bias);
+
+  return lambda(nodes, outShape, Type::float32, dotOrAffineNodeOp);
 #else
   a, b, bias, transA, transB, scale, clipValue;
   ABORT("You need to enable CPU compilation to use this feature. Use cmake .. -DCOMPILE_CPU=ON");
 #endif
 }
 
-template<Type vtype>
-static inline Expr dot(Expr a, Expr b, bool transA, bool transB, float scale) {
-  return affine<vtype>(a, b, nullptr, transA, transB, scale, 0 /*currently unused clipValue*/);
+static inline Expr affineOrDot(Expr a, Expr bQuant, Expr bias, bool transA, bool transB, float scale) {
+  Type bQuantElementType = bQuant->value_type();
+  switch(sizeOf(bQuantElementType)) {
+    case 1 :
+      return cpu::integer::affineOrDotTyped<Type::intgemm8>(a, bQuant, bias, transA, transB, scale);
+    case 2 :
+      return cpu::integer::affineOrDotTyped<Type::intgemm16>(a, bQuant, bias, transA, transB, scale);
+    default:
+      ABORT("Unsupported type {} for Intgemm type??", bQuantElementType);
+  }
 }
 
 }  // namespace integer

--- a/src/tensors/cpu/intgemm_interface.h
+++ b/src/tensors/cpu/intgemm_interface.h
@@ -456,7 +456,11 @@ template<Type vtype>
 static inline Expr affine(Expr a, Expr b, Expr bias, bool transA, bool transB, float scale, float clipValue=0 /*currently unused*/) {
 #if COMPILE_CPU
   clipValue;
+#if 0 // @TODO to be enabled in the future
   bool shiftedBias = a->graph()->getBackend()->isInt8Shift() && bias; // Use shifted multiplication if we have a enabled it in the options, and we have a bias
+#else
+  bool shiftedBias = false;
+#endif
 
   Type bElementType = b->value_type();
   auto aQuantMult = quantMult<vtype>(a, true);

--- a/src/tensors/cpu/intgemm_interface.h
+++ b/src/tensors/cpu/intgemm_interface.h
@@ -10,7 +10,6 @@ namespace cpu {
 namespace integer {
 
 #if COMPILE_CPU
-
 /*
  * Prepare an activation matrix into intgemm8/16 format. For now the activation matrix is just quantized.
  * Expr input: The input tensor
@@ -53,7 +52,7 @@ static inline Expr affineOrDotTyped(Expr a, Expr bQuant, Expr bias, bool transA,
   auto aQuant = prepareA<vtype>(transA ? transpose(a) : a); // A should not be quantized yet as seen above, hence quantize here
   
   // determine the output shape m x n for A: m x k and B: k x n
-  // since we transpose a beforehand we don't need to take care of transposed shapes here 
+  // since we transpose A beforehand we don't need to take care of transposed shapes here 
   Shape outShape = aQuant->shape();
   outShape.set(-1, bQuant->shape()[-1]);
 

--- a/src/tensors/gpu/backend.h
+++ b/src/tensors/gpu/backend.h
@@ -66,32 +66,6 @@ public:
 
   CudaCompute getCudaComputeCapability() { return compute_; }
 
-  // for CPU, sets to use optimized (intgemm8/intgemm16) code for matrix multiplication.
-  // for GPU, this is invalid. for gpu, all the functions below always returns false and the setters abort.
-  void setInt16(bool /*optimize*/) override {
-    ABORT("setInt16() is not supported on the GPU.");
-  }
-
-  bool isInt16() override {
-    return false;
-  }
-
-  void setInt8(bool /*optimize*/) override {
-    ABORT("setInt8() is not supported on the GPU.");
-  }
-
-  bool isInt8() override {
-    return false;
-  }
-
-  void setInt8Shift(bool /*shifted*/) override {
-    ABORT("setInt8Shift() is not supported on the GPU.");
-  }
-
-  bool isInt8Shift() override {
-    return false;
-  }
-
 private:
   cublasHandle_t cublasHandle_{0};     // make sure it's 0, so it can be initalized lazily
   cusparseHandle_t cusparseHandle_{0}; // as above

--- a/src/tests/prod.cpp
+++ b/src/tests/prod.cpp
@@ -7,7 +7,9 @@ int main(int /*argc*/, char** /*argv*/) {
     {
         auto g = New<ExpressionGraph>(true);
         g->setDevice({0, DeviceType::cpu});
+#if 0 // this file is not a real test, just used for manual stuff. Disable here by hand for now.
         g->getBackend()->setInt16(false);
+#endif
         g->reserveWorkspaceMB(2512);
 
         timer::AutoTimer timer;
@@ -40,7 +42,9 @@ int main(int /*argc*/, char** /*argv*/) {
     {
         auto g = New<ExpressionGraph>(true);
         g->setDevice({0, DeviceType::cpu});
+#if 0
         g->getBackend()->setInt16(true);
+#endif
         g->reserveWorkspaceMB(2512);
 
         timer::AutoTimer timer;
@@ -73,7 +77,9 @@ int main(int /*argc*/, char** /*argv*/) {
     {
         auto g = New<ExpressionGraph>(true);
         g->setDevice({0, DeviceType::cpu});
+#if 0
         g->getBackend()->setInt8(true);
+#endif
         g->reserveWorkspaceMB(2512);
 
         timer::AutoTimer timer;

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -88,10 +88,6 @@ public:
         graph->setDefaultElementType(typeFromString(prec[0]));
         graph->setDevice(device);
         graph->getBackend()->setClip(options_->get<float>("clip-gemm"));
-        if (device.type == DeviceType::cpu) { // Specific GEMM precisions are only supported on the CPU for now.
-          std::string gemmPrecision = options_->get<std::string>("gemm-precision", {"float32"});
-          graph->getBackend()->setGemmPrecision(gemmPrecision);
-        }
         graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
         graphs_[id] = graph;
 
@@ -231,10 +227,6 @@ public:
       graph->setDefaultElementType(typeFromString(precison[0])); // only use first type, used for parameter type in graph
       graph->setDevice(device);
       graph->getBackend()->setClip(options_->get<float>("clip-gemm"));
-      if (device.type == DeviceType::cpu) { // Specific GEMM precisions are only supported on the CPU for now.
-        std::string gemmPrecision = options_->get<std::string>("gemm-precision", {"float32"});
-        graph->getBackend()->setGemmPrecision(gemmPrecision);
-      }
       graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
       graphs_.push_back(graph);
 


### PR DESCRIPTION
Hi, 
this is a first draft of my small refactoring changes. All in all it was easier than thought. 

* Similar to FBGEMM the compute type is now determined by the Element type in the model.bin file.
* If that's only intgemm{8,16} it will do the hardware-specific stuff on the fly.
* If intgemm8avx2 etc. it is already pre-packed and does no conversion, but is hardware specific. This should be possible to mmap.
* Got rid of the code in backends (for now). Open to add it back later.

TODO:
* ~~Verify I did not break FBGEMM back-compat with the new types.~~ (regression tests for FBGEMM pass, @ykim362 you may want to do some more testing)
* ~~Test out mmapping~~ (seems to work out-of-the-box, see below)
* Take a look at the TODOs I mentioned, especially concerning aborting with wrong hardware during conversion.
* It seems sse2 or ssse3 models do not work for me on avx2, please help verify/debug. AVX2 on AVX2 hardware works fine.
* Verify AVX512 works on AVX512 hardware. 

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
