### PR TITLE
Topk refactor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "src/3rd_party/simple-websocket-server"]
 	path = src/3rd_party/simple-websocket-server
 	url = https://github.com/marian-nmt/Simple-WebSocket-Server
+[submodule "src/3rd_party/cub"]
+	path = src/3rd_party/cub
+	url = https://github.com/NVIDIA/cub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+- Includes cub as a dependency
+- Replaces the topK implementation in nth_element.cu and topk.cu
 - Add --train-embedder-rank for fine-tuning any encoder(-decoder) model for multi-lingual similarity via softmax-margin loss
 - Add --logical-epoch that allows to redefine the displayed epoch counter as a multiple of n data epochs, updates or labels. Also allows to define width of fractional part with second argument.
 - Add --metrics chrf for computing ChrF according to https://www.aclweb.org/anthology/W15-3049/ and SacreBLEU reference implementation

--- a/src/3rd_party/topk.cuh
+++ b/src/3rd_party/topk.cuh
@@ -23,9 +23,13 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#if CUDA_VERSION >= 11000
+#include <cub/cub.cuh>
+#include <cub/util_type.cuh>
+#else
 #include "cub/cub/cub.cuh"
 #include "cub/cub/util_type.cuh"
-
+#endif
 #define MAX_BLOCKS_PER_BEAM 8
 
 struct TopK {

--- a/src/3rd_party/topk.cuh
+++ b/src/3rd_party/topk.cuh
@@ -23,7 +23,6 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
-#include "cub/cub/util_type.cuh"
 #if CUDA_VERSION >= 11000
 #include <cub/cub.cuh>
 #else

--- a/src/3rd_party/topk.cuh
+++ b/src/3rd_party/topk.cuh
@@ -23,7 +23,6 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
-#include <condition_variable>
 #if CUDA_VERSION >= 11000
 #include <cub/cub.cuh>
 #else

--- a/src/3rd_party/topk.cuh
+++ b/src/3rd_party/topk.cuh
@@ -23,6 +23,7 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <condition_variable>
 #if CUDA_VERSION >= 11000
 #include <cub/cub.cuh>
 #else
@@ -136,7 +137,8 @@ __global__ void topk_stage_2(const int* __restrict topk_tmp_id_buf,
 
   for(int beam = tid; beam < k; beam += BLOCK_SIZE_) {
     TopK beamOut; 
-    beamOut.p = topk_tmp_id_buf[batch_id * size + topks[beam].p];
+    int indexInRow = topks[beam].p == NOT_FOUND? 0: topks[beam].p;
+    beamOut.p = topk_tmp_id_buf[batch_id * size + indexInRow];
     beamOut.p = beamOut.p == NOT_FOUND? 0 : beamOut.p; // If no max found, all values were equal to T::min so just return 0
     beamOut.u = topks[beam].u;
     top[batch_id * k + beam] = beamOut;

--- a/src/3rd_party/topk.cuh
+++ b/src/3rd_party/topk.cuh
@@ -1,0 +1,188 @@
+/*
+* Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* This code is modified from the topk implementation in NVIDIA's faster
+* transformer repository. The original source code files can be found here:
+*
+* https://github.com/NVIDIA/DeepLearningExamples/blob/master/FasterTransformer/v3.0/fastertransformer/cuda/topk_kernels.cu
+* https://github.com/NVIDIA/DeepLearningExamples/blob/master/FasterTransformer/v3.0/fastertransformer/cuda/topk_kernels.cuh
+*/
+
+#pragma once
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include "cub/cub/cub.cuh"
+#include "cub/cub/util_type.cuh"
+
+#define MAX_BLOCKS_PER_BEAM 8
+
+struct TopK {
+  int p = 0;
+  float u = cub::FpLimits<float>::Lowest();
+
+  __device__ __forceinline__ void insert(float elem, int elem_id) {
+    if(elem > u) {
+      u = elem;
+      p = elem_id;
+    }
+  }
+
+  __device__ __forceinline__ void init() {
+    u = cub::FpLimits<float>::Lowest();
+    p = 0;
+  }
+};
+
+__device__ __forceinline__ TopK reduce_topk_op(const TopK& a, const TopK& b) {
+  return a.u > b.u ? a : b;
+}
+
+template<typename T, int BLOCK_SIZE_, int BLOCKS_PER_BEAM_>
+__global__ void topk_stage_1(T* log_probs, 
+                             int* topk_tmp_id_buf,
+                             float* topk_tmp_val_buf, 
+                             const int k, 
+                             const int vocab_size) {
+
+  typedef cub::BlockReduce<TopK, BLOCK_SIZE_> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+  const int row_id = bid / BLOCKS_PER_BEAM_; // row id for log_probs
+  const int block_lane = bid % BLOCKS_PER_BEAM_; // block id for a beam 
+  const int tmp_log_buf_index = row_id * vocab_size; 
+  const int tmp_topk_buf_index = row_id * BLOCKS_PER_BEAM_ * k + block_lane * k;
+  TopK partial;
+
+  for(int ite = 0; ite < k; ite++) {
+    partial.init();
+    #pragma unroll
+    for(int elem_id = tid + block_lane * BLOCK_SIZE_; elem_id < vocab_size; elem_id += BLOCK_SIZE_ * BLOCKS_PER_BEAM_) {
+      int index = elem_id + tmp_log_buf_index;
+      partial.insert(log_probs[index], index);
+    }
+
+    TopK total = BlockReduce(temp_storage).Reduce(partial, reduce_topk_op);
+
+    if (tid == 0) {
+      const int index = tmp_topk_buf_index + ite;
+      topk_tmp_id_buf[index] = total.p;
+      topk_tmp_val_buf[index] = total.u;
+      log_probs[total.p] = cub::FpLimits<T>::Lowest();
+    }
+    __syncthreads();
+  }
+
+  // Update prob array with original values.
+  for(int beam = tid; beam < k; beam += BLOCK_SIZE_) {
+    const int index = tmp_topk_buf_index + beam;
+    log_probs[topk_tmp_id_buf[index]] = (T)topk_tmp_val_buf[index];
+  }
+}
+
+template<int BLOCK_SIZE_, int BLOCKS_PER_BEAM_>
+__global__ void topk_stage_2(const int* __restrict topk_tmp_id_buf,
+                             float* topk_tmp_val_buf,
+                             TopK* top,
+                             const int beams_per_batch,
+                             const int k) {
+
+  const int size = beams_per_batch * k * BLOCKS_PER_BEAM_; 
+  const int tid = threadIdx.x;
+  const int batch_id = blockIdx.x;
+
+  typedef cub::BlockReduce<TopK, BLOCK_SIZE_> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  extern __shared__ char array[];
+  float *s_val = topk_tmp_val_buf + batch_id * size;
+  TopK *topks = (TopK*)(array);
+  
+  TopK partial;
+
+  for(int ite = 0; ite < k; ite++) {
+    partial.init();
+    #pragma unroll
+    for(int i = tid; i < size; i+= BLOCK_SIZE_) {
+      partial.insert(s_val[i], i); 
+    }
+
+    TopK total = BlockReduce(temp_storage).Reduce(partial, reduce_topk_op);
+
+    if(tid == 0) {
+      topks[ite] = total;
+      s_val[total.p] = cub::FpLimits<float>::Lowest();
+    }
+    __syncthreads();
+  }
+
+  for(int beam = tid; beam < k; beam += BLOCK_SIZE_) {
+    TopK beamOut; 
+    beamOut.p = topk_tmp_id_buf[batch_id * size + topks[beam].p];
+    beamOut.u = topks[beam].u;
+    top[batch_id * k + beam] = beamOut;
+  }
+}
+
+#define CASE_K(K,BLOCK_SIZE_1_, BLOCK_SIZE_2_, BLOCKS_PER_BEAM_) \
+  case K: \
+    topk_stage_1<T, BLOCK_SIZE_1_, BLOCKS_PER_BEAM_><<<batch_size * beams_per_batch * BLOCKS_PER_BEAM_, BLOCK_SIZE_1_, 0, stream>>>( \
+        log_probs, \
+        topk_tmp_id_buf, \
+        topk_tmp_val_buf, \
+        k, vocab_size); \
+    topk_stage_2<BLOCK_SIZE_2_, BLOCKS_PER_BEAM_><<<batch_size, BLOCK_SIZE_2_, K * sizeof(TopK), stream>>>( \
+        topk_tmp_id_buf, \
+        topk_tmp_val_buf, \
+        tops, \
+        beams_per_batch, \
+        k); \
+  break; \
+
+template <typename T>
+void topK_kernelLauncher(T* log_probs,
+                         int* topk_tmp_id_buf,
+                         float* topk_tmp_val_buf,
+                         TopK* tops,
+                         const int batch_size,
+                         const int beams_per_batch,
+                         const int k,
+                         const int vocab_size,
+                         cudaStream_t stream) {
+  switch(k) {
+    CASE_K(1,128,128,MAX_BLOCKS_PER_BEAM);
+    CASE_K(2,128,128,MAX_BLOCKS_PER_BEAM);
+    CASE_K(4,128,128,MAX_BLOCKS_PER_BEAM);
+    CASE_K(6,128,128,MAX_BLOCKS_PER_BEAM);
+    CASE_K(8,128,128,MAX_BLOCKS_PER_BEAM);
+    CASE_K(10,128,128,MAX_BLOCKS_PER_BEAM);
+    CASE_K(16,128,128,5);
+    CASE_K(32,256,128,1);
+    CASE_K(64,256,256,1);
+    default:
+      topk_stage_1<T, 128, 1><<<batch_size * beams_per_batch * 1, 128, 0, stream>>>(log_probs, 
+                                                                                    topk_tmp_id_buf, 
+                                                                                    topk_tmp_val_buf,
+                                                                                    k, 
+                                                                                    vocab_size);
+
+      topk_stage_2<128, 1><<<batch_size, 128, k * sizeof(TopK), stream>>>(topk_tmp_id_buf,
+                                                                                           topk_tmp_val_buf,
+                                                                                           tops,
+                                                                                           beams_per_batch,
+                                                                                           k);
+    break;
+  }
+}

--- a/src/3rd_party/topk.cuh
+++ b/src/3rd_party/topk.cuh
@@ -25,10 +25,8 @@
 #include <cuda_fp16.h>
 #if CUDA_VERSION >= 11000
 #include <cub/cub.cuh>
-#include <cub/util_type.cuh>
 #else
 #include "cub/cub/cub.cuh"
-#include "cub/cub/util_type.cuh"
 #endif
 #define MAX_BLOCKS_PER_BEAM 8
 

--- a/src/3rd_party/topk.cuh
+++ b/src/3rd_party/topk.cuh
@@ -23,15 +23,18 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include "cub/cub/util_type.cuh"
 #if CUDA_VERSION >= 11000
 #include <cub/cub.cuh>
 #else
 #include "cub/cub/cub.cuh"
 #endif
+
+#define NOT_FOUND -1
 #define MAX_BLOCKS_PER_BEAM 8
 
 struct TopK {
-  int p = 0;
+  int p = NOT_FOUND;
   float u = cub::FpLimits<float>::Lowest();
 
   __device__ __forceinline__ void insert(float elem, int elem_id) {
@@ -43,7 +46,7 @@ struct TopK {
 
   __device__ __forceinline__ void init() {
     u = cub::FpLimits<float>::Lowest();
-    p = 0;
+    p = NOT_FOUND;
   }
 };
 
@@ -83,7 +86,8 @@ __global__ void topk_stage_1(T* log_probs,
       const int index = tmp_topk_buf_index + ite;
       topk_tmp_id_buf[index] = total.p;
       topk_tmp_val_buf[index] = total.u;
-      log_probs[total.p] = cub::FpLimits<T>::Lowest();
+      // If we found a max, blank out the value in the log prob array before starting the next iteration
+      if(total.p != NOT_FOUND) log_probs[total.p] = cub::FpLimits<T>::Lowest();
     }
     __syncthreads();
   }
@@ -91,7 +95,8 @@ __global__ void topk_stage_1(T* log_probs,
   // Update prob array with original values.
   for(int beam = tid; beam < k; beam += BLOCK_SIZE_) {
     const int index = tmp_topk_buf_index + beam;
-    log_probs[topk_tmp_id_buf[index]] = (T)topk_tmp_val_buf[index];
+    int k_idx = topk_tmp_id_buf[index];
+    if(k_idx != NOT_FOUND) log_probs[k_idx] = (T)topk_tmp_val_buf[index];
   }
 }
 
@@ -133,6 +138,7 @@ __global__ void topk_stage_2(const int* __restrict topk_tmp_id_buf,
   for(int beam = tid; beam < k; beam += BLOCK_SIZE_) {
     TopK beamOut; 
     beamOut.p = topk_tmp_id_buf[batch_id * size + topks[beam].p];
+    beamOut.p = beamOut.p == NOT_FOUND? 0 : beamOut.p; // If no max found, all values were equal to T::min so just return 0
     beamOut.u = topks[beam].u;
     top[batch_id * k + beam] = beamOut;
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+ # Part of this file was contributed by NVIDIA under license:
+ #   Copyright (C) 2020 NVIDIA Corporation
+ #   SPDX-License-Identifier: MIT
+
+add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT=1)
 add_subdirectory(3rd_party)
 
 include_directories(.)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@
  #   SPDX-License-Identifier: MIT
 
 add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT=1)
+add_definitions(-DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT=1)
 add_subdirectory(3rd_party)
 
 include_directories(.)

--- a/src/tensors/gpu/topk.cu
+++ b/src/tensors/gpu/topk.cu
@@ -1,8 +1,10 @@
+#include "common/definitions.h"
 #include "tensors/tensor_operators.h"
 #include "tensors/gpu/cuda_helpers.h"
 #include "tensors/allocator.h"
 
 #include <cuda.h>
+#include "3rd_party/topk.cuh"
 
 // GPU implementation of proper Marian top-k operator for TopkNodeOp
 // This file contains a lot of code-duplicaton with src/translator/nth_element.cu
@@ -12,309 +14,6 @@
 
 namespace marian {
 namespace gpu {  
-
-const int MAX_BINS   = 500;
-const int BLOCK_SIZE = 512;
-
-#define UNROLL_MAXARG_LOOP(n, max)                    \
-  if(tid < (n) && tid + (n) < (max)) {                \
-    if(sharedValues[tid + (n)] > sharedValues[tid]) { \
-      sharedIndices[tid] = sharedIndices[tid + (n)];  \
-      sharedValues[tid]  = sharedValues[tid + (n)];   \
-    }                                                 \
-  }
-
-// finds maximum element (first step) 
-template <typename T>
-__global__ void gMaxElement(IndexType* binIndices, // out: top-k positions
-                            T* binValues,          // out: top-k scores
-                            const T* inValues,     // this is the probs array, only one with type float or half
-                            int rows,              // we iterate over this many rows, row-major layout
-                            int cols,              // a row has that many columns, row-major layout
-                            float minimal,         // minimal is the smallest possible value. For simplicity we assume we look for the maxmimum.
-                            bool descending)       // This will be the largest possible value if the order is reversed (i.e. we look for the minimum).
-{
-  extern __shared__ float sharedValues[];
-  __shared__ IndexType sharedIndices[BLOCK_SIZE];
-
-  // id of current thread within block
-  int tid = threadIdx.x;
-
-  float flip = descending ? 1.f : -1.f;
-
-  // Roll over every row in row-major 2D representation of the data
-  for(int rowIdx = 0; rowIdx < rows; ++rowIdx) {
-    int begin = rowIdx * cols;        // start index of a row
-    int end   = rowIdx * cols + cols; // end index of a row
-
-    // We look at at most blockDim.x * 2 = 1024 values within a block, i.e. each thread reduces two values.
-    // Here we set the position to begin + blockId * 1024 + threadId. If a row has more values we 
-    // partition the row according to blocks of 1024 values.
-    int i = begin + blockIdx.x * (blockDim.x * 2) + tid;
-
-    // Initialize shared values to minimal value.
-    sharedValues[tid] = minimal;
-
-    // Do first set of comparisons outside loop, saves one iteration.
-    if(i + blockDim.x < end) { // Are we in a position for which we can access and compare two values in a row partition (shifted by block size)?
-      // yes, hence compare:
-      float a = flip * (float)inValues[i];              // value from first half of row parition for this block
-      float b = flip * (float)inValues[i + blockDim.x]; // value from second half of row partition for this block
-      if(a > b) { // just a max
-        sharedIndices[tid] = i;
-        sharedValues[tid]  = a;
-      } else {
-        sharedIndices[tid] = i + blockDim.x;
-        sharedValues[tid]  = b;
-      }
-    } else if(i < end) { // Are we instead in a position that has access to one value in the row partition (shifting by block size would be out of bounds)?
-      // Yes, hence save the current value and index as new max, no need to compare.
-      sharedIndices[tid] = i;
-      sharedValues[tid]  = flip * (float)inValues[i];
-    } // nothing else to do here
-
-    // We move to the next set of 1024 values shifted by block size times number of blocks
-    // and look at two of them according to thread id.
-    while(i + 2 * gridDim.x * blockDim.x < end) {
-      i += 2 * gridDim.x * blockDim.x;
-
-      // Check if first value is larger than what we have seen so far
-      float a = flip * (float)inValues[i];
-      if(a > sharedValues[tid]) {
-        // Yes, hence save index and value
-        sharedIndices[tid] = i;
-        sharedValues[tid]  = a;
-      }
-
-      // Check if second value is larger than what we have seen so far
-      if(i + blockDim.x < end) {
-        float b = flip * (float)inValues[i + blockDim.x];
-        if(b > sharedValues[tid]) {
-          // Yes, hence save index and value
-          sharedIndices[tid] = i + blockDim.x;
-          sharedValues[tid]  = b;
-        }
-      }
-    }
-
-    // We are done with the first sweep and have populated shared memory, time to wait for the other threads and reduce it all
-    __syncthreads();
-
-    // Reduce over shared memory, here per loop until we hit the last 32 unreduced elements
-    for(int s = (blockDim.x >> 1); s > 32; s >>= 1) {
-      if(tid < s && tid + s < end) {
-        if(sharedValues[tid + s] > sharedValues[tid]) {
-          // keep the max
-          sharedIndices[tid] = sharedIndices[tid + s];
-          sharedValues[tid]  = sharedValues[tid + s];
-        }
-      }
-      __syncthreads();
-    }
-
-    // Reduce over shared memory, here per unrolled code for powers of 2 lower equal 32.
-    // Because we are at 32 (warp size) the threads run in lock-step and we can abandon syncing.
-    UNROLL_MAXARG_LOOP(32, end);
-    UNROLL_MAXARG_LOOP(16, end);
-    UNROLL_MAXARG_LOOP(8, end);
-    UNROLL_MAXARG_LOOP(4, end);
-    UNROLL_MAXARG_LOOP(2, end);
-    UNROLL_MAXARG_LOOP(1, end);
-
-    // OK, we are done with the reduction and in the first thread
-    if(tid == 0) {
-      // assign the final maximal value to the bin, one bin per row and block
-      binIndices[rowIdx * gridDim.x + blockIdx.x] = sharedIndices[0]; // [rows, num_blocks]
-      binValues[rowIdx * gridDim.x + blockIdx.x]  = sharedValues[0];  // [rows, num_blocks]
-    }
-    __syncthreads();
-  }
-}
-
-// This runs after the function above, we now have the maximum value per row and block and can look further
-// for the top-k results. As above we pretend this does only maximum search.
-// This runs restricted to one row (one row per block)
-template <typename T>
-__global__ void gMaxElementUpdate(IndexType* binIndices, // memory for bin indices
-                                  T* binValues,          // memory for bin costs
-                                  IndexType* outIndices, // result indices
-                                  T* outValues,          // result costs
-                                  T* inValues,           // should work well enough with half, uses float everywhere else
-                                  const int cols,        // size of continous memory we search over
-                                  const int K,           // how many top-K elements?
-                                  int numBlocks,        // number of blocks/bins used in above function (per row)
-                                  float minimal,         // value for minimal element
-                                  bool descending)
-{
-  extern __shared__ float sharedValues[];
-  __shared__ int    sharedIndices[BLOCK_SIZE];
-  __shared__ float  bestBinCost;
-  __shared__ int    bestBinCostIdx;
-
-  const int tid    = threadIdx.x;
-
-  float flip = descending ? 1.f : -1.f;
-
-  // we only look at one row in this kernel
-  const int rowIdx = blockIdx.x;           // index of the row corresponds to block index
-  const int begin  = rowIdx * cols;        // start offset for this row relative to inValues tensor start
-  const int end    = rowIdx * cols + cols; // end offset for this row relative to inValues tensor start
-
-  int num_bins = numBlocks; // why not just use numBlocks? 
-
-  // iterate over top-k results
-  for(int k = 0; k < K; ++k) {
-
-    int kthOutIdx = rowIdx * K + k;  // offset into output tensor relative to outIndices/outValues tensor start
-    int i = tid;
-
-    sharedValues[tid] = minimal; // initialize to smallest value, everything else will be larger
-
-    // as in the function above, the code here does a tree reduction over shared memory to find the single maximum element
-    if(i + blockDim.x < num_bins) {
-      float a = binValues[rowIdx * numBlocks + i];
-      float b = binValues[rowIdx * numBlocks + i + blockDim.x];
-      if(a > b) {
-        sharedValues[tid] = a;
-        sharedIndices[tid] = i;
-      } else {
-        sharedValues[tid] = b;
-        sharedIndices[tid] = i + blockDim.x;
-      }
-    } else if(i < num_bins) {
-      sharedValues[tid] = binValues[rowIdx * numBlocks + i];
-      sharedIndices[tid] = i;
-    }
-
-    while(i + 2 * blockDim.x < num_bins) {
-      i += 2 * blockDim.x;
-
-      float a = binValues[rowIdx * numBlocks + i];
-      if(a > sharedValues[tid]) {
-        sharedValues[tid] = a;
-        sharedIndices[tid] = i;
-      }
-
-      if(i + blockDim.x < num_bins) {
-        float b = binValues[rowIdx * numBlocks + i + blockDim.x];
-        if(b > sharedValues[tid]) {
-          sharedValues[tid] = b;
-          sharedIndices[tid] = i + blockDim.x;
-        }
-      }
-    }
-
-    __syncthreads();
-
-    for(int s = (blockDim.x >> 1); s > 32; s >>= 1) {
-      if(tid < s && tid + s < num_bins) {
-        if(sharedValues[tid + s] > sharedValues[tid]) {
-          sharedValues[tid] = sharedValues[tid + s];
-          sharedIndices[tid] = sharedIndices[tid + s];
-        }
-      }
-      __syncthreads();
-    }
-
-    UNROLL_MAXARG_LOOP(32, num_bins);
-    UNROLL_MAXARG_LOOP(16, num_bins);
-    UNROLL_MAXARG_LOOP(8, num_bins);
-    UNROLL_MAXARG_LOOP(4, num_bins);
-    UNROLL_MAXARG_LOOP(2, num_bins);
-    UNROLL_MAXARG_LOOP(1, num_bins);
-
-    if(tid == 0) {
-      bestBinCost = sharedValues[0];
-      bestBinCostIdx = rowIdx * numBlocks + sharedIndices[0];
-
-      inValues[binIndices[bestBinCostIdx]] = flip * minimal; // this is restored in the last lines of this function
-
-      outIndices[kthOutIdx] = binIndices[bestBinCostIdx] - begin; // relative to beginning of row hence substract `begin`
-      outValues[kthOutIdx]  = flip * bestBinCost; // undo flip by flipping again
-    }
-
-    __syncthreads();
-
-    // Second part of the algorithm, why it that not replacing the first function call?? 
-    // Also shouldn't we skip here if k == K - 1?
-
-    // After marking the previously largest element with "flip * minimal" we populate again
-    // shared memory with the largest element as in gMaxElement(...)
-
-    if(k < K - 1) {
-      i = begin + (bestBinCostIdx - rowIdx * numBlocks) * (blockDim.x * 2) + tid;
-      const int dist = num_bins * 2 * blockDim.x;
-
-      sharedValues[tid] = minimal;
-
-      if(i + blockDim.x < end) {
-        float a = flip * (float)inValues[i];
-        float b = flip * (float)inValues[i + blockDim.x];
-        if(a > b) {
-          sharedIndices[tid] = i;
-          sharedValues[tid]  = a;
-        } else {
-          sharedIndices[tid] = i + blockDim.x;
-          sharedValues[tid]  = b;
-        }
-      } else if(i < end) {
-        sharedIndices[tid] = i;
-        sharedValues[tid] = flip * (float)inValues[i];
-      }
-
-      while(i + dist < end) {
-        i += dist;
-
-        float a = flip * (float)inValues[i];
-        if(a > sharedValues[tid]) {
-          sharedIndices[tid] = i;
-          sharedValues[tid]  = a;
-        }
-
-        if(i + blockDim.x < end) {
-          float b = flip * (float)inValues[i + blockDim.x];
-          if(b > sharedValues[tid]) {
-            sharedIndices[tid] = i + blockDim.x;
-            sharedValues[tid] =  b;
-          }
-        }
-      }
-
-      __syncthreads();
-
-      for(int s = (blockDim.x >> 1); s > 32; s >>= 1) {
-        if(tid < s && tid + s < end) {
-          if(sharedValues[tid + s] > sharedValues[tid]) {
-            sharedIndices[tid] = sharedIndices[tid + s];
-            sharedValues[tid] = sharedValues[tid + s];
-          }
-        }
-        __syncthreads();
-      }
-
-      UNROLL_MAXARG_LOOP(32, end);
-      UNROLL_MAXARG_LOOP(16, end);
-      UNROLL_MAXARG_LOOP(8, end);
-      UNROLL_MAXARG_LOOP(4, end);
-      UNROLL_MAXARG_LOOP(2, end);
-      UNROLL_MAXARG_LOOP(1, end);
-
-      if(tid == 0) {
-        binIndices[bestBinCostIdx] = sharedIndices[0];
-        binValues[bestBinCostIdx]  = sharedValues[0];
-      }
-      __syncthreads();
-    }
-  }
-
-  // final operation to restore blanked-out input values. They were blanked out for marking
-  // already found values. Since we want input values to be invariant we restore here.
-  // @TODO: The lack of constness here might be a problem for concurrent processing (which we currently don't have)
-  for(int k = tid; k < K; k += blockDim.x) {
-    int kthOutIdx = rowIdx * K + k;
-    inValues[begin + outIndices[kthOutIdx]] = outValues[kthOutIdx];
-  }
-}
 
 void TopK(Tensor outVal, Tensor outInd, Ptr<Allocator> allocator, const Tensor in, int k, int axis, bool descending) {
   
@@ -330,45 +29,43 @@ void TopK(Tensor outVal, Tensor outInd, Ptr<Allocator> allocator, const Tensor i
 
   ABORT_IF(k > cols, "Cannot select more than {} elements for axis {}", cols, axis);
 
-  float minimal = NumericLimits<float>(in->type()).lowest; // lowest if looking for max
+  // @TODO: When nth_element is removed, rename MAX_BLOCKS_PER_BEAM to MAX_BLOCKS_PER_ROW and increase
+  //        the number of blocks per row for the kernel launches after benchmarking. The current set of
+  //        params assume that each group of blocks processes 1 beam instead of potentially several beams
+  //        in this case.
+  const int beams = 1;
+  const int tempElts = rows * beams * beams * MAX_BLOCKS_PER_BEAM;
 
-  const int numBlocks = std::min(MAX_BINS, int(cols / (2 * BLOCK_SIZE)) + int(cols % (2 * BLOCK_SIZE) != 0));
-  auto tempMemInd = allocator->alloc<IndexType>(rows * numBlocks);
+  auto tempMemInd = allocator->alloc<IndexType>(tempElts);
 
   MemoryPiece::PtrType tempMemVal;
   if(in->type() == Type::float32) {
-    tempMemVal = allocator->alloc<float>(rows * numBlocks);
-    // first find the maximum value per row and block and save indices and values to temporary memory
-    gMaxElement<<<numBlocks, // blocks
-                  BLOCK_SIZE, // threads
-                  BLOCK_SIZE * sizeof(float), // shared memory size
-                  /* stream_ */ 0>>>(
-      tempMemInd->data<IndexType>(), tempMemVal->data<float>(),
-      in->data<float>(), rows, cols, minimal, descending);
-    gMaxElementUpdate<<<rows,       // blocks ... seems we can have up to 2^31-1 of these, so we are safe?
-                        BLOCK_SIZE, // threads
-                        BLOCK_SIZE * sizeof(float),  // shared memory size
-                        /* stream_ */ 0>>>(
-      tempMemInd->data<IndexType>(), tempMemVal->data<float>(), 
-      outInd->data<IndexType>(), outVal->data<float>(), 
-      in->data<float>(), cols, k, numBlocks, minimal, descending);
+    tempMemVal = allocator->alloc<float>(tempElts);
+    topK_kernelLauncher<IndexType, float, true>(in->data<float>(), 
+                        tempMemInd->data<IndexType>(),
+                        tempMemVal->data<float>(),
+                        outInd->data<IndexType>(),
+                        outVal->data<float>(),
+                        rows,
+                        1, // This is the beam size. This is set to 1 since we "trick" the existing implementation to treat a row as a beam
+                        k,
+                        cols,
+                        descending,
+                        cudaStreamPerThread);
 #if COMPILE_FP16
   } else if(in->type() == Type::float16) {
-    tempMemVal = allocator->alloc<__half>(rows * numBlocks);
-    // first find the maximum value per row and block and save indices and values to temporary memory
-    gMaxElement<<<numBlocks, // blocks
-                  BLOCK_SIZE, // threads
-                  BLOCK_SIZE * sizeof(float), // shared memory size
-                  /* stream_ */ 0>>>(
-      tempMemInd->data<IndexType>(), tempMemVal->data<__half>(),
-      in->data<__half>(), rows, cols, minimal, descending);
-    gMaxElementUpdate<<<rows,       // blocks ... seems we can have up to 2^31-1 of these, so we are safe?
-                        BLOCK_SIZE, // threads
-                        BLOCK_SIZE * sizeof(float),  // shared memory size
-                        /* stream_ */ 0>>>(
-      tempMemInd->data<IndexType>(), tempMemVal->data<__half>(), 
-      outInd->data<IndexType>(), outVal->data<__half>(), 
-      in->data<__half>(), cols, k, numBlocks, minimal, descending);
+    tempMemVal = allocator->alloc<__half>(tempElts);
+    topK_kernelLauncher<IndexType, __half, true>(in->data<__half>(), 
+                        tempMemInd->data<IndexType>(),
+                        tempMemVal->data<__half>(),
+                        outInd->data<IndexType>(),
+                        outVal->data<__half>(),
+                        rows,
+                        1, // This is the beam size. This is set to 1 since we "trick" the existing implementation to treat a row as a beam
+                        k,
+                        cols,
+                        descending,
+                        cudaStreamPerThread);
 #endif
   } else {
     ABORT("Topk not implemented for type {}", in->type());

--- a/src/tensors/gpu/topk.cu
+++ b/src/tensors/gpu/topk.cu
@@ -41,7 +41,7 @@ void TopK(Tensor outVal, Tensor outInd, Ptr<Allocator> allocator, const Tensor i
   MemoryPiece::PtrType tempMemVal;
   if(in->type() == Type::float32) {
     tempMemVal = allocator->alloc<float>(tempElts);
-    topK_kernelLauncher<IndexType, float, true>(in->data<float>(), 
+    topK_kernelLauncher<IndexType, float, true /*get indices relative to row */>(in->data<float>(), 
                         tempMemInd->data<IndexType>(),
                         tempMemVal->data<float>(),
                         outInd->data<IndexType>(),
@@ -55,7 +55,7 @@ void TopK(Tensor outVal, Tensor outInd, Ptr<Allocator> allocator, const Tensor i
 #if COMPILE_FP16
   } else if(in->type() == Type::float16) {
     tempMemVal = allocator->alloc<__half>(tempElts);
-    topK_kernelLauncher<IndexType, __half, true>(in->data<__half>(), 
+    topK_kernelLauncher<IndexType, __half, true /*get indices relative to row */>(in->data<__half>(), 
                         tempMemInd->data<IndexType>(),
                         tempMemVal->data<__half>(),
                         outInd->data<IndexType>(),

--- a/src/tensors/gpu/topk.cu
+++ b/src/tensors/gpu/topk.cu
@@ -1,3 +1,8 @@
+ /* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include "common/definitions.h"
 #include "tensors/tensor_operators.h"
 #include "tensors/gpu/cuda_helpers.h"

--- a/src/translator/nth_element.cu
+++ b/src/translator/nth_element.cu
@@ -3,6 +3,11 @@
  *   SPDX-License-Identifier: MIT
  */
 
+ /* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include <iostream>
 
 #include "translator/nth_element.h"

--- a/src/translator/nth_element.cu
+++ b/src/translator/nth_element.cu
@@ -58,7 +58,7 @@ private:
     cudaSetDevice(deviceId_.no);
 
     topK_kernelLauncher(probs, topk_tmp_id_buf, (T*)topk_tmp_val_buf, (TopK<IndexType, T>*)tops,
-                        batchSize, beamsPerBatch, beamWidth, vocabSize, 0);    
+                        batchSize, beamsPerBatch, beamWidth, vocabSize, true, 0);    
   }
 
 public:

--- a/src/translator/nth_element.cu
+++ b/src/translator/nth_element.cu
@@ -6,275 +6,12 @@
 #include <iostream>
 
 #include "translator/nth_element.h"
+#include "3rd_party/topk.cuh"
 
 #include <cuda.h>
 #include "tensors/gpu/cuda_helpers.h"
 
 namespace marian {
-
-#define UNROLL_MAXARG_LOOP(n, max)       \
-  if(tid < (n) && tid + (n) < (max)) {   \
-    if(sdata[tid + (n)] > sdata[tid]) {  \
-      sdata[tid] = sdata[tid + (n)];     \
-      indices[tid] = indices[tid + (n)]; \
-    }                                    \
-  }
-
-template <typename T>
-__global__ void gMaxElement(float* d_out,
-                            int* d_ind,
-                            T* d_in, // this is the probs array, only one with type float or half
-                            int numBatches,
-                            int* batchFirstElementIdxs,
-                            float disabledPathScore) // disabledPathScore is used to blank out found values, type-dependent
-{
-  extern __shared__ float sdata[];
-  __shared__ int indices[512];
-
-  int tid = threadIdx.x;
-
-  for(int batchIdx = 0; batchIdx < numBatches; ++batchIdx) {
-    int begin = batchFirstElementIdxs[batchIdx];
-    int end = batchFirstElementIdxs[batchIdx + 1];
-
-    int i = begin + blockIdx.x * (blockDim.x * 2) + tid;
-
-    sdata[tid] = disabledPathScore;
-
-    if(i < end) {
-      sdata[tid] = (float)d_in[i];
-      indices[tid] = i;
-    }
-
-    if(i + blockDim.x < end) {
-      float a = (float)d_in[i];
-      float b = (float)d_in[i + blockDim.x];
-      if(a > b) {
-        sdata[tid] = a;
-        indices[tid] = i;
-      } else {
-        sdata[tid] = b;
-        indices[tid] = i + blockDim.x;
-      }
-    }
-
-    while(i + 2 * gridDim.x * blockDim.x < end) {
-      i += 2 * gridDim.x * blockDim.x;
-
-      float a = (float)d_in[i];
-      if(a > sdata[tid]) {
-        sdata[tid] = a;
-        indices[tid] = i;
-      }
-
-      if(i + blockDim.x < end) {
-        float b = (float)d_in[i + blockDim.x];
-        if(b > sdata[tid]) {
-          sdata[tid] = b;
-          indices[tid] = i + blockDim.x;
-        }
-      }
-    }
-
-    __syncthreads();
-
-    for(int s = (blockDim.x >> 1); s > 32; s >>= 1) {
-      if(tid < s && tid + s < end) {
-        if(sdata[tid + s] > sdata[tid]) {
-          sdata[tid] = sdata[tid + s];
-          indices[tid] = indices[tid + s];
-        }
-      }
-      __syncthreads();
-    }
-
-    UNROLL_MAXARG_LOOP(32, end);
-    UNROLL_MAXARG_LOOP(16, end);
-    UNROLL_MAXARG_LOOP(8, end);
-    UNROLL_MAXARG_LOOP(4, end);
-    UNROLL_MAXARG_LOOP(2, end);
-    UNROLL_MAXARG_LOOP(1, end);
-
-    if(tid == 0) {
-      d_out[blockIdx.x + batchIdx * gridDim.x] = sdata[0];
-      d_ind[blockIdx.x + batchIdx * gridDim.x] = indices[0];
-    }
-    __syncthreads();
-  }
-}
-
-template <typename T>
-__global__ void gMaxElementUpdate(float* binCosts,
-                                  int* binIdxs,
-                                  T* probs, // should work well enough with half, uses float everywhere else
-                                  int* batchFirstElements,
-                                  float* outCosts,
-                                  int* outIdxs,
-                                  int* cumulativeBeamSizes,
-                                  int NUM_BLOCKS,
-                                  float disabledPathScore) {
-  extern __shared__ float sdata[];
-  __shared__ int indices[512];
-  __shared__ float bestBinCost;
-  __shared__ int bestBinCostIdx;
-
-  const int tid = threadIdx.x;
-  const int batchIdx = blockIdx.x;
-  const int N = batchFirstElements[batchIdx + 1] - batchFirstElements[batchIdx];
-  int num_bins = int(N / (2 * 512)) + int(N % (2 * 512) != 0);
-  if(num_bins > 500) {
-    num_bins = 500;
-  }
-
-  for(int pos = cumulativeBeamSizes[batchIdx];
-      pos < cumulativeBeamSizes[batchIdx + 1];
-      ++pos) {
-    int i = tid;
-
-    sdata[tid] = disabledPathScore;
-
-    if(i < num_bins) {
-      sdata[tid] = binCosts[batchIdx * NUM_BLOCKS + i];
-      indices[tid] = i;
-    }
-
-    if(i + blockDim.x < num_bins) {
-      float a = binCosts[batchIdx * NUM_BLOCKS + i];
-      float b = binCosts[batchIdx * NUM_BLOCKS + i + blockDim.x];
-      if(a > b) {
-        sdata[tid] = a;
-        indices[tid] = i;
-      } else {
-        sdata[tid] = b;
-        indices[tid] = i + blockDim.x;
-      }
-    }
-
-    while(i + 2 * blockDim.x < num_bins) {
-      i += 2 * blockDim.x;
-
-      float a = binCosts[batchIdx * NUM_BLOCKS + i];
-      if(a > sdata[tid]) {
-        sdata[tid] = a;
-        indices[tid] = i;
-      }
-
-      if(i + blockDim.x < num_bins) {
-        float b = binCosts[batchIdx * NUM_BLOCKS + i + blockDim.x];
-        if(b > sdata[tid]) {
-          sdata[tid] = b;
-          indices[tid] = i + blockDim.x;
-        }
-      }
-    }
-
-    __syncthreads();
-
-    for(int s = (blockDim.x >> 1); s > 32; s >>= 1) {
-      if(tid < s && tid + s < num_bins) {
-        if(sdata[tid + s] > sdata[tid]) {
-          sdata[tid] = sdata[tid + s];
-          indices[tid] = indices[tid + s];
-        }
-      }
-      __syncthreads();
-    }
-
-    UNROLL_MAXARG_LOOP(32, num_bins);
-    UNROLL_MAXARG_LOOP(16, num_bins);
-    UNROLL_MAXARG_LOOP(8, num_bins);
-    UNROLL_MAXARG_LOOP(4, num_bins);
-    UNROLL_MAXARG_LOOP(2, num_bins);
-    UNROLL_MAXARG_LOOP(1, num_bins);
-
-    if(tid == 0) {
-      bestBinCost = sdata[0];
-      bestBinCostIdx = batchIdx * NUM_BLOCKS + indices[0];
-
-      probs[binIdxs[bestBinCostIdx]] = disabledPathScore;
-
-      outIdxs[pos] = binIdxs[bestBinCostIdx];
-      outCosts[pos] = bestBinCost;
-    }
-
-    __syncthreads();
-
-    i = batchFirstElements[batchIdx]
-        + (bestBinCostIdx - batchIdx * NUM_BLOCKS) * (blockDim.x * 2) + tid;
-    const int dist = num_bins * 2 * blockDim.x;
-
-    sdata[tid] = disabledPathScore;
-
-    if(i < batchFirstElements[batchIdx + 1]) {
-      sdata[tid] = (float)probs[i];
-      indices[tid] = i;
-    }
-
-    if(i + blockDim.x < batchFirstElements[batchIdx + 1]) {
-      float a = (float)probs[i];
-      float b = (float)probs[i + blockDim.x];
-      if(a > b) {
-        sdata[tid] = a;
-        indices[tid] = i;
-      } else {
-        sdata[tid] = b;
-        indices[tid] = i + blockDim.x;
-      }
-    }
-
-    while(i + dist < batchFirstElements[batchIdx + 1]) {
-      i += dist;
-
-      float a = (float)probs[i];
-      if(a > sdata[tid]) {
-        sdata[tid] = a;
-        indices[tid] = i;
-      }
-
-      if(i + blockDim.x < batchFirstElements[batchIdx + 1]) {
-        float b = (float)probs[i + blockDim.x];
-        if(b > sdata[tid]) {
-          sdata[tid] = b;
-          indices[tid] = i + blockDim.x;
-        }
-      }
-    }
-
-    __syncthreads();
-
-    for(int s = (blockDim.x >> 1); s > 32; s >>= 1) {
-      if(tid < s && tid + s < batchFirstElements[batchIdx + 1]) {
-        if(sdata[tid + s] > sdata[tid]) {
-          sdata[tid] = sdata[tid + s];
-          indices[tid] = indices[tid + s];
-        }
-      }
-      __syncthreads();
-    }
-
-    UNROLL_MAXARG_LOOP(32, batchFirstElements[batchIdx + 1]);
-    UNROLL_MAXARG_LOOP(16, batchFirstElements[batchIdx + 1]);
-    UNROLL_MAXARG_LOOP(8, batchFirstElements[batchIdx + 1]);
-    UNROLL_MAXARG_LOOP(4, batchFirstElements[batchIdx + 1]);
-    UNROLL_MAXARG_LOOP(2, batchFirstElements[batchIdx + 1]);
-    UNROLL_MAXARG_LOOP(1, batchFirstElements[batchIdx + 1]);
-
-    if(tid == 0) {
-      binCosts[bestBinCostIdx] = sdata[0];
-      binIdxs[bestBinCostIdx] = indices[0];
-    }
-    __syncthreads();
-  }
-}
-
-__global__ void gGetValueByKey(float* d_in, float* d_out, int* indeces, int n) {
-  int tid = threadIdx.x + blockDim.x * blockIdx.x;
-  if(tid < n) {
-    int index = indeces[tid];
-    d_out[tid] = d_in[index];
-  }
-}
-
 class NthElementGPU {
 public:
   NthElementGPU() = delete;
@@ -284,82 +21,38 @@ public:
                 size_t maxBatchSize,
                 DeviceId deviceId)
       : deviceId_(deviceId),
-        maxBeamSize_(maxBeamSize), maxBatchSize_(maxBatchSize),
-        NUM_BLOCKS(std::min(
-            500,
-            int(maxBeamSize* MAX_VOCAB_SIZE / (2 * BLOCK_SIZE))
-                + int(maxBeamSize* MAX_VOCAB_SIZE % (2 * BLOCK_SIZE) != 0))) {
+        maxBeamSize_(maxBeamSize), maxBatchSize_(maxBatchSize) {
     // std::cerr << "NthElement::NthElement" << std::endl;
 
     cudaSetDevice(deviceId_.no);
 
-    CUDA_CHECK(cudaMalloc((void**)&d_ind, maxBatchSize * NUM_BLOCKS * sizeof(int)));
-    CUDA_CHECK(cudaMalloc((void**)&d_out, maxBatchSize * NUM_BLOCKS * sizeof(float)));
-
-    CUDA_CHECK(cudaMalloc((void**)&d_res_idx, maxBatchSize * maxBeamSize * sizeof(int)));
-    CUDA_CHECK(cudaMalloc((void**)&d_res,     maxBatchSize * maxBeamSize * sizeof(float)));
-
-    CUDA_CHECK(cudaHostAlloc((void**)&h_res,     maxBeamSize * maxBatchSize * sizeof(float), cudaHostAllocDefault));
-    CUDA_CHECK(cudaHostAlloc((void**)&h_res_idx, maxBeamSize * maxBatchSize * sizeof(int), cudaHostAllocDefault));
-
-    CUDA_CHECK(cudaMalloc((void**)&d_breakdown, maxBeamSize * sizeof(float)));
-    CUDA_CHECK(cudaMalloc((void**)&d_batchPosition, (maxBatchSize + 1) * sizeof(int)));
-    CUDA_CHECK(cudaMalloc((void**)&d_cumBeamSizes,  (maxBatchSize + 1) * sizeof(int)));
+    const int tempElts = maxBatchSize * maxBeamSize * maxBeamSize * MAX_BLOCKS_PER_BEAM;
+    CUDA_CHECK(cudaMalloc((void**)&topk_tmp_id_buf, tempElts * sizeof(int)));
+    CUDA_CHECK(cudaMalloc((void**)&topk_tmp_val_buf, tempElts * sizeof(float)));
+    CUDA_CHECK(cudaMalloc((void**)&tops, maxBatchSize * maxBeamSize * sizeof(TopK)));
+    CUDA_CHECK(cudaHostAlloc((void**)&topsHost, maxBeamSize * maxBatchSize * sizeof(TopK), cudaHostAllocDefault));
   }
 
   ~NthElementGPU() {
     // No CUDA error checking as this is a destructor and we cannot do anything about errors anyway.
     cudaSetDevice(deviceId_.no);
-    cudaFree(d_cumBeamSizes);
-    cudaFree(d_batchPosition);
-    cudaFree(d_breakdown);
-    cudaFreeHost(h_res_idx);
-    cudaFreeHost(h_res);
-    cudaFree(d_res);
-    cudaFree(d_res_idx);
-    cudaFree(d_out);
-    cudaFree(d_ind);
+    cudaFree(topk_tmp_id_buf);
+    cudaFree(topk_tmp_val_buf);
+    cudaFree(tops);
+    cudaFreeHost(topsHost);
   }
 
 private:
   template <typename T>
-  void selectNBest(T* probs,
-                   const std::vector<int>& batchFirstElementIdxs,
-                   const std::vector<int>& cumulativeBeamSizes,
-                   float disabledPathScore) {
-
+  void selectNBest(T* probs, 
+                   const int batchSize,
+                   const int beamsPerBatch,
+                   const int beamWidth,
+                   const int vocabSize) {
     cudaSetDevice(deviceId_.no);
-    CUDA_CHECK(cudaMemcpyAsync(d_batchPosition,
-                               batchFirstElementIdxs.data(),
-                               batchFirstElementIdxs.size() * sizeof(int),
-                               cudaMemcpyHostToDevice,
-                               /* stream_ */ 0));
-    CUDA_CHECK(cudaMemcpyAsync(d_cumBeamSizes,
-                               cumulativeBeamSizes.data(),
-                               cumulativeBeamSizes.size() * sizeof(int),
-                               cudaMemcpyHostToDevice,
-                               /* stream_ */ 0));
 
-    const int numBatches = batchFirstElementIdxs.size() - 1;
-
-    gMaxElement<<<NUM_BLOCKS,
-                  BLOCK_SIZE,
-                  BLOCK_SIZE * sizeof(float), // shared memory size
-                  /* stream_ */ 0>>>(
-        d_out, d_ind, probs, numBatches, d_batchPosition, disabledPathScore);
-
-    gMaxElementUpdate<<<numBatches,
-                        BLOCK_SIZE,
-                        BLOCK_SIZE * sizeof(float),  // shared memory size
-                        /* stream_ */ 0>>>(d_out,
-                                           d_ind,
-                                           probs,
-                                           d_batchPosition,
-                                           d_res,
-                                           d_res_idx,
-                                           d_cumBeamSizes,
-                                           NUM_BLOCKS,
-                                           disabledPathScore);
+    topK_kernelLauncher(probs, topk_tmp_id_buf, topk_tmp_val_buf, tops,
+                        batchSize, beamsPerBatch, beamWidth, vocabSize, 0);    
   }
 
 public:
@@ -373,68 +66,42 @@ public:
     const auto vocabSize = scores->shape()[-1];
     const auto inputN    = scores->shape()[-2];
     const auto dimBatch  = scores->shape()[-4];
+
     ABORT_IF(inputN != (isFirst ? 1 : N), "Input tensor has wrong beam dim??"); // @TODO: Remove isFirst argument altogether
     ABORT_IF(vocabSize > MAX_VOCAB_SIZE, "GetNBestList(): actual vocab size {} exceeds MAX_VOCAB_SIZE of {}", vocabSize, MAX_VOCAB_SIZE);
     ABORT_IF(dimBatch > maxBatchSize_, "GetNBestList(): actual batch size {} exceeds initialization parameter {}", dimBatch, maxBatchSize_);
     ABORT_IF(std::max(N, (size_t)inputN) > maxBeamSize_, "GetNBestList(): actual beam size {} exceeds initialization parameter {}", N, maxBeamSize_);
 
-    const std::vector<size_t> beamSizes(dimBatch, N);
-    std::vector<int> cumulativeBeamSizes(beamSizes.size() + 1, 0);    
-    std::vector<int> batchFirstElementIdxs(beamSizes.size() + 1, 0);
-
-     for(size_t batchIdx = 0; batchIdx < beamSizes.size(); ++batchIdx) {
-#if 1
-      cumulativeBeamSizes[batchIdx + 1] = (batchIdx + 1) * (int)N;
-      batchFirstElementIdxs[batchIdx + 1] += (batchIdx + 1) * inputN * vocabSize;
-      ABORT_IF(cumulativeBeamSizes[batchIdx + 1] != cumulativeBeamSizes[batchIdx] + (int)N, "cumulativeBeamSizes wrong??");
-      ABORT_IF((isFirst ? batchIdx + 1 : cumulativeBeamSizes[batchIdx + 1]) != (batchIdx + 1) * inputN, "inputN wrong??");
-#else
-      cumulativeBeamSizes[batchIdx + 1] = cumulativeBeamSizes[batchIdx] + beamSizes[batchIdx];
-      ABORT_IF(cumulativeBeamSizes[batchIdx + 1] != (batchIdx + 1) * N, "cumulativeBeamSizes wrong??");
-      batchFirstElementIdxs[batchIdx + 1]
-          += ((isFirst) ? (batchIdx + 1) : cumulativeBeamSizes[batchIdx + 1]) * vocabSize;
-      ABORT_IF((isFirst ? batchIdx + 1 : cumulativeBeamSizes[batchIdx + 1]) != (batchIdx + 1) * inputN, "inputN wrong??");
-#endif
-    }
-
     if(scores->type() == Type::float32) {
-      float disabledPathScore = NumericLimits<float>(scores->type()).lowest;
-      selectNBest(scores->data<float>(), batchFirstElementIdxs, cumulativeBeamSizes, disabledPathScore);
+      selectNBest(scores->data<float>(), dimBatch, inputN, N, vocabSize);
 #if COMPILE_FP16
     } else if(scores->type() == Type::float16) {
-      float disabledPathScore = NumericLimits<float>(scores->type()).lowest;
-      selectNBest(scores->data<half>(), batchFirstElementIdxs, cumulativeBeamSizes, disabledPathScore);
+      selectNBest(scores->data<half>(), dimBatch, inputN, N, vocabSize);
 #endif
     } else {
       ABORT("getNBestList not implemented for type {}", scores->type());
     }
     getPairs(dimBatch * N, outKeys, outCosts);
-    ABORT_IF(cumulativeBeamSizes.back() != dimBatch * N, "cumulativeBeamSizes.back() wrong??");
+    ABORT_IF(outKeys.size() != dimBatch * N, "Expected {} but got {} values during topk", outKeys.size(), dimBatch * N);
   }
 
 private:
-  void getPairs(size_t number,
+  void getPairs(size_t numElts,
                 std::vector<unsigned>& outKeys,
                 std::vector<float>& outValues) {
     cudaSetDevice(deviceId_.no);
-    CUDA_CHECK(cudaMemcpyAsync(h_res,
-                               d_res,
-                               number * sizeof(float),
+    CUDA_CHECK(cudaMemcpyAsync(topsHost,
+                               tops,
+                               numElts * sizeof(TopK),
                                cudaMemcpyDeviceToHost,
                                /* stream_ */ 0));
-    CUDA_CHECK(cudaMemcpyAsync(h_res_idx,
-                               d_res_idx,
-                               number * sizeof(int),
-                               cudaMemcpyDeviceToHost,
-                               /* stream_ */ 0));
-    cudaStreamSynchronize(/* stream_ */ 0);
 
-    for(size_t i = 0; i < number; ++i) {
-      outKeys.push_back(h_res_idx[i]);
-      outValues.push_back(h_res[i]);
+    CUDA_CHECK(cudaStreamSynchronize(/* stream_ */ 0));
+
+    for(size_t i = 0; i < numElts; ++i) {
+      outKeys.push_back(topsHost[i].p);
+      outValues.push_back(topsHost[i].u);
     }
-
-    //lastN = number;
   }
 
   DeviceId deviceId_;
@@ -443,22 +110,10 @@ private:
   size_t maxBeamSize_;
   size_t maxBatchSize_;
 
-  const int BLOCK_SIZE = 512;
-  const int NUM_BLOCKS;
-
-  int* d_ind;           // [maxBatchSize * NUM_BLOCKS]
-  float* d_out;         // [maxBatchSize * NUM_BLOCKS]
-
-  int* d_res_idx;       // [maxBatchSize * maxBeamSize]
-  float* d_res;         // [maxBatchSize * maxBeamSize]
-
-  int* h_res_idx;       // [maxBeamSize * maxBatchSize]
-  float* h_res;         // [maxBeamSize * maxBatchSize]
-
-  float* d_breakdown;   // [maxBeamSize]
-  int* d_batchPosition; // [maxBatchSize + 1]
-  int* d_cumBeamSizes;  // [maxBatchSize + 1]
-  //size_t lastN;
+  int* topk_tmp_id_buf; // [maxBatchSize * maxBeamSize, maxBeamSize * MAX_BLOCKS_PER_BEAM]
+  float* topk_tmp_val_buf; // [maxBatchSize * maxBeamSize, maxBeamSize * MAX_BLOCKS_PER_BEAM]
+  TopK* tops; // [maxBatchSize, maxBeamSize]
+  TopK* topsHost; // [maxBatchSize, maxBeamSize]
 };
 
 // factory function


### PR DESCRIPTION
### Description
This PR rewrites the topk implementation. It is an optimization to benefit large batch and does not hinder small batch performance. This PR also changes the topk operator in topk.cu to use the new implementation.

There is a temporary template parameter in the topk launcher to enable/disable indexing relative to a given row. This can be removed if nth_element.cu is removed.

Performance improvements relative to PR #768 


Times with 1 stream
--
Batch | Initial Time (s) | Current Time(s) | % Runtime reduction | Speedup factor
-- | -- | -- | -- | --
1 | 166.74 | 166.392 | 0.002087082 | 1.002091447
2 | 114.46 | 113.005 | 0.012711864 | 1.012875536
4 | 69.39 | 69.5436 | -0.002213575 | 0.997791314
8 | 41.52 | 40.7636 | 0.018217726 | 1.01855577
16 | 25.07 | 23.9823 | 0.043386518 | 1.045354282
32 | 15.98 | 14.7954 | 0.074130163 | 1.080065426
64 | 10.57 | 9.6 | 0.091769158 | 1.101041667
128 | 7.15 | 6.48 | 0.093706294 | 1.103395062
256 | 5.39 | 4.65 | 0.13729128 | 1.159139785


Times with 2 streams
--
Batch | Initial Time (s) | Current Time(s) | % Runtime reduction | Speedup factor
-- | -- | -- | -- | --
1 | 119.03 | 116.7 | 0.019574897 | 1.019965724
2 | 79.63 | 78.46 | 0.014692955 | 1.014912057
4 | 48.64 | 47.83 | 0.016652961 | 1.016934978
8 | 29.07 | 28.107 | 0.033126935 | 1.034261928
16 | 17.29 | 16.69 | 0.03470214 | 1.03594967
32 | 10.98 | 10.24 | 0.067395264 | 1.072265625
64 | 7.19 | 6.57 | 0.086230876 | 1.094368341
128 | 5.18 | 4.65 | 0.102316602 | 1.113978495
256 | 4.06 | 3.47 | 0.145320197 | 1.170028818




List of changes:
- Introduces cub as a dependency
- Reimplements the topK kernel and replaces the call in nth_element.cu and topk.cu

Added dependencies: cub

### How to test
Run the unit tests. There are unit tests that cover the topk operator and they all still passed.

CMake command: cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on   -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off -DCOMPILE_TESTS=on

Ubuntu - 18.04.3 LTS
nvcc - 10.1.243
gcc - 7.5.0


### Checklist

- [x ] I have tested the code manually
- [x ] I have run regression tests
- [x ] I have read and followed CONTRIBUTING.md
- [x ] I have updated CHANGELOG.md
