### PR TITLE
Update simple-websocket-server to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for using Apple Accelerate as the BLAS library
 
 ### Fixed
+- Fix building server with Boost 1.75
 - Segfault of spm_train when compiled with -DUSE_STATIC_LIBS=ON seems to have gone away with update to newer SentencePiece version.
 - Fix bug causing certain reductions into scalars to be 0 on the GPU backend. Removed unnecessary warp shuffle instructions.
 - Do not apply dropout in embeddings layers during inference with dropout-src/trg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix building server with Boost 1.75
+
 ## [1.10.0] - 2021-02-06
 
 ### Added
@@ -38,7 +41,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for using Apple Accelerate as the BLAS library
 
 ### Fixed
-- Fix building server with Boost 1.75
 - Segfault of spm_train when compiled with -DUSE_STATIC_LIBS=ON seems to have gone away with update to newer SentencePiece version.
 - Fix bug causing certain reductions into scalars to be 0 on the GPU backend. Removed unnecessary warp shuffle instructions.
 - Do not apply dropout in embeddings layers during inference with dropout-src/trg


### PR DESCRIPTION
### Description

This adds support for boost 1.75 for `marian-server`

Closes #796 

List of changes:
- Updated simple websocket server to the latest version

Added dependencies: none

### How i tested things
#### Regression tests
I ran only the regression tests under `tests/server`.

On Arch Linux with Boost 1.75 i ran the regression tests using a cpu-only build of marian.
```
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=YES -DCOMPILE_CUDA=off -DCOMPILE_SERVER=ON -DCOMPILE_TESTS=ON
```

On Ubuntu with Boost 1.65 i ran the regression tests on a gpu-supporting build of marian.
```
cmake .. -DCOMPILE_SERVER=ON
```

#### Regular tests
Using the Ubuntu setup with the older Boost i ran the regular tests for marian.
```
cmake .. -DCOMPILE_SERVER=ON -DCOMPILE_TESTS=ON
make -j
make test
```

The 2nd test fails but i checked that the same thing happens on master.
```Running tests...
Test project /home/TILDE.LV/rihards.krislauks/src/marian-orig/build
    Start 1: graph_tests
1/6 Test #1: graph_tests ......................   Passed    0.97 sec
    Start 2: operator_tests
2/6 Test #2: operator_tests ...................***Exception: Child aborted  3.12 sec
    Start 3: rnn_tests
3/6 Test #3: rnn_tests ........................   Passed    2.02 sec
    Start 4: attention_tests
4/6 Test #4: attention_tests ..................   Passed    1.89 sec
    Start 5: fastopt_tests
5/6 Test #5: fastopt_tests ....................   Passed    0.13 sec
    Start 6: utils_tests
6/6 Test #6: utils_tests ......................   Passed    0.15 sec

83% tests passed, 1 tests failed out of 6

Total Test time (real) =   8.35 sec

The following tests FAILED:
	  2 - operator_tests (Child aborted)
Errors while running CTest
Makefile:129: recipe for target 'test' failed
make: *** [test] Error 8
```


### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
