### PR TITLE
Beam search logit refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Batches retrieval of logits from the GPU when the --n-best flag is specified.
 - Add --train-embedder-rank for fine-tuning any encoder(-decoder) model for multi-lingual similarity via softmax-margin loss
 - Add --logical-epoch that allows to redefine the displayed epoch counter as a multiple of n data epochs, updates or labels. Also allows to define width of fractional part with second argument.
 - Add --metrics chrf for computing ChrF according to https://www.aclweb.org/anthology/W15-3049/ and SacreBLEU reference implementation

--- a/src/tensors/gpu/algorithm.cu
+++ b/src/tensors/gpu/algorithm.cu
@@ -150,5 +150,33 @@ template void swap_ranges<float>(Ptr<Backend>, float*, float*, float*);
 template void swap_ranges<double>(Ptr<Backend>, double*, double*, double*);
 // clang-format on
 
+template <typename T>
+__global__ void ggatherIndices(float* d_out, T* d_in, size_t* indices, size_t indicesToGather) {  
+  int index = threadIdx.x + blockDim.x * blockIdx.x;
+  if(index < indicesToGather) {
+    d_out[index] = static_cast<float>(d_in[indices[index]]);
+  }
+}
+
+void gatherIndices(Ptr<Backend> backend, float* d_out, float* d_in, size_t* d_indices, size_t indices_size) {
+  CUDA_CHECK(cudaSetDevice(backend->getDeviceId().no));
+  int threadsPerBlock = std::min(MAX_THREADS, (int)indices_size);
+  int blocks = (indices_size + threadsPerBlock - 1) / threadsPerBlock;
+  ggatherIndices<<<blocks, threadsPerBlock>>>(d_out, d_in, d_indices, indices_size);
+  CUDA_CHECK(cudaStreamSynchronize(0));
+}
+
+void gatherIndices(Ptr<Backend> backend, float* d_out, float16* d_in, size_t* d_indices, size_t indices_size) {
+#if COMPILE_FP16
+  CUDA_CHECK(cudaSetDevice(backend->getDeviceId().no));
+  int threadsPerBlock = std::min(MAX_THREADS, (int)indices_size);
+  int blocks = (indices_size + threadsPerBlock - 1) / threadsPerBlock; 
+  ggatherIndices<<<blocks, threadsPerBlock>>>(d_out, (__half*)d_in, d_indices, indices_size);
+  CUDA_CHECK(cudaStreamSynchronize(0));
+#else
+  ABORT("FP16 not supported with current hardware or CUDA version");
+#endif
+}
+
 }  // namespace gpu
 }  // namespace marian

--- a/src/tensors/gpu/algorithm.h
+++ b/src/tensors/gpu/algorithm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "tensors/backend.h"
+#include "common/types.h"
 
 namespace marian {
 namespace gpu {
@@ -17,5 +18,9 @@ void setSparse(Ptr<marian::Backend> backend,
                const std::vector<size_t>&,
                const std::vector<float>&,
                float*);
+
+void gatherIndices(Ptr<marian::Backend> backend, float* d_out, float* d_in, size_t* d_indices, size_t indices_size);     
+
+void gatherIndices(Ptr<marian::Backend> backend, float* d_out, float16* d_in, size_t* d_indices, size_t indices_size);   
 }  // namespace gpu
 }  // namespace marian

--- a/src/tensors/gpu/algorithm.h
+++ b/src/tensors/gpu/algorithm.h
@@ -1,3 +1,8 @@
+ /* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+ 
 #pragma once
 
 #include "tensors/backend.h"

--- a/src/tensors/tensor.h
+++ b/src/tensors/tensor.h
@@ -1,3 +1,8 @@
+ /* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "common/definitions.h"

--- a/src/tensors/tensor.h
+++ b/src/tensors/tensor.h
@@ -114,8 +114,12 @@ public:
           "The type of the result tensor must be float32.");
 
     if(backend_->getDeviceId().type == DeviceType::cpu) {
+      float* gatheredResultsPtr = gatheredResults->data<float>();
+      size_t* flattenedIndicesPtr = flattenedIndices->data<size_t>();
+      float* dataToGather = data();
+
       for(int i = 0; i < flattenedIndices->size(); ++i) {
-        gatheredResults->set(i, get<float>(flattenedIndices->get<size_t>(i)));
+        gatheredResultsPtr[i] = dataToGather[flattenedIndicesPtr[i]];
       }
     }
   #ifdef CUDA_FOUND

--- a/src/tensors/tensor.h
+++ b/src/tensors/tensor.h
@@ -103,6 +103,35 @@ public:
     return TensorBase::New(mem, Shape{1, (int)size}, type(), backend_);
   }
 
+  void gatherFromIndices(Tensor gatheredResults, Tensor flattenedIndices) {
+    ABORT_IF((flattenedIndices->type() != Type::uint64),
+             "Type of indices must be uint64");
+
+    ABORT_IF(gatheredResults->size() < flattenedIndices->size(), 
+             "The result tensor is too small to hold all of the indexed values.");
+    
+    ABORT_IF(gatheredResults->type() != Type::float32, 
+          "The type of the result tensor must be float32.");
+
+    if(backend_->getDeviceId().type == DeviceType::cpu) {
+      for(int i = 0; i < flattenedIndices->size(); ++i) {
+        gatheredResults->set(i, get<float>(flattenedIndices->get<size_t>(i)));
+      }
+    }
+  #ifdef CUDA_FOUND
+    else {
+      if (type_ == Type::float32) {
+        return gpu::gatherIndices(backend_, gatheredResults->data<float>(), data<float>(), flattenedIndices->data<size_t>(), flattenedIndices->size());
+      } else if(type_ == Type::float16) {
+         return gpu::gatherIndices(backend_, gatheredResults->data<float>(), data<float16>(), flattenedIndices->data<size_t>(), flattenedIndices->size());
+      } else {
+        ABORT("INVALID TYPE FOR OP");
+      }
+    }
+  #endif    
+
+  }
+
   // @TODO: review if we can eliminate GPU-specific code here, 
   // potentially by moving this to non-class members.
   template <typename T>

--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -1,6 +1,8 @@
 #include "translator/beam_search.h"
+#include "tensors/tensor_allocator.h"
 
 #include "data/factored_vocab.h"
+// #include "tensors/tensor_allocator.h"
 #include "translator/helpers.h"
 #include "translator/nth_element.h"
 #include "data/shortlist.h"
@@ -40,6 +42,12 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
     }
   }
 
+  // Hold the flattened logit indices for each state so we can batch retrieval later. Additionally, store the original batch index to we can update the hypothesis in new beams
+  std::vector<size_t> origBatchIndices;
+  std::vector<size_t> oldBeamHypIndices;
+  std::vector<size_t> newBeamHypIndices;
+  std::vector<std::vector<size_t>> flattenedLogitIndices(states.size());
+  
   for(size_t i = 0; i < nBestKeys.size(); ++i) { // [currentDimBatch, beamSize] flattened
     // Keys encode batchIdx, beamHypIdx, and word index in the entire beam.
     // They can be between 0 and (vocabSize * nBestBeamSize * batchSize)-1.
@@ -123,10 +131,8 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
 
     // Set score breakdown for n-best lists
     if(options_->get<bool>("n-best")) {
-      auto breakDown = beam[beamHypIdx]->getScoreBreakdown();
       ABORT_IF(factoredVocab && factorGroup > 0 && !factoredVocab->canExpandFactoredWord(word, factorGroup),
                "A word without this factor snuck through to here??");
-      breakDown.resize(states.size(), 0); // at start, this is empty, so this will set the initial score to 0
       for(size_t j = 0; j < states.size(); ++j) {
         auto lval = states[j]->getLogProbs().getFactoredLogitsTensor(factorGroup); // [maxBeamSize, 1, currentDimBatch, dimFactorVocab]
         // The flatting happens based on actual (current) batch size and batch index computed with batch-pruning as we are looking into the pruned tensor
@@ -136,10 +142,11 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
         ABORT_IF(lval->shape() != Shape({(int)nBestBeamSize, 1, (int)currentDimBatch, (int)vocabSize}) &&
                  (beamHypIdx == 0 && lval->shape() != Shape({1, 1, (int)currentDimBatch, (int)vocabSize})),
                  "Unexpected shape of logits?? {} != {}", lval->shape(), Shape({(int)nBestBeamSize, 1, (int)currentDimBatch, (int)vocabSize}));
-
-        breakDown[j] += lval->get(flattenedLogitIndex);
+        flattenedLogitIndices[j].push_back(flattenedLogitIndex);
       }
-      hyp->setScoreBreakdown(breakDown);
+      newBeamHypIndices.push_back(newBeam.size());
+      origBatchIndices.push_back(origBatchIdx);
+      oldBeamHypIndices.push_back(beamHypIdx);
     }
 
     // Set alignments
@@ -149,6 +156,36 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
       hyp->setAlignment(beam[beamHypIdx]->getAlignment());
 
     newBeam.push_back(hyp);
+  }
+
+  // We need to set the score breakdown outside of the main loop to batch requests. This avoids issuing several 4 byte memcpys when using the GPU backend.
+  if(options_->get<bool>("n-best")) {
+    Tensor indices;
+    Tensor logitsTensor;
+    allocator->allocate(indices, {(int)flattenedLogitIndices[0].size()}, Type::uint64);
+    allocator->allocate(logitsTensor, indices->shape(), Type::float32);
+    std::vector<float> logits(flattenedLogitIndices[0].size());
+
+    for(size_t state = 0; state < states.size(); ++state) {
+      auto lval = states[state]->getLogProbs().getFactoredLogitsTensor(factorGroup); // [maxBeamSize, 1, currentDimBatch, dimFactorVocab]
+      indices->set(flattenedLogitIndices[state]); 
+      lval->gatherFromIndices(logitsTensor, indices);
+      logitsTensor->get(logits);
+
+      for(int i = 0; i < flattenedLogitIndices[state].size(); ++i) {
+        const auto originalBatchIdx = origBatchIndices[i];
+        const auto beamHypIdx = oldBeamHypIndices[i];
+        const auto& beam = beams[originalBatchIdx];
+        auto& newBeam = newBeams[originalBatchIdx];
+
+        auto breakDown = beam[beamHypIdx]->getScoreBreakdown(); 
+        breakDown.resize(states.size(), 0); // at start, this is empty, so this will set the initial score to 0
+        breakDown[state] += logits[i];
+        newBeam[newBeamHypIndices[i]]->setScoreBreakdown(breakDown);
+      }
+    }
+    allocator->free(indices);
+    allocator->free(logitsTensor);
   }
 
   // if factored vocab and this is not the first factor, we need to
@@ -261,6 +298,7 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
   const auto trgUnkId = trgVocab_->getUnkId();
 
   auto getNBestList = createGetNBestListFn(beamSize_, origDimBatch, graph->getDeviceId());
+  allocator = graph->getTensorAllocator();
 
   for(auto scorer : scorers_) {
     scorer->clear(graph);

--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -1,8 +1,12 @@
+ /* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include "translator/beam_search.h"
 #include "tensors/tensor_allocator.h"
 
 #include "data/factored_vocab.h"
-// #include "tensors/tensor_allocator.h"
 #include "translator/helpers.h"
 #include "translator/nth_element.h"
 #include "data/shortlist.h"
@@ -162,8 +166,8 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
   if(options_->get<bool>("n-best")) {
     Tensor indices;
     Tensor logitsTensor;
-    allocator->allocate(indices, {(int)flattenedLogitIndices[0].size()}, Type::uint64);
-    allocator->allocate(logitsTensor, indices->shape(), Type::float32);
+    allocator_->allocate(indices, {(int)flattenedLogitIndices[0].size()}, Type::uint64);
+    allocator_->allocate(logitsTensor, indices->shape(), Type::float32);
     std::vector<float> logits(flattenedLogitIndices[0].size());
 
     for(size_t state = 0; state < states.size(); ++state) {
@@ -184,8 +188,8 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
         newBeam[newBeamHypIndices[i]]->setScoreBreakdown(breakDown);
       }
     }
-    allocator->free(indices);
-    allocator->free(logitsTensor);
+    allocator_->free(indices);
+    allocator_->free(logitsTensor);
   }
 
   // if factored vocab and this is not the first factor, we need to
@@ -298,7 +302,7 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
   const auto trgUnkId = trgVocab_->getUnkId();
 
   auto getNBestList = createGetNBestListFn(beamSize_, origDimBatch, graph->getDeviceId());
-  allocator = graph->getTensorAllocator();
+  allocator_ = graph->getTensorAllocator();
 
   for(auto scorer : scorers_) {
     scorer->clear(graph);

--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -50,7 +50,7 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
   std::vector<size_t> origBatchIndices;
   std::vector<size_t> oldBeamHypIndices;
   std::vector<size_t> newBeamHypIndices;
-  std::vector<std::vector<size_t>> flattenedLogitIndices(states.size());
+  std::vector<std::vector<uint64_t>> flattenedLogitIndices(states.size());
   
   for(size_t i = 0; i < nBestKeys.size(); ++i) { // [currentDimBatch, beamSize] flattened
     // Keys encode batchIdx, beamHypIdx, and word index in the entire beam.
@@ -137,10 +137,10 @@ Beams BeamSearch::toHyps(const std::vector<unsigned int>& nBestKeys, // [current
     if(options_->get<bool>("n-best")) {
       ABORT_IF(factoredVocab && factorGroup > 0 && !factoredVocab->canExpandFactoredWord(word, factorGroup),
                "A word without this factor snuck through to here??");
-      for(size_t j = 0; j < states.size(); ++j) {
+      for(uint64_t j = 0; j < states.size(); ++j) {
         auto lval = states[j]->getLogProbs().getFactoredLogitsTensor(factorGroup); // [maxBeamSize, 1, currentDimBatch, dimFactorVocab]
         // The flatting happens based on actual (current) batch size and batch index computed with batch-pruning as we are looking into the pruned tensor
-        size_t flattenedLogitIndex = (beamHypIdx * currentDimBatch + currentBatchIdx) * vocabSize + wordIdx;  // (beam idx, batch idx, word idx); note: beam and batch are transposed, compared to 'key'
+        uint64_t flattenedLogitIndex = (beamHypIdx * currentDimBatch + currentBatchIdx) * vocabSize + wordIdx;  // (beam idx, batch idx, word idx); note: beam and batch are transposed, compared to 'key'
 
         // @TODO: use a function on shape() to index, or new method val->at({i1, i2, i3, i4}) with broadcasting
         ABORT_IF(lval->shape() != Shape({(int)nBestBeamSize, 1, (int)currentDimBatch, (int)vocabSize}) &&

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -6,12 +6,14 @@
 
 namespace marian {
 
+class TensorAllocator;
 class BeamSearch {
 private:
   Ptr<Options> options_;
   std::vector<Ptr<Scorer>> scorers_;
   size_t beamSize_;
   Ptr<const Vocab> trgVocab_;
+  Ptr<TensorAllocator> allocator;
 
   const float INVALID_PATH_SCORE = std::numeric_limits<float>::lowest(); // @TODO: observe this closely
   const bool PURGE_BATCH = true; // @TODO: diagnostic, to-be-removed once confirmed there are no issues.

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -1,3 +1,8 @@
+ /* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "marian.h"
@@ -13,7 +18,7 @@ private:
   std::vector<Ptr<Scorer>> scorers_;
   size_t beamSize_;
   Ptr<const Vocab> trgVocab_;
-  Ptr<TensorAllocator> allocator;
+  Ptr<TensorAllocator> allocator_;
 
   const float INVALID_PATH_SCORE = std::numeric_limits<float>::lowest(); // @TODO: observe this closely
   const bool PURGE_BATCH = true; // @TODO: diagnostic, to-be-removed once confirmed there are no issues.


### PR DESCRIPTION
### Description

Refactors the beam search when --n-best is specified so the retrieval of logits from the GPU is batched.

On a standard transformer with 3 decoder layers, this change saw improvements of up tp 10% when --n-best is specified. It also has the benefit of reducing CPU - GPU communication.

This does not contain a table similar to other PRs from #743 since the model motivating this change is different from the proxy model used in #743.


List of changes:
- Refactors beam search and adds new tensor operators to support batched retrieval.

Added dependencies: none

### How to test
Ran regression tests and they passed.

CMake command: cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off -DCOMPILE_TESTS=on

Ubuntu - 18.04.3 LTS
nvcc - 10.1.243
gcc - 7.5.0

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
