### PR TITLE
Fix fallback to default paths in MNIST example

### DIFF
--- a/src/examples/mnist/mnist_ffnn.cpp
+++ b/src/examples/mnist/mnist_ffnn.cpp
@@ -24,9 +24,9 @@ using namespace marian;
 int main(int argc, char** argv) {
   auto options = parseOptions(argc, argv, cli::mode::training, false);
 
-  if(!options->has("train-sets"))
+  if(!options->hasAndNotEmpty("train-sets"))
     options->set("train-sets", TRAIN_SET);
-  if(!options->has("valid-sets"))
+  if(!options->hasAndNotEmpty("valid-sets"))
     options->set("valid-sets", VALID_SET);
 
   if(options->get<std::string>("type") != "mnist-lenet")


### PR DESCRIPTION
### Description
The MNIST example does not fallback to the hard-coded paths as the default config has an empty entry for `train-sets` and `valid-sets`. This PR checks that these options are non-empty.

List of changes:
- Replace `has` with `hasAndNotEmpty` in MNIST example setup.

Added dependencies: none

### How to test
In progress...

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
