### PR TITLE
Fix OMP compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Correct training with fp16 via `--fp16`. 
 - Dynamic cost-scaling with `--cost-scaling`.
 - Dynamic gradient-scaling with `--dynamic-gradient-scaling`.
+- Fix compilation with OMP
 
 ### Fixed
 - Find MKL installed under Ubuntu 20.04 via apt-get

--- a/src/tensors/cpu/tensor_operators.cpp
+++ b/src/tensors/cpu/tensor_operators.cpp
@@ -914,13 +914,13 @@ void CrossEntropyPick(Tensor out, Tensor in, Tensor labelIndices, float labelSmo
     }
 
     float sumexp = 0.f;
-    #pragma omp simd reduction(+ : sum)
+    #pragma omp simd reduction(+ : sumexp)
     for(int i = 0; i < cols; ++i) {
       sumexp += std::exp(sp[i] - max);
     }
 
     float mean = 0.f;
-    #pragma omp simd reduction(+ : sum)
+    #pragma omp simd reduction(+ : mean)
     for(int i = 0; i < cols; ++i) {
       mean += sp[i] - max;
     }


### PR DESCRIPTION
### Description
Currently marian does not compile with `-DUSE_OPENMP=ON`.  

The variable names for OMP pragmas no longer matched the variables in question.  This change fixes them to match.  

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
