### PR TITLE
Fix broken links to MNIST data sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix building server with Boost 1.75
 - Missing implementation for cos/tan expression operator
 - Missing float template specialisation for elem::Plus
+- Broken links to MNIST data sets
 
 ### Changed
 - Change compile options a la -DCOMPILE_CUDA_SM35 to -DCOMPILE_KEPLER, -DCOMPILE_MAXWELL,

--- a/src/examples/mnist/download.sh
+++ b/src/examples/mnist/download.sh
@@ -5,9 +5,6 @@ if [ `ls -1 *-ubyte 2>/dev/null | wc -l ` == 4 ]; then
     exit;
 fi
 
-wget http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
-wget http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
-wget http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
-wget http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
-
-gzip -d *-ubyte.gz
+wget https://romang.blob.core.windows.net/mariandev/regression-tests/data/exdb_mnist.tar.gz
+tar zxvf exdb_mnist.tar.gz
+mv exdb_mnist/*-ubyte .


### PR DESCRIPTION
### Description
We have been downloading MNIST data sets from external links, which are dead now. I moved the MNIST data to our Azure storage and this PR updates the links and regression tests accordingly.

Added dependencies: none

### How to test
Run regression tests for MNIST example.

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
