### PR TITLE
Updating Boost in GitHub checks to 1.72

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -86,9 +86,9 @@ jobs:
         CC=/usr/bin/gcc-${{ matrix.gcc }} CXX=/usr/bin/g++-${{ matrix.gcc }} CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }} \
         cmake .. \
           -DBoost_ARCHITECTURE=-x64 \
-          -DBOOST_INCLUDEDIR=$BOOST_ROOT_1_69_0/include \
-          -DBOOST_LIBRARYDIR=$BOOST_ROOT_1_69_0/lib \
-          -DBOOST_ROOT=$BOOST_ROOT_1_69_0 \
+          -DBOOST_INCLUDEDIR=$BOOST_ROOT_1_72_0/include \
+          -DBOOST_LIBRARYDIR=$BOOST_ROOT_1_72_0/lib \
+          -DBOOST_ROOT=$BOOST_ROOT_1_72_0 \
           -DCMAKE_BUILD_TYPE=Release \
           -DCOMPILE_CPU=${{ matrix.cpu }} \
           -DCOMPILE_CUDA=${{ matrix.gpu }} \


### PR DESCRIPTION
### Description

Boost 1.69 is deprecated since November, 10.