### PR TITLE
Generate documentation artifact with GitHub action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,47 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  api-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Doxygen
+        run: sudo apt-get install -y doxygen
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('doc/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        working-directory: ./doc
+        run: pip install -r requirements.txt
+
+      - name: Build documentation
+        working-directory: ./doc
+        run: make html
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v2
+        with:
+          name: api-docs
+          path: ./doc/build/html
+          if-no-files-found: error


### PR DESCRIPTION
### Description
Automates the building of the documentation in `doc/` and provides a downloadable artifact. Runs on pushes and PRs to master.

Closes #813

List of changes:
- Adds new documentation workflow using GitHub actions.

Added dependencies: none

### How to test
Tested in a fork. Workflow uses `ubuntu-latest` which is currently 18.04. I have also tested 20.04 explicitly due to actions/virtual-environments#1816

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests *not needed*
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
