### PR TITLE
Prefer if/else in place of try/catch in FastOpt makeScalar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed compile flags -Ofast to -O3 and remove --ffinite-math
 - Moved old graph groups to depracated folder
 - Make cublas and cusparse handle inits lazy to save memory when unused
+- Replaced exception-based implementation for type determination in FastOpt::makeScalar
 
 ## [1.9.0] - 2020-03-10
 


### PR DESCRIPTION
### Description
This PR refactorizes the code in `FastOpt::makeScalar` to prefer determining the scalar type via if/else rather than try/catch. 

### How to test
This PR passes the relevant unit test (src/tests/units/fastopt_tests.cpp)

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
