### PR TITLE
Factor maxes op

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "src/3rd_party/simple-websocket-server"]
 	path = src/3rd_party/simple-websocket-server
 	url = https://github.com/marian-nmt/Simple-WebSocket-Server
+[submodule "src/3rd_party/cub"]
+	path = src/3rd_party/cub
+	url = https://github.com/NVIDIA/cub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Add new operator to compute path score for lemmas for a factored vocabulary
 - Add --train-embedder-rank for fine-tuning any encoder(-decoder) model for multi-lingual similarity via softmax-margin loss
 - Add --logical-epoch that allows to redefine the displayed epoch counter as a multiple of n data epochs, updates or labels. Also allows to define width of fractional part with second argument.
 - Add --metrics chrf for computing ChrF according to https://www.aclweb.org/anthology/W15-3049/ and SacreBLEU reference implementation

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT=1)
+add_definitions(-DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT=1)
 add_subdirectory(3rd_party)
 
 include_directories(.)

--- a/src/data/factored_vocab.h
+++ b/src/data/factored_vocab.h
@@ -3,6 +3,11 @@
 // and via dynamic_cast to FactoredVocab for factored-specific things used by
 // the Embedding and Output layers.
 
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "common/definitions.h"
@@ -69,6 +74,7 @@ public:
   const std::string& getFactorGroupPrefix(size_t groupIndex) const { return groupPrefixes_[groupIndex]; } // for diagnostics only
   const std::string& getFactorName(size_t groupIndex, size_t factorIndex) const { return factorVocab_[(WordIndex)(factorIndex + groupRanges_[groupIndex].first)]; }
   std::string decodeForDiagnostics(const Words& sentence) const;
+  const std::vector<std::vector<bool>>& getLemmaHasFactorGroupVector() const {return lemmaHasFactorGroup_;};
 
   static constexpr size_t FACTOR_NOT_APPLICABLE = (SIZE_MAX - 1);
   static constexpr size_t FACTOR_NOT_SPECIFIED  = (SIZE_MAX - 2);

--- a/src/graph/expression_graph.h
+++ b/src/graph/expression_graph.h
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "common/config.h"
@@ -26,6 +31,8 @@ private:
 
   typedef std::unordered_map<size_t, std::vector<WExpr>> WeakMemory;
   typedef std::unordered_map<size_t, std::vector<Expr>> Memory;
+
+  std::map<std::string, Expr> memoizationMap_;
 
   Ptr<WeakMemory> shortterm_;
   Ptr<Memory> longterm_;
@@ -97,6 +104,19 @@ public:
       }
     }
     (*shortterm_)[hash].push_back(node.get()); // weakPtr
+    return nullptr;
+  }
+
+  void rememberByName(const std::string& name, Expr e) {
+    ABORT_IF(e == nullptr, "Expression must be non-null");
+    ABORT_IF(e->type() == "param", "Not intended for graph parameters");
+    memoizationMap_[name] = e;
+    findOrRemember(e);
+  }
+
+  Expr findByName(const std::string&name) {
+    if(memoizationMap_.count(name))
+      return findOrRemember(memoizationMap_[name]);
     return nullptr;
   }
 
@@ -470,6 +490,14 @@ public:
 
   // Returns the tensor allocator of the graph workspace, different from above as proper tensor objects are allocated
   Ptr<TensorAllocator> getTensorAllocator() { return tensors_->getTensorAllocator(); }
+
+  void rememberByName(const std::string& name, Expr e) {
+    tensors_->rememberByName(name, e);
+  }
+
+  Expr findByName(const std::string&name) {
+    return tensors_->findByName(name);
+  }
 
   void clear() {
     // clear everything apart from parameters and memoized nodes

--- a/src/graph/expression_operators.cpp
+++ b/src/graph/expression_operators.cpp
@@ -683,19 +683,21 @@ Expr unlikelihood(Expr logits, Expr indices) {
   return -log(gather(1.f - softmax(logits), /*axis=*/-1, indicesWithLayout));
 }
 
-Expr addFactorMaxes(Expr lemmaHasFactorGroup, std::vector<Expr> groupLosses, Expr hypIndices, size_t groupStart, size_t numLemmas) {
+Expr addFactorMaxes(Expr lemmaHasFactorGroup, std::vector<Expr> groupLosses, Expr hypIndices, size_t group0Start) {
   if(groupLosses.size() == 1) {
     return groupLosses[0];
   }
+
+  int numLemmas = groupLosses[0]->shape()[-1];
+
   std::vector<Expr> nodes({lemmaHasFactorGroup});
   if (hypIndices) {
     nodes.push_back(hypIndices);
   }
   nodes.insert(nodes.end(), groupLosses.begin(), groupLosses.end());
   bool hasShortList = hypIndices != nullptr;
-  return Expression<AddFactorMaxesOp>(nodes, hasShortList, groupStart, numLemmas);
+  return Expression<AddFactorMaxesOp>(nodes, hasShortList, group0Start, numLemmas);
 }
-
 
 Expr plus(const std::vector<Expr>& nodes) {
   ABORT_IF(nodes.size() > 1, "Not implemented");

--- a/src/graph/expression_operators.cpp
+++ b/src/graph/expression_operators.cpp
@@ -1,3 +1,7 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */ 
 #include "graph/expression_operators.h"
 #include "layers/constructors.h"
 
@@ -678,6 +682,20 @@ Expr unlikelihood(Expr logits, Expr indices) {
   // This is currently implemented with multiple ops, might be worth doing a special operation like for cross_entropy
   return -log(gather(1.f - softmax(logits), /*axis=*/-1, indicesWithLayout));
 }
+
+Expr addFactorMaxes(Expr lemmaHasFactorGroup, std::vector<Expr> groupLosses, Expr hypIndices, size_t groupStart, size_t numLemmas) {
+  if(groupLosses.size() == 1) {
+    return groupLosses[0];
+  }
+  std::vector<Expr> nodes({lemmaHasFactorGroup});
+  if (hypIndices) {
+    nodes.push_back(hypIndices);
+  }
+  nodes.insert(nodes.end(), groupLosses.begin(), groupLosses.end());
+  bool hasShortList = hypIndices != nullptr;
+  return Expression<AddFactorMaxesOp>(nodes, hasShortList, groupStart, numLemmas);
+}
+
 
 Expr plus(const std::vector<Expr>& nodes) {
   ABORT_IF(nodes.size() > 1, "Not implemented");

--- a/src/graph/expression_operators.h
+++ b/src/graph/expression_operators.h
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+ 
 #pragma once
 #include "graph/expression_graph.h"
 #include "graph/node_initializers.h"
@@ -171,6 +176,8 @@ Expr atleast_2d(Expr a);
 Expr atleast_3d(Expr a);
 Expr atleast_4d(Expr a);
 Expr atleast_nd(Expr a, size_t dims);
+
+Expr addFactorMaxes(Expr lemmaHasFactorGroup, std::vector<Expr> groupLosses, Expr hypIndices, size_t groupStart, size_t numLemmas);
 
 // create a constant of shape a->shape() and initialize with init
 // @TODO: add a && version, to avoid a ref count. NodeInitializers are typically temps.

--- a/src/graph/expression_operators.h
+++ b/src/graph/expression_operators.h
@@ -177,7 +177,7 @@ Expr atleast_3d(Expr a);
 Expr atleast_4d(Expr a);
 Expr atleast_nd(Expr a, size_t dims);
 
-Expr addFactorMaxes(Expr lemmaHasFactorGroup, std::vector<Expr> groupLosses, Expr hypIndices, size_t groupStart, size_t numLemmas);
+Expr addFactorMaxes(Expr lemmaHasFactorGroup, std::vector<Expr> groupLosses, Expr hypIndices, size_t group0Start);
 
 // create a constant of shape a->shape() and initialize with init
 // @TODO: add a && version, to avoid a ref count. NodeInitializers are typically temps.

--- a/src/graph/node_operators_binary.h
+++ b/src/graph/node_operators_binary.h
@@ -1255,7 +1255,7 @@ size_t numLemmas_;
 bool hasShortlist_;
 public:
   AddFactorMaxesOp(const std::vector<Expr>& nodes, bool hasShortlist, size_t groupStart, size_t numLemmas)
-      : NaryNodeOp(nodes, getShape(nodes, hasShortlist), nodes[hasShortlist? 2 : 1]->value_type()) {
+      : NaryNodeOp(nodes, getShape(nodes, hasShortlist), commonType(std::vector<Expr>(nodes.begin() + 1, nodes.end())) ) {
     groupStart_ = groupStart;
     numLemmas_ = hasShortlist? nodes[1]->shape().size(): numLemmas;
     hasShortlist_ = hasShortlist;

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include "marian.h"
 
 #include "layers/generic.h"
@@ -77,15 +82,20 @@ namespace marian {
     //  - lemma: add all maxes of applicable factors
     if (groupIndex > 0) {
       sel = sel - max(sel, -1);
-    }
-    else {
+    } else {
       auto numGroups = getNumFactorGroups();
-      for (size_t g = 1; g < numGroups; g++) {
-        auto factorMaxima = max(logits_[g]->loss(), -1);
-        auto factorMasks = constant(getFactorMasks(g, shortlist ? shortlist->indices() : std::vector<WordIndex>()));
-        sel = sel + factorMaxima * factorMasks; // those lemmas that don't have a factor get multiplied with 0
+      if(numGroups > 1 && graph()->isInference() && graph()->getBackend()->getDeviceId().type == DeviceType::gpu) {
+        Expr shortlistExpr = shortlist? constant(shortlist->indices()) : nullptr;
+        sel = addFactorMaxesHelper(shortlistExpr); 
+      } else {
+        for (size_t g = 1; g < numGroups; g++) {
+          auto factorMaxima = max(logits_[g]->loss(), -1);
+          Expr factorMasks = constant(getFactorMasks(g, shortlist ? shortlist->indices() : std::vector<WordIndex>()));
+          sel = sel + factorMaxima * factorMasks; // those lemmas that don't have a factor get multiplied with 0
+        }
       }
     }
+    
 
     // if selIdx are given, then we must reshuffle accordingly
     if (!hypIndices.empty()) // use the same function that shuffles decoder state
@@ -184,6 +194,48 @@ namespace marian {
       res.push_back((float)factoredVocab_->lemmaHasFactorGroup(lemma, factorGroup));
     }
     return res;
+  }
+
+  Expr Logits::addFactorMaxesHelper(Expr indices) const {
+  auto g = graph();
+  const std::string name = "lemmaHasFactorGroup";
+  auto lemmaHasFactorGroupTensor = g->findByName(name);
+  if(!lemmaHasFactorGroupTensor) {
+      // We want to make this a graph param so the GPU can use this to implement lemmaHasFactorGroup to avoid unneeded memcpys.
+      const auto lemmaHasFactorGroup = factoredVocab_->getLemmaHasFactorGroupVector();
+      int dimLemma = (int)lemmaHasFactorGroup.size();
+      int dimFactorGroup = (int)lemmaHasFactorGroup[0].size();
+
+      for(const auto&  lemma : lemmaHasFactorGroup) {
+        // Paranoid check - Instead of aborting I think we can pad here and copy the array
+        ABORT_IF(lemma.size() != dimFactorGroup, "All groups must be the same size");
+      }
+
+      auto initFunc = [lemmaHasFactorGroup, dimLemma, dimFactorGroup] (Tensor t) {
+        std::vector<int8_t> flattened(dimLemma * dimFactorGroup);
+        int row = 0;
+        for(const auto& v : lemmaHasFactorGroup) {
+          int offset = row * dimFactorGroup;
+          for(int i = 0; i < v.size(); ++i) {
+            flattened[offset + i] = static_cast<int8_t>(v[i]);
+          }
+          ++row;
+        }
+        t->set(flattened);
+      };
+
+      lemmaHasFactorGroupTensor = graph()->constant({dimLemma, dimFactorGroup}, inits::fromLambda(initFunc), Type::int8);
+      lemmaHasFactorGroupTensor->setMemoize(true);
+      g->rememberByName(name, lemmaHasFactorGroupTensor);
+    }
+    size_t n = indices ?  indices->shape().elements() : (factoredVocab_->getGroupRange(0).second - factoredVocab_->getGroupRange(0).first);
+
+    std::vector<Expr> groupLosses(getNumFactorGroups());
+    for(int g = 0; g < getNumFactorGroups(); ++g) {
+      groupLosses[g] = logits_[g]->loss();
+    }
+
+    return addFactorMaxes(lemmaHasFactorGroupTensor, groupLosses, indices, factoredVocab_->getGroupRange(0).first, n);
   }
 
   Logits Logits::applyUnaryFunction(const std::function<Expr(Expr)>& f) const { // clone this but apply f to all loss values

--- a/src/layers/generic.h
+++ b/src/layers/generic.h
@@ -147,6 +147,7 @@ private:
     template<typename T> Expr constant(const std::vector<T>& data) const { return constant(Shape{(int)data.size()}, data); } // same as constant() but assuming vector
     Expr indices(const std::vector<uint32_t>& data) const { return graph()->indices(data); } // actually the same as constant(data) for this data type
     std::vector<float> getFactorMasks(size_t factorGroup, const std::vector<WordIndex>& indices) const;
+    Expr getLemmaHasFactorGroupTensor() const;
     Expr addFactorMaxesHelper(Expr indices=nullptr) const;
 private:
     // members

--- a/src/layers/generic.h
+++ b/src/layers/generic.h
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+ 
 #pragma once
 
 #include "marian.h"
@@ -142,6 +147,7 @@ private:
     template<typename T> Expr constant(const std::vector<T>& data) const { return constant(Shape{(int)data.size()}, data); } // same as constant() but assuming vector
     Expr indices(const std::vector<uint32_t>& data) const { return graph()->indices(data); } // actually the same as constant(data) for this data type
     std::vector<float> getFactorMasks(size_t factorGroup, const std::vector<WordIndex>& indices) const;
+    Expr addFactorMaxesHelper(Expr indices=nullptr) const;
 private:
     // members
     // @TODO: we don't use the RationalLoss component anymore, can be removed again, and replaced just by the Expr

--- a/src/tensors/cpu/tensor_operators.cpp
+++ b/src/tensors/cpu/tensor_operators.cpp
@@ -3,6 +3,11 @@
  *   SPDX-License-Identifier: MIT
  */
 
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include "tensors/tensor_operators.h"
 #include "tensors/cpu/backend.h"
 #include "tensors/allocator.h"
@@ -22,6 +27,16 @@ namespace cpu {
 
   void IsNaN(const Tensor /*in*/, Ptr<Allocator> /*allocator*/, bool& /*isNaN*/, bool& /*isInf*/) {
   ABORT("Not implemented");
+}
+
+void AddFactorMaxes(Tensor /*out*/,
+                    Ptr<Allocator> /*allocator*/,
+                    const Tensor /*lemmaHasFactorGroupTensor*/,
+                    const Tensor /*indices*/,
+                    const std::vector<marian::Tensor>& /*groupLosses*/,
+                    size_t /*groupStart*/,
+                    size_t /*numLemmas*/) {
+  ABORT("AddFactorMaxes not implemented on CPU");
 }
 
 template <typename To, typename From>

--- a/src/tensors/gpu/tensor_operators.cu
+++ b/src/tensors/gpu/tensor_operators.cu
@@ -3100,7 +3100,6 @@ void AddFactorMaxes(Tensor out,
                                                       sizeWithoutInnerDim,
                                                       groupStart, lemmaHasFactorGroupTensor->shape()[1], numLemmas,
                                                       std::numeric_limits<float>::lowest());
-    CUDA_CHECK(cudaStreamSynchronize(0));
     allocator->free(mp_ptrs);
   #if COMPILE_FP16
   } else if(out->type() == Type::float16) {
@@ -3125,7 +3124,6 @@ void AddFactorMaxes(Tensor out,
                                                       sizeWithoutInnerDim,
                                                       groupStart, lemmaHasFactorGroupTensor->shape()[1], numLemmas,
                                                       __float2half(std::numeric_limits<float>::lowest()) );
-    CUDA_CHECK(cudaStreamSynchronize(0));
     allocator->free(mp_ptrs);
   #endif
   } else {

--- a/src/tensors/gpu/tensor_operators.cu
+++ b/src/tensors/gpu/tensor_operators.cu
@@ -23,6 +23,13 @@ __device__ __forceinline__ half max(const half a, const half b) {
 }
 #endif
 
+
+#if CUDA_VERSION >= 11000
+#include <cub/cub.cuh>
+#else
+#include "cub/cub/cub.cuh"
+#endif
+
 namespace marian {
 
 namespace gpu {
@@ -2990,28 +2997,46 @@ __global__ void gAddFactorMaxes(T* out, const int8_t* const lemmaHasFactorGroup,
   extern __shared__ uint8_t _sharedBytes[];
   T* sel = (T*)_sharedBytes;
   T* factorMaximasInBlock = sel + blockDim.x;  
-  T shared[32];
-  
-  // First, each block computes the max across the row for each group and stores in in factorMaximasInBlock[g]
-  for(int g = 1; g < (int)numGroups; ++g) {
-    T* groupLosses = lossAndLastDimSize[g].ptr;
-    int groupLossesInnerDim = lossAndLastDimSize[g].innerDim;
+  typedef cub::WarpReduce<T> WarpReduce;
+  __shared__ typename WarpReduce::TempStorage temp_storage[32]; // Max thread size (1024) divided by warp size (32)
+
+
+  // We exploit the fact that the factor groups (except for the lemmas) tends to be small. Therefore, we perform
+  // all of the reductions across factor groups in parallel by splitting the work across warps.
+  const int lane = threadIdx.x % warpSize;
+  const int wid = threadIdx.x / warpSize;
+  const int numWarps = blockDim.x / warpSize; 
+
+  for(int warpFactorGroup = wid + 1; warpFactorGroup < numGroups; warpFactorGroup+=numWarps) {
+    T* groupLosses = lossAndLastDimSize[warpFactorGroup].ptr;
+    int groupLossesInnerDim = lossAndLastDimSize[warpFactorGroup].innerDim;
     int groupLossSize = groupLossesInnerDim * sizeWithoutInnerDim;
 
-    // Now, we get the max for the factors. If the size of the inner dim is greater than the blocksize,
-    // first reduce maxes so they fit within a block.
     T factorMaxima = minimal;
-    int blockRowStart = blockIdx.x * groupLossesInnerDim;
-    for(int lossCol = threadIdx.x; lossCol < groupLossesInnerDim; lossCol += blockDim.x) {
-      int offset = blockRowStart + lossCol;
-      if(offset < groupLossSize) {        
-        factorMaxima = max(factorMaxima, groupLosses[offset]);
+    // Each block computes the factor maxes within a given row.
+    // We start by each warp computing offset to the row its block is responsible for in the loss
+
+    // This is per warp since groupLossesInnerDim is warp specific and the groupLossesPtr is also warp specific.
+    const int blockRowStart = blockIdx.x * groupLossesInnerDim;
+    for(int lossCol = lane; lossCol < groupLossesInnerDim; lossCol += warpSize) {
+      int warpOffset = blockRowStart + lossCol;
+      if(warpOffset < groupLossSize) {
+        factorMaxima = max(factorMaxima, groupLosses[warpOffset]);
       }
     }
-    dBlockReduceMax(factorMaxima, min(blockDim.x, groupLossesInnerDim), shared, factorMaximasInBlock + g);
-    __syncthreads();  
+
+    // Each warp reduces the accumulated values. Warps can do this in parallel. Then each each writes its final value to shared mem.
+    factorMaxima = WarpReduce(temp_storage[wid]).Reduce(factorMaxima, cub::Max());
+    if(lane == 0) {
+      factorMaximasInBlock[warpFactorGroup] = factorMaxima;
+    }
   }
 
+  // Wait for all warps to write out to shared mem so the second phase of this kernel can proceed.
+  __syncthreads();
+  
+  // First, each block computes the max across the row for each group and stores in in factorMaximasInBlock[g]
+  
   // Each block has the max for each factor, so we iterate over the groups again and accumulate the 
   // output in shared mem one block at a time before writing the results for the row to out
   T* selGlobal = lossAndLastDimSize[0].ptr;

--- a/src/tensors/gpu/tensor_operators.cu
+++ b/src/tensors/gpu/tensor_operators.cu
@@ -1,3 +1,10 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
+#include <limits>
+#include "common/logging.h"
 #include "common/types.h"
 #include "tensors/tensor_operators.h"
 
@@ -2930,5 +2937,143 @@ void PoolingWithMaskingBackward(Tensor adj,
                                            width,
                                            lastWidth);
 }
+
+// Finds max within warp. Assumes val in non-participating warps set to T::min()
+// or a valid non-garbage value
+template<typename T>
+__device__ __forceinline__ T dWarpReduceMax(T val) {
+  constexpr unsigned fullMask = 0xffffffff;
+  #pragma unroll
+  for (int offset = (warpSize / 2); offset > 0; offset /= 2) {
+    val = max(val, __shfl_down_sync(fullMask, val, offset));
+  }
+  return val;
+}
+
+// Elts to reduce must be <= blockDim.x. Needed since factorDims can be varied lengths. 
+template<typename T>
+__device__ __forceinline__ void dBlockReduceMax(T val, int eltsToReduce, volatile T* shared, volatile T* writeLoc) {
+  const int lane = threadIdx.x % warpSize;
+  const int wid = threadIdx.x / warpSize;
+  const int warpsNeeded = (eltsToReduce + warpSize - 1) / warpSize;
+
+  if (wid < warpsNeeded) val = dWarpReduceMax(val);
+  if (lane==0) shared[wid]=val; 
+  __syncthreads(); // Needed to ensure all threads write to shared before reading.       
+
+  //read from shared memory lane only if that warp existed. Otherwise just get first lane.
+  val = (threadIdx.x < warpsNeeded) ? shared[lane] : shared[0];
+  if(wid==0) {
+    T temp = dWarpReduceMax(val);
+    if(lane == 0) writeLoc[0] = temp;
+  }
+}
+
+template <typename T>
+struct ptrInnerDimPair {
+  T* ptr;
+  int innerDim;
+};
+
+template <typename T>
+__global__ void gAddFactorMaxes(T* out, const int8_t* const lemmaHasFactorGroup, const IndexType* const indices, 
+                                ptrInnerDimPair<T>* lossAndLastDimSize, size_t numGroups, size_t sizeWithoutInnerDim, 
+                                size_t groupStart, int lemmaHasFactorGroupWidth, size_t numLemmas, T minimal) {
+
+  extern __shared__ T _sharedMem[];
+  T* sel = _sharedMem;
+  T* factorMaximasInBlock = _sharedMem + blockDim.x;  
+  T shared[32];
+  
+  // First, each block computes the max across the row for each group and stores in in factorMaximasInBlock[g]
+  for(int g = 1; g < (int)numGroups; ++g) {
+    T* groupLosses = lossAndLastDimSize[g].ptr;
+    int groupLossesInnerDim = lossAndLastDimSize[g].innerDim;
+    int groupLossSize = groupLossesInnerDim * sizeWithoutInnerDim;
+
+    // Now, we get the max for the factors. If the size of the inner dim is greater than the blocksize,
+    // first reduce maxes so they fit within a block.
+    T factorMaxima = minimal;
+    int blockRowStart = blockIdx.x * groupLossesInnerDim;
+    for(int lossCol = threadIdx.x; lossCol < groupLossesInnerDim; lossCol += blockDim.x) {
+      int offset = blockRowStart + lossCol;
+      if(offset < groupLossSize) {        
+        factorMaxima = max(factorMaxima, groupLosses[offset]);
+      }
+    }
+    dBlockReduceMax(factorMaxima, min(blockDim.x, groupLossesInnerDim), shared, factorMaximasInBlock + g);
+    __syncthreads();  
+  }
+
+  // Each block has the max for each factor, so we iterate over the groups again and accumulate the 
+  // output in shared mem one block at a time before writing the results for the row to out
+  T* selGlobal = lossAndLastDimSize[0].ptr;
+  const int outTensorInnerDim = lossAndLastDimSize[0].innerDim;
+  const int outputSize = sizeWithoutInnerDim * outTensorInnerDim;
+  const int outRowOffset = blockIdx.x * outTensorInnerDim;
+
+  for(int offset = threadIdx.x; offset < outTensorInnerDim; offset += blockDim.x) {
+    const int outOffset = outRowOffset + offset;
+    if(outOffset < outputSize) sel[threadIdx.x] = selGlobal[outOffset]; 
+
+    // Accumulate the row's portion in shared memory
+    for(int g = 1; g < (int)numGroups; ++g) {
+      int lemma = indices? indices[offset] - groupStart: offset;
+      T factorMask = static_cast<T>(lemmaHasFactorGroup[lemma * lemmaHasFactorGroupWidth + g]);
+      T factorMaxima = factorMaximasInBlock[g];
+
+      if(outOffset < outputSize) {
+        sel[threadIdx.x] += (factorMask * factorMaxima);
+      }
+    }
+    if(outOffset < outputSize) out[outOffset] = sel[threadIdx.x];
+  }
+}
+
+void AddFactorMaxes(Tensor out,
+                    Ptr<Allocator> allocator,
+                    const Tensor lemmaHasFactorGroupTensor,
+                    const Tensor indices,
+                    const std::vector<marian::Tensor>& groupLosses,
+                    size_t groupStart,
+                    size_t numLemmas) {
+
+  cudaSetDevice(out->getDeviceId().no);
+
+  ABORT_IF(lemmaHasFactorGroupTensor->type() != Type::int8, "lemmaHasFactor group tensor wrong type");
+  ABORT_IF(out->shape()[-1] != (int) numLemmas, "Output shape {} or numLemmas {} incorrect", out->shape(), numLemmas);
+
+  const int threads = std::min(MAX_THREADS, std::max(32, out->shape()[-1]));
+  const int sizeWithoutInnerDim = out->shape().elements() / out->shape()[-1];
+
+  if(out->type() == Type::float32) {
+    IPtr<MemoryPiece> mp_ptrs = allocator->alloc<ptrInnerDimPair<float>>(groupLosses.size()); 
+    ptrInnerDimPair<float>* dest = mp_ptrs->data<ptrInnerDimPair<float>>();
+
+    std::vector<ptrInnerDimPair<float>> lossPtrs;
+    for(const auto& t : groupLosses) {
+      ptrInnerDimPair<float> pair = {t->data<float>(), t->shape()[-1]};
+      lossPtrs.push_back(pair);
+    }
+
+    // Async just so that call is issued in per thread default stream
+    CUDA_CHECK(cudaMemcpyAsync(dest, lossPtrs.data(), lossPtrs.size() * sizeof(ptrInnerDimPair<float>), cudaMemcpyHostToDevice, 0));
+    const int blocks = sizeWithoutInnerDim;
+    const int sharedBytes = sizeof(float) * (groupLosses.size() + threads);
+    gAddFactorMaxes<<<blocks, threads, sharedBytes>>>(out->data<float>(), 
+                                                      lemmaHasFactorGroupTensor->data<int8_t>(), 
+                                                      indices? indices->data<IndexType>(): nullptr, 
+                                                      dest,
+                                                      groupLosses.size(),
+                                                      sizeWithoutInnerDim,
+                                                      groupStart, lemmaHasFactorGroupTensor->shape()[1], numLemmas,
+                                                      std::numeric_limits<float>::lowest());
+    CUDA_CHECK(cudaStreamSynchronize(0));
+    allocator->free(mp_ptrs);
+  } else {
+    ABORT("AddFactorMaxes not implemented for type {}", out->type());
+  }
+}
+
 }  // namespace gpu
 }  // namespace marian

--- a/src/tensors/tensor_operators.h
+++ b/src/tensors/tensor_operators.h
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+ 
 #pragma once
 
 #include "common/definitions.h"
@@ -119,6 +124,8 @@ DISPATCH5(Shift, marian::Tensor, marian::Tensor, marian::Shape, float, bool)
 DISPATCH4(ShiftGrad, marian::Tensor, marian::Tensor, marian::Shape, bool)
 
 DISPATCH3(Concatenate, marian::Tensor, const std::vector<marian::Tensor>&, int)
+
+DISPATCH7(AddFactorMaxes, marian::Tensor, Ptr<Allocator>, const marian::Tensor, const marian::Tensor, const std::vector<marian::Tensor>&, size_t, size_t)
 
 // clang-format on
 

--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -1,3 +1,8 @@
+/* Part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
+
 #include "translator/beam_search.h"
 
 #include "data/factored_vocab.h"
@@ -396,7 +401,8 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
         }
         if(factorGroup == 0)
           currentDimBatch = (IndexType) batchIndices.size(); // keep batch size constant for all factor groups in a time step
-        prevPathScores = graph->constant({(int)maxBeamSize, 1, (int)currentDimBatch, 1}, inits::fromVector(prevScores));
+        // Avoid unnecessary memcpy on GPU  
+        if(anyCanExpand) prevPathScores = graph->constant({(int)maxBeamSize, 1, (int)currentDimBatch, 1}, inits::fromVector(prevScores));
       }
       if (!anyCanExpand) // all words cannot expand this factor: skip
         continue;


### PR DESCRIPTION
### Description
This PR adds a new inference operator to GPU for getting the lemma logits for a factored vocabulary. It demonstrates significant speedup on GPU inference over PR #772 

Here are some perf numbers relative to PR #772 

Times from a proxy model with 1 stream as measured on a Titan V.

Batch | Time from #772 (s) | Current Time(s) | Speedup factor
-- | -- | -- | --
1 | 162.169 | 105.638 | 1.53513887
2 | 109.386 | 73.2865 | 1.492580489
4 | 66.8378 | 45.1652 | 1.479851744
8 | 39.2434 | 27.1344 | 1.446260098
16 | 23.2354 | 16.1808 | 1.43598586
32 | 14.3573 | 10.1867 | 1.4094162
64 | 9.01939 | 6.45151 | 1.398027749
128 | 6.04882 | 4.39468 | 1.376396006
256 | 4.28963 | 3.2189 | 1.332638479

Times from a proxy model with two streams as measured on a Titan V

Batch | Time from #772 (s) | Current Time(s) | Speedup factor
-- | -- | -- | --
1 | 110.365 | 94.137 | 1.172387053
2 | 74.248 | 61.736 | 1.202669431
4 | 45.4441 | 37.2677 | 1.219396421
8 | 26.7974 | 21.81 | 1.22867492
16 | 15.6832 | 12.6072 | 1.243987563
32 | 9.79104 | 7.70231 | 1.271182282
64 | 6.22622 | 4.86047 | 1.280991344
128 | 4.22329 | 3.3429 | 1.263361153
256 | 3.2422 | 2.52556 | 1.28375489


List of changes:
- Adds a new operator used only for GPU inference 
- Adds a cache by name function to the expression graph so store a tensor containing whether each lemma has a given factor group. (There may be a better way to do this but it wasn't obvious to me). This tensor needs to reside permanently on the GPU since the D2H copy time would be too great for this optimization to be worthwhile otherwise.

Added dependencies: cub

### How to test
I ran the regression tests and they all passed. I also manually tested on a proxy model and the outputs from master exactly match the outputs after this change was made.

CMake command: cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off -DCOMPILE_TESTS=on

Ubuntu - 18.04.3 LTS
nvcc - 10.1.243
gcc - 7.5.0

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
