### PR TITLE
Small optimizations

### DIFF
--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include "data/corpus.h"
 
 #include <numeric>
@@ -265,6 +270,14 @@ CorpusBase::batch_ptr Corpus::toBatch(const std::vector<Sample>& batchVector) {
         maxDims[i] = (int)ex[i].size();
     }
     sentenceIds.push_back(ex.getId());
+  }
+  
+  // When running on GPU, we want the batchWidth to be a multiple of 8 for better tensorcore usage
+  if(options_->get<int>("cpu-threads") == 0) {
+    constexpr int roundingFactor = 8;
+    for(size_t j = 0; j < maxDims.size(); ++j) {
+      maxDims[j] = roundingFactor * ((maxDims[j] + roundingFactor - 1) / roundingFactor);
+    }
   }
 
   std::vector<Ptr<SubBatch>> subBatches;

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -1,5 +1,5 @@
  
-/* All or part of this file was contributed by NVIDIA under license:
+/* Part of this file was contributed by NVIDIA under license:
  *   Copyright (C) 2020 NVIDIA Corporation
  *   SPDX-License-Identifier: MIT
  */

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -88,8 +88,10 @@ namespace marian {
     }
 
     // if selIdx are given, then we must reshuffle accordingly
-    if (!hypIndices.empty()) // use the same function that shuffles decoder state
-      sel = rnn::State::select(sel, hypIndices, (int)beamSize, /*isBatchMajor=*/false);
+    if (!hypIndices.empty()) { // use the same function that shuffles decoder state
+      auto indices = graph()->indices(hypIndices);
+      sel = rnn::State::select(sel, indices, (int)beamSize, /*isBatchMajor=*/false);
+    }
     return sel;
   }
 

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -1,3 +1,9 @@
+ 
+/* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include "marian.h"
 
 #include "layers/generic.h"

--- a/src/models/states.h
+++ b/src/models/states.h
@@ -1,3 +1,8 @@
+/* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "marian.h"

--- a/src/models/states.h
+++ b/src/models/states.h
@@ -1,4 +1,4 @@
-/* All or part of this file was contributed by NVIDIA under license:
+/* Part of this file was contributed by NVIDIA under license:
  *   Copyright (C) 2020 NVIDIA Corporation
  *   SPDX-License-Identifier: MIT
  */

--- a/src/models/states.h
+++ b/src/models/states.h
@@ -30,7 +30,8 @@ public:
   // Sub-select active batch entries from encoder context and context mask
   Ptr<EncoderState> select(const std::vector<IndexType>& batchIndices) { // [batchIndex] indices of active batch entries
     // Dimension -2 is OK for both, RNN and Transformer models as the encoder context in Transformer gets transposed to the same dimension layout
-    return New<EncoderState>(index_select(context_, -2, batchIndices), index_select(mask_, -2, batchIndices), batch_);
+    auto indices = context_->graph()->indices(batchIndices);
+    return New<EncoderState>(index_select(context_, -2, indices), index_select(mask_, -2, indices), batch_);
   }
 };
 

--- a/src/rnn/types.h
+++ b/src/rnn/types.h
@@ -1,4 +1,4 @@
-/* All or part of this file was contributed by NVIDIA under license:
+/* Part of this file was contributed by NVIDIA under license:
  *   Copyright (C) 2020 NVIDIA Corporation
  *   SPDX-License-Identifier: MIT
  */

--- a/src/rnn/types.h
+++ b/src/rnn/types.h
@@ -1,3 +1,8 @@
+/* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "common/definitions.h"

--- a/src/rnn/types.h
+++ b/src/rnn/types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/definitions.h"
+#include "common/shape.h"
 #include "marian.h"
 
 #include <iostream>
@@ -12,7 +14,7 @@ struct State {
   Expr output;
   Expr cell;
 
-  State select(const std::vector<IndexType>& selIdx, // [beamIndex * activeBatchSize + batchIndex]
+  State select(Expr selIdx, // [beamIndex * activeBatchSize + batchIndex]
                int beamSize, bool isBatchMajor) const {
     return{ select(output, selIdx, beamSize, isBatchMajor),
             select(cell,   selIdx, beamSize, isBatchMajor) };
@@ -20,15 +22,14 @@ struct State {
 
   // this function is also called by Logits
   static Expr select(Expr sel, // [beamSize, dimTime, dimBatch, dimDepth] or [beamSize, dimBatch, dimTime, dimDepth] (dimTime = 1 for RNN)
-                     const std::vector<IndexType>& selIdx, // [beamIndex * activeBatchSize + batchIndex]
+                     Expr selIdx, // [beamIndex * activeBatchSize + batchIndex]
                      int beamSize, bool isBatchMajor)
   {
     if (!sel)
       return sel; // keep nullptr untouched
 
     sel = atleast_4d(sel);
-
-    int dimBatch = (int)selIdx.size() / beamSize;
+    int dimBatch =(int) selIdx->shape().elements()/beamSize;
     int dimDepth = sel->shape()[-1];
     int dimTime  = isBatchMajor ? sel->shape()[-2] : sel->shape()[-3];
 
@@ -83,8 +84,24 @@ public:
   States select(const std::vector<IndexType>& selIdx, // [beamIndex * activeBatchSize + batchIndex]
                 int beamSize, bool isBatchMajor) const {
     States selected;
+    Expr indices;
+    // I think this doesn't work if model split among gpus but not sure if it matters
+    
+    for (auto& state : states_) {
+      if (state.cell) {
+        indices = state.cell->graph()->indices(selIdx);
+        break;
+      }
+
+      if (state.output) {
+        indices = state.output->graph()->indices(selIdx);
+        break;
+      }
+    }
+    
+    // GPU OPT: Implement kernel to batch these on GPU
     for(auto& state : states_)
-      selected.push_back(state.select(selIdx, beamSize, isBatchMajor));
+      selected.push_back(state.select(indices, beamSize, isBatchMajor));
     return selected;
   }
 

--- a/src/tensors/gpu/backend.h
+++ b/src/tensors/gpu/backend.h
@@ -1,4 +1,4 @@
-/* All or part of this file was contributed by NVIDIA under license:
+/* Part of this file was contributed by NVIDIA under license:
  *   Copyright (C) 2020 NVIDIA Corporation
  *   SPDX-License-Identifier: MIT
  */

--- a/src/tensors/gpu/backend.h
+++ b/src/tensors/gpu/backend.h
@@ -52,6 +52,7 @@ public:
     if(!cublasHandle_) { // lazy initialization here to avoid memory usage when unused
       setDevice();
       cublasCreate(&cublasHandle_);
+      cublasSetStream(cublasHandle_, cudaStreamPerThread);
     }
     return cublasHandle_;
   }
@@ -60,6 +61,7 @@ public:
     if(!cusparseHandle_) { // lazy initialization here to avoid memory usage when unused
       setDevice();
       cusparseCreate(&cusparseHandle_);
+      cusparseSetStream(cusparseHandle_, cudaStreamPerThread);  
     }
     return cusparseHandle_;
   }

--- a/src/tensors/gpu/backend.h
+++ b/src/tensors/gpu/backend.h
@@ -1,3 +1,8 @@
+/* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "common/config.h"

--- a/src/tensors/gpu/prod.cpp
+++ b/src/tensors/gpu/prod.cpp
@@ -1,4 +1,4 @@
-/* All or part of this file was contributed by NVIDIA under license:
+/* Part of this file was contributed by NVIDIA under license:
  *   Copyright (C) 2020 NVIDIA Corporation
  *   SPDX-License-Identifier: MIT
  */

--- a/src/tensors/gpu/prod.cpp
+++ b/src/tensors/gpu/prod.cpp
@@ -1,4 +1,8 @@
-
+/* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+ 
 #ifdef _MSC_VER
 #pragma warning(disable: 4505) // warning C4505: '__float2half_rz': unreferenced local function has been removed (missing 'static inline')
 #endif


### PR DESCRIPTION
### Description

This PR splits out some small optimizations from PR #743.

Performance improvements from this PR as measured on a Titan V using a proxy transformer model:


Times with 1 Stream
Batch | Initial Time (s) | Current Time(s) | % Runtime reduction | Speedup factor
-- | -- | -- | -- | --
1 | 204.41 | 166.74 | 0.184286483 | 1.225920595
2 | 136.77 | 114.46 | 0.163120567 | 1.194915254
4 | 84.76 | 69.39 | 0.181335536 | 1.221501657
8 | 50.32 | 41.52 | 0.174880763 | 1.21194605
16 | 29.94 | 25.07 | 0.162658651 | 1.194256083
32 | 18.51 | 15.98 | 0.136682874 | 1.158322904
64 | 12.09 | 10.57 | 0.125723739 | 1.143803217
128 | 8.19 | 7.15 | 0.126984127 | 1.145454545
256 | 6.02 | 5.39 | 0.104651163 | 1.116883117


Times with two streams
Batch | Initial Time (s) | Current Time(s) | % Runtime reduction | Speedup factor
-- | -- | -- | -- | --
1 | 156.74 | 119.03 | 0.240589511 | 1.316810888
2 | 106.13 | 79.63 | 0.249693772 | 1.33278915
4 | 65.1 | 48.64 | 0.252841782 | 1.338404605
8 | 38.46 | 29.07 | 0.244149766 | 1.323013416
16 | 22.68 | 17.29 | 0.237654321 | 1.311740891
32 | 14.31 | 10.98 | 0.232704403 | 1.303278689
64 | 9.51 | 7.19 | 0.243953733 | 1.322670376
128 | 6.66 | 5.18 | 0.222222222 | 1.285714286
256 | 5.05 | 4.06 | 0.196039604 | 1.243842365




List of changes:
- Uses the per thread default stream for cublas
- Uses the strided batched gemm cublas call when possible for the batchedGemm. 
- In the general batchedGemm case, reduces the number of memcpy calls from 3 to 1.
- Rounds the width of input batches to a multiple of 8 when the GPU backend is being used. This is to enable better use of tensorcores on Volta architectures and newer
- Adds notices to the files changed

### How to test
I ran the regression tests. On Volta, some regression tests fail due to the additional use of tensor cores. This is because prior to CUDA 11, cublas does not use tensorcores if matrices fail to meet alignment requirements. This restriction is lifted in CUDA >= 11.

The differences in the float output from the failing regression tests are small. A list of them are provided here:
  - tests/interface/input-tsv/test_tsv_train_with_align.sh
  - tests/interface/input-tsv/test_tsv_train_with_align_and_weights.sh
  - tests/interface/input-tsv/test_tsv_train_with_align_and_weights_inputtypes.sh
  - tests/interface/input-tsv/test_tsv_train_with_align_pos0.sh
  - tests/interface/input-tsv/test_tsv_train_with_align_shuffle_in_ram.sh
  - tests/interface/input-tsv/test_tsv_train_with_align_stdin.sh
  - tests/scorer/nbest/test_compare_parallel_and_nbest.sh
  - tests/training/features/mixed-ensembles/test_ensemble_of_different_s2s.sh
  - tests/training/features/mixed-ensembles/test_ensemble_of_s2s_and_transformer.sh
  - tests/training/features/guided-alignment/test_guided_alignment_rnn.sh
  - tests/training/features/guided-alignment/test_guided_alignment_transformer.sh

OS: Ubuntu 18.04.3 LTS
Compiler gcc 7.5.0
nvcc version: 10.1.243

cmake command:

cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on   -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off -DCOMPILE_TESTS=on


### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
