### PR TITLE
Refactor of beam search to process factor groups in parallel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "src/3rd_party/simple-websocket-server"]
 	path = src/3rd_party/simple-websocket-server
 	url = https://github.com/marian-nmt/Simple-WebSocket-Server
+[submodule "src/3rd_party/cub"]
+	path = src/3rd_party/cub
+	url = https://github.com/NVIDIA/cub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Adds a fast path to perform a max reduction along the last axis to reduce the H2D communication.
+- Refactors the beam search to batch processing of secondary factors for factored vocabulary models.
 - Add --train-embedder-rank for fine-tuning any encoder(-decoder) model for multi-lingual similarity via softmax-margin loss
 - Add --logical-epoch that allows to redefine the displayed epoch counter as a multiple of n data epochs, updates or labels. Also allows to define width of fractional part with second argument.
 - Add --metrics chrf for computing ChrF according to https://www.aclweb.org/anthology/W15-3049/ and SacreBLEU reference implementation

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT=1)
 add_subdirectory(3rd_party)
 
 include_directories(.)

--- a/src/graph/node_operators_unary.h
+++ b/src/graph/node_operators_unary.h
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "tensors/backend.h"
@@ -495,6 +500,9 @@ struct ReduceNodeOp : public UnaryNodeOp {
     case ReduceNodeOpCode::min:
       return {NodeOp(Reduce(_1, min(_1,_2), std::numeric_limits<float>::max(), val_, child(0)->val()))};
     case ReduceNodeOpCode::max:
+      if(axis_ == child(0)->shape().size() - 1 && graph()->getBackend()->getDeviceId().type == DeviceType::gpu ) {
+        return {NodeOp(ReduceMaxLastAxis(val_, child(0)->val()))};
+      }
       return {NodeOp(Reduce(_1, max(_1,_2), std::numeric_limits<float>::lowest(), val_, child(0)->val()))};
     case ReduceNodeOpCode::prod:
       return {NodeOp(Reduce(_1, _1 * _2, 1.0f, val_, child(0)->val()))};

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -90,8 +90,8 @@ namespace marian {
       sel = sel - max(sel, -1);
       
       // Obtain slice for indices
-      size_t start = totalElts * fgIndex;
-      size_t end = totalElts * (fgIndex + 1);
+      int start = (int)totalElts * fgIndex;
+      int end = (int)totalElts * (fgIndex + 1);
       Slice fgSlice(start, end, 1);
       Expr fgIndices = slice(indices, 0, fgSlice);
 

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -77,12 +77,12 @@ namespace marian {
                                                      size_t batchSize, size_t beamSize,
                                                      const std::vector<Expr>& expandedPathScores, 
                                                      float scorerWeight) const {
-    const int totalElts = batchSize * beamSize;
+    const size_t totalElts = batchSize * beamSize;
     std::vector<Expr> updatedPathScores(factorGroups.size());
     auto indices = graph()->indices(hypIndices);
 
     for(int fgIndex = 0; fgIndex < (int)factorGroups.size(); ++fgIndex) {
-      int factorGroup = factorGroups[fgIndex];
+      size_t factorGroup = factorGroups[fgIndex];
       ABORT_IF(factorGroup == 0, "Lemmas not supported");
 
       // Find and subtract max from factor scores
@@ -90,8 +90,8 @@ namespace marian {
       sel = sel - max(sel, -1);
       
       // Obtain slice for indices
-      int start = totalElts * fgIndex;
-      int end = totalElts * (fgIndex + 1);
+      size_t start = totalElts * fgIndex;
+      size_t end = totalElts * (fgIndex + 1);
       Slice fgSlice(start, end, 1);
       Expr fgIndices = slice(indices, 0, fgSlice);
 

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -125,8 +125,10 @@ namespace marian {
     }
 
     // if selIdx are given, then we must reshuffle accordingly
-    if (!hypIndices.empty()) // use the same function that shuffles decoder state
-      sel = rnn::State::select(sel, hypIndices, (int)beamSize, /*isBatchMajor=*/false);
+    if (!hypIndices.empty()) { // use the same function that shuffles decoder state
+      auto indices = graph()->indices(hypIndices);
+      sel = rnn::State::select(sel, indices, (int)beamSize, /*isBatchMajor=*/false);
+    }
     return sel;
   }
 

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -1,3 +1,9 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
+#include "graph/node_initializers.h"
 #include "marian.h"
 
 #include "layers/generic.h"
@@ -65,6 +71,26 @@ namespace marian {
   //  ABORT_IF(!logits_.front()->count(), "getRationalLoss() used on rational loss without count");
   //  return logits_.front();
   //}
+
+  std::vector<Expr> Logits::getSecondaryFactorLogits(std::vector<size_t> factorGroups, const std::vector<IndexType>& hypIndices, size_t batchSize, size_t beamSize) const {
+    const int totalElts = batchSize * beamSize;
+    std::vector<Expr> logProbs(factorGroups.size());
+    auto indices = graph()->indices(hypIndices);
+
+    for(int fgIndex = 0; fgIndex < (int)factorGroups.size(); ++fgIndex) {
+      int factorGroup = factorGroups[fgIndex];
+      ABORT_IF(factorGroup == 0, "Lemmas not supported");
+      int start = totalElts * fgIndex;
+      int end = totalElts * (fgIndex + 1);
+      auto sel = logits_[factorGroup]->loss(); // [localBeamSize, 1, dimBatch, dimFactorVocab]
+      sel = sel - max(sel, -1);
+      Slice fgSlice(start, end, 1);
+      Expr fgIndices = slice(indices, 0, fgSlice);
+      logProbs[fgIndex] = rnn::State::select(sel, fgIndices, (int)beamSize, /*isBatchMajor=*/false);
+    }
+
+    return logProbs;
+  }
 
   // get logits for one factor group
   // For groupIndex == 0, the function also requires the shortlist if there is one.

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -72,24 +72,35 @@ namespace marian {
   //  return logits_.front();
   //}
 
-  std::vector<Expr> Logits::getSecondaryFactorLogits(std::vector<size_t> factorGroups, const std::vector<IndexType>& hypIndices, size_t batchSize, size_t beamSize) const {
+  std::vector<Expr> Logits::getSecondaryFactorLogits(std::vector<size_t> factorGroups, 
+                                                     const std::vector<IndexType>& hypIndices, 
+                                                     size_t batchSize, size_t beamSize,
+                                                     const std::vector<Expr>& expandedPathScores, 
+                                                     float scorerWeight) const {
     const int totalElts = batchSize * beamSize;
-    std::vector<Expr> logProbs(factorGroups.size());
+    std::vector<Expr> updatedPathScores(factorGroups.size());
     auto indices = graph()->indices(hypIndices);
 
     for(int fgIndex = 0; fgIndex < (int)factorGroups.size(); ++fgIndex) {
       int factorGroup = factorGroups[fgIndex];
       ABORT_IF(factorGroup == 0, "Lemmas not supported");
-      int start = totalElts * fgIndex;
-      int end = totalElts * (fgIndex + 1);
+
+      // Find and subtract max from factor scores
       auto sel = logits_[factorGroup]->loss(); // [localBeamSize, 1, dimBatch, dimFactorVocab]
       sel = sel - max(sel, -1);
+      
+      // Obtain slice for indices
+      int start = totalElts * fgIndex;
+      int end = totalElts * (fgIndex + 1);
       Slice fgSlice(start, end, 1);
       Expr fgIndices = slice(indices, 0, fgSlice);
-      logProbs[fgIndex] = rnn::State::select(sel, fgIndices, (int)beamSize, /*isBatchMajor=*/false);
+
+      // Select relevant scores
+      Expr logProbs = rnn::State::select(sel, fgIndices, (int)beamSize, /*isBatchMajor=*/false);
+      updatedPathScores[fgIndex] = expandedPathScores[fgIndex] + scorerWeight * logProbs;
     }
 
-    return logProbs;
+    return updatedPathScores;
   }
 
   // get logits for one factor group

--- a/src/layers/generic.h
+++ b/src/layers/generic.h
@@ -120,7 +120,8 @@ public:
     Logits(std::vector<Ptr<RationalLoss>>&& logits, Ptr<FactoredVocab> embeddingFactorMapping) // factored-output constructor
       : logits_(std::move(logits)), factoredVocab_(embeddingFactorMapping) {}
     Expr getLogits() const; // assume it holds logits: get them, possibly aggregating over factors
-    std::vector<Expr> getSecondaryFactorLogits(std::vector<size_t> factorGroups, const std::vector<IndexType>& hypIndices, size_t batchSize, size_t beamSize) const; // get logits all secondary factor groups in factorGroups vector
+    std::vector<Expr> getSecondaryFactorLogits(std::vector<size_t> factorGroups, const std::vector<IndexType>& hypIndices, size_t batchSize, size_t beamSize,
+                                               const std::vector<Expr>& expandedPathScores, float scorerWeight) const; // get logits all secondary factor groups in factorGroups vector
     Expr getFactoredLogits(size_t groupIndex, Ptr<data::Shortlist> shortlist = nullptr, const std::vector<IndexType>& hypIndices = {}, size_t beamSize = 0) const; // get logits for only one factor group, with optional reshuffle
     //Ptr<RationalLoss> getRationalLoss() const; // assume it holds a loss: get that
     Expr applyLossFunction(const Words& labels, const std::function<Expr(Expr/*logits*/,Expr/*indices*/)>& lossFn) const;

--- a/src/layers/generic.h
+++ b/src/layers/generic.h
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "marian.h"
@@ -115,6 +120,7 @@ public:
     Logits(std::vector<Ptr<RationalLoss>>&& logits, Ptr<FactoredVocab> embeddingFactorMapping) // factored-output constructor
       : logits_(std::move(logits)), factoredVocab_(embeddingFactorMapping) {}
     Expr getLogits() const; // assume it holds logits: get them, possibly aggregating over factors
+    std::vector<Expr> getSecondaryFactorLogits(std::vector<size_t> factorGroups, const std::vector<IndexType>& hypIndices, size_t batchSize, size_t beamSize) const; // get logits all secondary factor groups in factorGroups vector
     Expr getFactoredLogits(size_t groupIndex, Ptr<data::Shortlist> shortlist = nullptr, const std::vector<IndexType>& hypIndices = {}, size_t beamSize = 0) const; // get logits for only one factor group, with optional reshuffle
     //Ptr<RationalLoss> getRationalLoss() const; // assume it holds a loss: get that
     Expr applyLossFunction(const Words& labels, const std::function<Expr(Expr/*logits*/,Expr/*indices*/)>& lossFn) const;

--- a/src/rnn/types.h
+++ b/src/rnn/types.h
@@ -1,5 +1,12 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
+#include "common/definitions.h"
+#include "common/shape.h"
 #include "marian.h"
 
 #include <iostream>
@@ -12,7 +19,7 @@ struct State {
   Expr output;
   Expr cell;
 
-  State select(const std::vector<IndexType>& selIdx, // [beamIndex * activeBatchSize + batchIndex]
+  State select(Expr selIdx, // [beamIndex * activeBatchSize + batchIndex]
                int beamSize, bool isBatchMajor) const {
     return{ select(output, selIdx, beamSize, isBatchMajor),
             select(cell,   selIdx, beamSize, isBatchMajor) };
@@ -20,15 +27,14 @@ struct State {
 
   // this function is also called by Logits
   static Expr select(Expr sel, // [beamSize, dimTime, dimBatch, dimDepth] or [beamSize, dimBatch, dimTime, dimDepth] (dimTime = 1 for RNN)
-                     const std::vector<IndexType>& selIdx, // [beamIndex * activeBatchSize + batchIndex]
+                     Expr selIdx, // [beamIndex * activeBatchSize + batchIndex]
                      int beamSize, bool isBatchMajor)
   {
     if (!sel)
       return sel; // keep nullptr untouched
 
     sel = atleast_4d(sel);
-
-    int dimBatch = (int)selIdx.size() / beamSize;
+    int dimBatch =(int) selIdx->shape().elements()/beamSize;
     int dimDepth = sel->shape()[-1];
     int dimTime  = isBatchMajor ? sel->shape()[-2] : sel->shape()[-3];
 
@@ -83,8 +89,30 @@ public:
   States select(const std::vector<IndexType>& selIdx, // [beamIndex * activeBatchSize + batchIndex]
                 int beamSize, bool isBatchMajor) const {
     States selected;
+    Expr indices;
+    
+    // We need to check if either a states's cell or output fields are non-null. In this case, we need
+    // to select rows from at least one of the tensors. If only some exprs are non-null, the call to
+    // select will handle this for us by returning a null expr naturally.
+    for (auto& state : states_) {
+      if (state.cell) {
+        indices = state.cell->graph()->indices(selIdx);
+        break;
+      }
+
+      if (state.output) {
+        indices = state.output->graph()->indices(selIdx);
+        break;
+      }
+    }
+
+    // If indices is null here, then all of the state.cell and state.output entries are null. Therefore,
+    // select will ignore the null indices expr and simply return a null pointer which is the expected
+    // behavior
+    
+    // GPU OPT: Implement kernel to batch these on GPU
     for(auto& state : states_)
-      selected.push_back(state.select(selIdx, beamSize, isBatchMajor));
+      selected.push_back(state.select(indices, beamSize, isBatchMajor));
     return selected;
   }
 

--- a/src/tensors/cpu/tensor_operators.cpp
+++ b/src/tensors/cpu/tensor_operators.cpp
@@ -3,6 +3,12 @@
  *   SPDX-License-Identifier: MIT
  */
 
+ /* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
+
 #include "tensors/tensor_operators.h"
 #include "tensors/cpu/backend.h"
 #include "tensors/allocator.h"
@@ -21,6 +27,11 @@ namespace marian {
 namespace cpu {
 
   void IsNaN(const Tensor /*in*/, Ptr<Allocator> /*allocator*/, bool& /*isNaN*/, bool& /*isInf*/) {
+  ABORT("Not implemented");
+}
+
+void ReduceMaxLastAxis(Tensor /*out*/,
+                       const marian::Tensor& /*input*/) {
   ABORT("Not implemented");
 }
 

--- a/src/tensors/tensor_operators.h
+++ b/src/tensors/tensor_operators.h
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "common/definitions.h"
@@ -103,6 +108,7 @@ DISPATCH7(Prod, marian::Tensor, const marian::Tensor&, const marian::Tensor&, bo
 DISPATCH8(ProdBatched, marian::Tensor, Ptr<Allocator>, const marian::Tensor, const marian::Tensor, bool, bool, float, float)
 DISPATCH9(CSRProd, marian::Tensor, Ptr<Allocator>, const marian::Tensor&, const marian::Tensor&, const marian::Tensor&, const marian::Tensor&, bool, bool, float)
 
+DISPATCH2(ReduceMaxLastAxis, marian::Tensor, const marian::Tensor&)
 DISPATCH2(Softmax, marian::Tensor, marian::Tensor)
 DISPATCH3(SoftmaxGrad, marian::Tensor, marian::Tensor, marian::Tensor)
 

--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -415,7 +415,7 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
 
           // If none of the factor groups can be expanded
           if(!factorCanExpand && !processingLemmas) {
-            int newElts = currentDimBatch * maxBeamSize;
+            int newElts = currentDimBatch * (int)maxBeamSize;
             hypIndices.resize(hypIndices.size() - newElts);
             prevWords.resize(prevWords.size() - newElts);
             prevScores.resize(prevScores.size() - newElts);
@@ -439,7 +439,7 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
         expandedPathScoresForFactorGroups[0] = prevPathScores;
       } else {
         for(int fgIndex = 0; fgIndex < factorGroupsToExpand.size(); ++fgIndex) {
-          Slice window(fgIndex * maxBeamSize, (fgIndex + 1) * maxBeamSize, 1);
+          Slice window(fgIndex * (int)maxBeamSize, (fgIndex + 1) * (int)maxBeamSize, 1);
           auto scoreSlice = slice(prevPathScores, 0, window);
           scoreSlice = reshape(scoreSlice, {(int)maxBeamSize, 1, (int)currentDimBatch, 1});
           expandedPathScoresForFactorGroups[fgIndex] = scoreSlice;
@@ -513,7 +513,7 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
       // perform beam search
       for(int fgIndex = 0; fgIndex < (int) factorGroupsToExpand.size(); ++fgIndex) {
         Expr expandedPathScores = expandedPathScoresForFactorGroups[fgIndex];
-        int factorGroup = factorGroupsToExpand[fgIndex];
+        int factorGroup = (int)factorGroupsToExpand[fgIndex];
 
         // find N best amongst the (maxBeamSize * dimVocab) hypotheses
         std::vector<unsigned int> nBestKeys; // [currentDimBatch, maxBeamSize] flattened -> (batchIdx, beamHypIdx, word idx) flattened

--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -484,10 +484,8 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
           // INVALID_PATH_SCORE. Instead, toHyps() explicitly propagates those hyps by simply copying the
           // previous hypothesis.
 
-          std::vector<Expr> logProbs =  states[i]->getLogProbs().getSecondaryFactorLogits(factorGroupsToExpand, hypIndices, currentDimBatch, maxBeamSize);
-          for(int fgIndex = 0; fgIndex < (int)factorGroupsToExpand.size(); ++fgIndex) {
-            expandedPathScoresForFactorGroups[fgIndex] = expandedPathScoresForFactorGroups[fgIndex] + scorers_[i]->getWeight() * logProbs[fgIndex];  
-          }
+          expandedPathScoresForFactorGroups =  states[i]->getLogProbs().getSecondaryFactorLogits(factorGroupsToExpand, hypIndices, currentDimBatch, maxBeamSize, 
+                                                                                                 expandedPathScoresForFactorGroups, scorers_[i]->getWeight());
         }
       }
 


### PR DESCRIPTION
### Description
This PR refactors the beam search to process the secondary factors in parallel.

As is, this work significantly reduces the H2D communication required when processing the secondary factors in a model with a factored vocabulary.

Note - The changes in this PR are not integrated into PR #743. The table below shows the improvements on top of PR #770.



Times   with 1 stream
--
Batch | Initial Time (s) | Current Time(s) | % Runtime reduction | Speedup factor
-- | -- | -- | -- | --
1 | 166.392 | 162.169 | 0.025379826 | 1.026040735
2 | 113.005 | 109.386 | 0.032025132 | 1.033084673
4 | 69.5436 | 66.8378 | 0.038907966 | 1.04048308
8 | 40.7636 | 39.2434 | 0.037293075 | 1.038737724
16 | 23.9823 | 23.2354 | 0.031143802 | 1.032144917
32 | 14.7954 | 14.3573 | 0.029610555 | 1.030514094
64 | 9.6 | 9.01939 | 0.060480208 | 1.064373533
128 | 6.48 | 6.04882 | 0.066540123 | 1.071283325
256 | 4.65 | 4.28963 | 0.077498925 | 1.084009577





Times   with 2 streams
--
Batch | Initial Time (s) | Current Time(s) | % Runtime reduction | Speedup factor
-- | -- | -- | -- | --
1 | 116.7 | 110.365 | 0.05428449 | 1.057400444
2 | 78.46 | 74.248 | 0.053683406 | 1.056728801
4 | 47.83 | 45.4441 | 0.049882919 | 1.052501865
8 | 28.107 | 26.7974 | 0.046593375 | 1.048870413
16 | 16.69 | 15.6832 | 0.060323547 | 1.064196082
32 | 10.24 | 9.79104 | 0.04384375 | 1.045854169
64 | 6.57 | 6.22622 | 0.052325723 | 1.055214882
128 | 4.65 | 4.22329 | 0.091765591 | 1.101037343
256 | 3.47 | 3.2422 | 0.065648415 | 1.070260934



List of changes:
- Adds a kernel to perform a max reduction on the last axis of a tensor for GPU. This cuts down on the kernel launches needed and removes a stream synchronize for every call.
- Beam search refactor to batch secondary factors
- Some changes from PR #768 to reduce index copying.

Added dependencies: cub

### How to test
I ran the regression tests and tested manually with a proxy model.

CMake command: cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off -DCOMPILE_TESTS=on

Ubuntu - 18.04.3 LTS
nvcc - 10.1.243
gcc - 7.5.0


### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
