### PR TITLE
Update GitHub workflows with Ubuntu+CUDA

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
             examples: false
           # Ubuntu GPU-only build
           - name: "Ubuntu GPU-only"
-            os: ubuntu-latest
+            os: ubuntu-18.04
             cuda: "10.2"
             gcc: 7
             cpu: false
@@ -30,14 +30,15 @@ jobs:
             unit_tests: false
             examples: true
           # Ubuntu 20.04 supports CUDA 11+
-          #- name: "Ubuntu 20.04 CUDA 11.0 gcc-9"
-            #os: ubuntu-20.04
-            #cuda: "11.0"
-            #gcc: 9
-            #cpu: false
-            #gpu: true
-            #unit_tests: false
-            #examples: false
+          # Unit tests and examples are not compiled to save disk space
+          - name: "Ubuntu 20.04 CUDA 11.2 gcc-9"
+            os: ubuntu-20.04
+            cuda: "11.2"
+            gcc: 9
+            cpu: false
+            gpu: true
+            unit_tests: false
+            examples: false
           # Ubuntu 18.04 supports CUDA 10.1+
           # Unit tests and examples are not compiled to save disk space
           - name: "Ubuntu 18.04 CUDA 10.2 gcc-8"


### PR DESCRIPTION
Updating workflows with Ubuntu and CUDA after the image 'ubuntu-latest' has been updated to Ubuntu 20.04 on GitHub-hosted runners, and the newer distro does not support CUDA<11.

PR also adds a build on Ubuntu 20.04 with CUDA 11.2 and GCC 9.