### PR TITLE
Compute tensor size using integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Dynamic gradient-scaling with `--dynamic-gradient-scaling`.
 - Add unit tests for binary files.
 - Fix compilation with OMP
+- Compute aligned memory sizes using exact sizing
 
 ### Fixed
 - Fixed an issue when loading intgemm16 models from unaligned memory.

--- a/src/tensors/allocator.h
+++ b/src/tensors/allocator.h
@@ -175,8 +175,9 @@ public:
     reserve(bytes);
   }
 
-  size_t alignedSize(size_t size) {
-    return (size_t)(ceil(size / (double)alignment_) * alignment_);
+  size_t alignedSize(size_t size) const {
+    size_t over = size + alignment_ - 1;
+    return over - (over % alignment_);
   }
 
   void throwAtReallocation(bool throwRealloc) { throw_ = throwRealloc; }

--- a/src/tensors/device.h
+++ b/src/tensors/device.h
@@ -15,8 +15,9 @@ protected:
   size_t size_{0};
   size_t alignment_;
 
-  size_t align(size_t size) {
-    return (size_t)(ceil(size / (float)alignment_) * alignment_);
+  size_t align(size_t size) const {
+    size_t over = size + alignment_ - 1;
+    return over - (over % alignment_);
   }
 
 public:


### PR DESCRIPTION
### Description

Use exact integer arithmetic to compute `alignedSize`

If intdiv is too slow we can always force alignment_ to be a power of 2
then just use (size + alignment_ - 1) & ~(alignment_ - 1)

### How to test

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
