### PR TITLE
Adds some cuda 11 FP16 SPMM support and fixes beam search to work with FP16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Changes the invalid path score in the beam search to be negative infinity instead of the lowest float. The beam search did not work with fp16 for factored vocab models due to float min being cast to fp16.
+- Adds spmm fp16 support for CUDA 11
 - Add --train-embedder-rank for fine-tuning any encoder(-decoder) model for multi-lingual similarity via softmax-margin loss
 - Add --logical-epoch that allows to redefine the displayed epoch counter as a multiple of n data epochs, updates or labels. Also allows to define width of fractional part with second argument.
 - Add --metrics chrf for computing ChrF according to https://www.aclweb.org/anthology/W15-3049/ and SacreBLEU reference implementation

--- a/src/tensors/gpu/prod.cpp
+++ b/src/tensors/gpu/prod.cpp
@@ -387,6 +387,7 @@ static cusparseSgemmiEx(cusparseHandle_t handle, int m,
 }
 
 // Computes C = A x B for row-major matrices where C is dense, A is sparse and B is dense
+#if CUDA_VERSION >= 11000
 cusparseStatus_t static cusparseSpMMTyped(cusparseHandle_t handle,
                                           Ptr<Allocator> allocator,
                                           bool transA, bool transB,
@@ -432,6 +433,7 @@ cusparseStatus_t static cusparseSpMMTyped(cusparseHandle_t handle,
 
   return status;
 }
+#endif
 
 // @TODO: make this work with fp16
 

--- a/src/tests/units/operator_tests.cpp
+++ b/src/tests/units/operator_tests.cpp
@@ -1,3 +1,7 @@
+/* All or part of this file was contributed by NVIDIA under license:
+ *   Copyright (C) 2020 NVIDIA Corporation
+ *   SPDX-License-Identifier: MIT
+ */
 #include "catch.hpp"
 #include "graph/expression_graph.h"
 #include "graph/expression_operators.h"

--- a/src/tests/units/operator_tests.cpp
+++ b/src/tests/units/operator_tests.cpp
@@ -1,7 +1,3 @@
-/* All or part of this file was contributed by NVIDIA under license:
- *   Copyright (C) 2020 NVIDIA Corporation
- *   SPDX-License-Identifier: MIT
- */
 #include "catch.hpp"
 #include "graph/expression_graph.h"
 #include "graph/expression_operators.h"

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -13,7 +13,7 @@ private:
   size_t beamSize_;
   Ptr<const Vocab> trgVocab_;
 
-  const float INVALID_PATH_SCORE = std::numeric_limits<float>::lowest(); // @TODO: observe this closely
+  const float INVALID_PATH_SCORE = -std::numeric_limits<float>::infinity(); // @TODO: observe this closely
   const bool PURGE_BATCH = true; // @TODO: diagnostic, to-be-removed once confirmed there are no issues.
 
 public:

--- a/src/translator/nth_element.cu
+++ b/src/translator/nth_element.cu
@@ -398,11 +398,11 @@ public:
     }
 
     if(scores->type() == Type::float32) {
-      float disabledPathScore = NumericLimits<float>(scores->type()).lowest;
+      float disabledPathScore = -std::numeric_limits<float>::infinity(); 
       selectNBest(scores->data<float>(), batchFirstElementIdxs, cumulativeBeamSizes, disabledPathScore);
 #if COMPILE_FP16
     } else if(scores->type() == Type::float16) {
-      float disabledPathScore = NumericLimits<float>(scores->type()).lowest;
+      float disabledPathScore = -std::numeric_limits<float>::infinity(); 
       selectNBest(scores->data<half>(), batchFirstElementIdxs, cumulativeBeamSizes, disabledPathScore);
 #endif
     } else {


### PR DESCRIPTION
### Description

This PR aims to allow factored vocabulary models to use FP16 with CUDA 11. It also fixes the beam search so that factored vocabulary models work with FP16.

List of changes:
- Adds a new code path in CSRProd for fp16 to support the simple SPMM case (no swapping or transposing)
- Changes getFactorLogits to use the graph constant method so that the factorMasks are casted to FP16 when the graph default type is fp16.
- Changes the INVALID_PATH_SCORE  in the beam search to negative infinity instead of float min. When running FP16, the float min was being cast to FP16 causing it to be -inf. This caused the beam search to fail when creating new hypotheses. I chose to set the INVALID_PATH_SCORE to -infinity since it maintains the same value before and after the cast so we can reliably check for this regardless of if we are using FP32 or FP16.
- Changes the minimal value in TopK to be negative infinity to account for the change above.

Added dependencies: none

### How to test

I ran the regression tests and most passed with CUDA 11. With CUDA 10, the regression tests pass as expected. I also manually tested on a proxy model with fp16 and it no longer gives errors. The results from the proxy model look sensible.

CMake command: cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off -DCOMPILE_TESTS=on

Ubuntu - 18.04.3 LTS
nvcc - 10.1.243
gcc - 7.5.0

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
