### PR TITLE
Returns translated sentences immediately in beam search

### DIFF
--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -1,5 +1,5 @@
 # It is recommended to use a machine which supports CUDA to build this image.
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 AS BUILDER
+FROM nvidia/cuda:11.1-cudnn8-devel-ubuntu18.04 AS BUILDER
 RUN apt-get update --fix-missing
 RUN apt-get install -y curl git autoconf automake libtool curl make g++ unzip cmake build-essential cpio
 RUN apt-get -y clean && \
@@ -42,7 +42,7 @@ RUN ./b2 install --prefix=/usr --with-system --with-thread --with-date_time --wi
 
 # Marian install
 WORKDIR /
-RUN  git clone --no-checkout   https://github.com/rhenry-nv/marian-dev.git
+RUN  git clone --no-checkout https://github.com/rhenry-nv/marian-dev.git
 WORKDIR marian-dev
 RUN git checkout async_return
 RUN mkdir src/static
@@ -55,7 +55,7 @@ COPY src/CMakeLists.txt /marian-dev/src
 WORKDIR /marian-dev/build
 RUN cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on  \ 
              -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off \
-             -DCUDA_cublas_device_LIBRARY=/usr/lib/x86_64-linux-gnu/libcublas.so
+             -DCUDA_cublas_device_LIBRARY=/usr/local/cuda/lib64/libcublas.so
 
 RUN make -j $(grep -c ^processor /proc/cpuinfo)
 

--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -54,7 +54,7 @@ COPY src/CMakeLists.txt /marian-dev/src
 
 WORKDIR /marian-dev/build
 RUN cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on  \ 
-             -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off \
+             -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=on \
              -DCUDA_cublas_device_LIBRARY=/usr/local/cuda/lib64/libcublas.so
 
 RUN make -j $(grep -c ^processor /proc/cpuinfo)

--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -42,7 +42,7 @@ RUN ./b2 install --prefix=/usr --with-system --with-thread --with-date_time --wi
 
 # Marian install
 WORKDIR /
-RUN  git clone --no-checkout https://github.com/rhenry-nv/marian-dev.git 
+RUN git clone --no-checkout https://github.com/rhenry-nv/marian-dev.git 
 WORKDIR marian-dev
 RUN git checkout async
 RUN mkdir src/static

--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -42,7 +42,7 @@ RUN ./b2 install --prefix=/usr --with-system --with-thread --with-date_time --wi
 
 # Marian install
 WORKDIR /
-RUN git clone --no-checkout https://github.com/rhenry-nv/marian-dev.git
+RUN  git clone --no-checkout   https://github.com/rhenry-nv/marian-dev.git
 WORKDIR marian-dev
 RUN git checkout async_return
 RUN mkdir src/static

--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -42,10 +42,9 @@ RUN ./b2 install --prefix=/usr --with-system --with-thread --with-date_time --wi
 
 # Marian install
 WORKDIR /
-RUN git clone --no-checkout https://github.com/marian-nmt/marian-dev
+RUN git clone --no-checkout https://github.com/rhenry-nv/marian-dev.git
 WORKDIR marian-dev
-RUN git checkout youki/quantize-embedding
-RUN git checkout dad48865fd3b7f1d7b891de81040f7651e824510
+RUN git checkout async_return
 RUN mkdir src/static
 RUN mkdir build
 COPY src/cmarian.cpp /marian-dev/src/static

--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -42,9 +42,9 @@ RUN ./b2 install --prefix=/usr --with-system --with-thread --with-date_time --wi
 
 # Marian install
 WORKDIR /
-RUN  git clone --no-checkout https://github.com/rhenry-nv/marian-dev.git
+RUN  git clone --no-checkout https://github.com/rhenry-nv/marian-dev.git 
 WORKDIR marian-dev
-RUN git checkout async_return
+RUN git checkout async
 RUN mkdir src/static
 RUN mkdir build
 COPY src/cmarian.cpp /marian-dev/src/static

--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -1,7 +1,7 @@
 # It is recommended to use a machine which supports CUDA to build this image.
 FROM nvidia/cuda:11.1-cudnn8-devel-ubuntu18.04 AS BUILDER
 RUN apt-get update --fix-missing
-RUN apt-get install -y curl git autoconf automake libtool curl make g++ unzip cmake build-essential cpio
+RUN apt-get install -y curl git autoconf automake libtool curl make g++ unzip cmake build-essential cpio libgoogle-perftools-dev
 RUN apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/contrib/triton-aml/Dockerfile
+++ b/contrib/triton-aml/Dockerfile
@@ -53,7 +53,10 @@ RUN rm src/CMakeLists.txt
 COPY src/CMakeLists.txt /marian-dev/src
 
 WORKDIR /marian-dev/build
-RUN cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on -DCUDA_cublas_device_LIBRARY=/usr/lib/x86_64-linux-gnu/libcublas.so
+RUN cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on  \ 
+             -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off \
+             -DCUDA_cublas_device_LIBRARY=/usr/lib/x86_64-linux-gnu/libcublas.so
+
 RUN make -j $(grep -c ^processor /proc/cpuinfo)
 
 # build cmarian static library
@@ -65,6 +68,7 @@ COPY --from=BUILDER /marian-dev/build/src/3rd_party/fbgemm/libfbgemm.a /usr/lib
 COPY --from=BUILDER /marian-dev/build/src/3rd_party/fbgemm/asmjit/libasmjit.a /usr/lib
 COPY --from=BUILDER /marian-dev/build/src/3rd_party/sentencepiece/src/libsentencepiece_train.a /usr/lib
 COPY --from=BUILDER /marian-dev/build/src/3rd_party/sentencepiece/src/libsentencepiece.a /usr/lib
+COPY --from=BUILDER /marian-dev/build/src/3rd_party/intgemm/libintgemm.a /usr/lib
 COPY --from=BUILDER /marian-dev/build/libmarian.a /usr/lib/libcmarian.a
 COPY --from=BUILDER /marian-dev/build/src/libmarian_cuda.a /usr/lib/libcmarian_cuda.a
 

--- a/contrib/triton-aml/README.md
+++ b/contrib/triton-aml/README.md
@@ -27,9 +27,18 @@ For the AzureML Inference team members, you can put it into the following place 
 
 Where <backend_directory> is by default /opt/tritonserver/backends.
 
+This backend will return sentences as soon as they are done with translation by default. To only return when the 
+entire batch is finished translating, set the async_mode to false by adding the following your config.pbtxt file.
+
+parameters [
+  {
+    key: "async"
+    value: { string_value : "false" }
+  }
+]
 ## Make changes
 
-If you want to compile with another version of Marian, you need to replace `RUN git checkout youki/quantize-embedding` in the Dockerfile, then copy the new CMakeLists.txt replace the old one, add src/cmarian.cpp into CMakeLists.txt and make some changes to make sure it will build a static library of Marian.
+If you want to compile with another version of Marian, you need to replace `RUN git checkout async` in the Dockerfile, then copy the new CMakeLists.txt replace the old one, add src/cmarian.cpp into CMakeLists.txt and make some changes to make sure it will build a static library of Marian.
 
 ## Limitation
 

--- a/contrib/triton-aml/marian_backend/CMakeLists.txt
+++ b/contrib/triton-aml/marian_backend/CMakeLists.txt
@@ -94,6 +94,7 @@ target_link_libraries(
     fbgemm
     asmjit
     protobuf
+    intgemm
 )
 
 

--- a/contrib/triton-aml/marian_backend/src/marian.cc
+++ b/contrib/triton-aml/marian_backend/src/marian.cc
@@ -148,16 +148,24 @@ ModelState::SetAsyncMode()
             RETURN_IF_ERROR(async_value.MemberAsString(
                 "string_value", &return_async_mode)
             );
-            LOG_MESSAGE(
-                TRITONSERVER_LOG_INFO,
-                (std::string("Async mode set to : ") + return_async_mode)
-                .c_str()
-            );
         }
     }
 
     std::transform(return_async_mode.begin(), return_async_mode.end(), return_async_mode.begin(), ::tolower);
-    async_mode_ = return_async_mode == "true";
+
+    if (!return_async_mode.empty() && return_async_mode != "true" && return_async_mode != "false") 
+    {
+        return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_UNSUPPORTED, "Async mode must be empty, true or false");
+    }
+
+    async_mode_ = return_async_mode == "true" || return_async_mode.empty();
+
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        (std::string("Async mode set to : ") + async_mode_)
+        .c_str()
+    );
+
     return nullptr;  // success
 }
 

--- a/contrib/triton-aml/marian_backend/src/marian.cc
+++ b/contrib/triton-aml/marian_backend/src/marian.cc
@@ -162,7 +162,7 @@ ModelState::SetAsyncMode()
 
     LOG_MESSAGE(
         TRITONSERVER_LOG_INFO,
-        (std::string("Async mode set to : ") + async_mode_)
+        (std::string("Async mode set to : ") + std::to_string(async_mode_))
         .c_str()
     );
 

--- a/contrib/triton-aml/marian_backend/src/marian.cc
+++ b/contrib/triton-aml/marian_backend/src/marian.cc
@@ -710,8 +710,6 @@ void sendResponse(int bn, const char* result, void* userData)
         }
     }
 
-    std::cout << bn << " " << concatedSentences << std::endl;
-
     TRITONBACKEND_Input* input = state->request_input[requestNumber];
     const char* input_name;
     TRITONSERVER_DataType input_datatype;

--- a/contrib/triton-aml/marian_backend/src/marian.cc
+++ b/contrib/triton-aml/marian_backend/src/marian.cc
@@ -283,8 +283,7 @@ TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInstance* instance)
     return nullptr;  // success
 }
 
-TRITONSERVER_Error*
-TRITONBACKEND_ModelInstanceExecute(
+TRITONSERVER_Error* serveRequestsSync(
     TRITONBACKEND_ModelInstance* instance, TRITONBACKEND_Request** requests,
     const uint32_t request_count)
 {
@@ -577,6 +576,377 @@ TRITONBACKEND_ModelInstanceExecute(
     free_result(result);
 
     return nullptr;  // success
+}
+
+// Again, this is gross but the exposed API is a C API. These states are needed
+// to correctly process sentences asynchronously. They are updated when the async
+// execute function is called.
+
+struct CallbackState {
+    // A vector of vectors containing requests that are partially completed. This vector
+    // is of length request_count. Each vector within has size request_batch_size. A 
+    // request is complete when all the vectors for that request are not empty.
+    std::vector<std::vector<std::string>> partially_completed_requests;
+
+    // A vector mapping each request to its orig batch. That is marianBatch_to_tritonRequest_map[b] gives
+    // the request that element b in the marian batch originated from. This handles the fact 
+    // that some requests may be split into several sentences to Marian.
+    std::vector<int> marianBatch_to_tritonRequest_map;
+
+    // A vector mapping the marian batch index to the index of the request.
+    std::vector<int> marianBatchIdx_to_requestBatchIdx_map;
+
+    // 'responses' is initialized with the response objects below and
+    // if/when an error response is sent the corresponding entry in
+    // 'responses' is set to nullptr to indicate that that response has
+    // already been sent.
+    std::vector<TRITONBACKEND_Response*> responses;
+
+    // State to collect statistics about the sentence in the given batch.
+    uint64_t exec_start_ns;
+
+    // Request inputs
+    std::vector<TRITONBACKEND_Input*> request_input;
+
+    // Requests to Triton
+    TRITONBACKEND_Request** requests;
+};
+
+
+
+void sendResponse(int bn, const char* result, void* userData) 
+{
+    CallbackState* state = (CallbackState*) userData;
+
+    // Use at to get bound checking when accessing the vector
+    int requestNumber = state->marianBatch_to_tritonRequest_map.at(bn);
+    int requestBatchIdx = state->marianBatchIdx_to_requestBatchIdx_map.at(bn);
+    size_t requestBatchSize = state->partially_completed_requests.at(requestNumber).size();
+
+    // For uniformity, I always assign the translated sentence to the partially completed requests array.
+    const std::vector<std::string>& requestStaging = state->partially_completed_requests.at(requestNumber);
+
+    if (!requestStaging.at(requestBatchIdx).empty()) {
+        GUARDED_RESPOND_IF_ERROR(
+            state->responses, requestNumber,
+            TRITONSERVER_ErrorNew(
+                TRITONSERVER_ERROR_UNSUPPORTED,
+                "Staging this request will overwrite an existing sentence."
+            )
+        );
+
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_ERROR,
+            (std::string("request ") + std::to_string(requestNumber) +
+            ": failed to stage request as a sentence seems to exist in the staging area.")
+            .c_str()
+        );
+        return;
+    }
+    requestStaging.at(requestBatchIdx) = result;
+
+    // Now we check if any sentence in the batch of requests still remains to be processed. If so, 
+    // return immediately since we have already stored the translated sentence in the staging area above.
+    for (const auto& sentence : requestStaging) {
+        if (sentence.empty()) {
+            return;
+        }
+    }
+    
+    // If here, we need to concat all the sentences in the staging area for the given request and immediately
+    // send a response to the user.
+    std::string concatedSentences;
+    for (int sen = 0; sen < (int)requestStaging.size(); ++sen) {
+        concatedSentences += sentence;
+        if (sen + 1 != (int)requestStaging.size()) {
+            concatedSentences += "\n";
+        }
+    }
+
+    std::cout << bn << " " << concatedSentences << std::endl;
+
+    TRITONBACKEND_Input* input = state->request_input[r];
+    const char* input_name;
+    TRITONSERVER_DataType input_datatype;
+    const int64_t* input_shape;
+    uint32_t input_dims_count;
+    uint64_t input_byte_size;
+    uint32_t input_buffer_count;
+
+    GUARDED_RESPOND_IF_ERROR(
+        state->responses, requestNumber,
+        TRITONBACKEND_InputProperties(
+            input, &input_name, &input_datatype, &input_shape,
+            &input_dims_count, &input_byte_size, &input_buffer_count
+        )
+    );
+
+    if (state->responses[requestNumber] == nullptr) {
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_ERROR,
+            (std::string("request ") + std::to_string(requestNumber) +
+                ": failed to read input properties, error response sent")
+                .c_str()
+        );
+        return;
+    }
+
+    TRITONBACKEND_Request* request = state->requests[requestNumber];
+    const char* requested_output_name = nullptr;
+    GUARDED_RESPOND_IF_ERROR(
+        state->responses, requestNumber,
+        TRITONBACKEND_RequestOutputName(
+            request, 0 /* index */, &requested_output_name
+        )
+    );
+
+    // Create an output tensor in the response,
+    // input and output have same datatype and shape...
+    TRITONBACKEND_Response* response = state->responses[requestNumber];
+    TRITONBACKEND_Output* output;
+    GUARDED_RESPOND_IF_ERROR(
+        state->responses, requestNumber,
+        TRITONBACKEND_ResponseOutput(
+            response, &output, requested_output_name, input_datatype,
+            input_shape, input_dims_count
+        )
+    );
+
+    // Get the output buffer. We request a buffer in CPU memory
+    // but we have to handle any returned type. If we get back
+    // a buffer in GPU memory we just fail the request.
+    void* output_buffer;
+    int c_str_size = (int)concatedSentences.size() + 1;
+    TRITONSERVER_MemoryType output_memory_type = TRITONSERVER_MEMORY_CPU;
+    int64_t output_memory_type_id = 0;
+    GUARDED_RESPOND_IF_ERROR(
+        state->responses, requestNumber,
+        TRITONBACKEND_OutputBuffer(
+            output, &output_buffer, c_str_size + 4,
+            &output_memory_type, &output_memory_type_id
+        )
+    );
+
+    if ((responses[requestNumber] == nullptr) ||
+        (output_memory_type == TRITONSERVER_MEMORY_GPU)) {
+        GUARDED_RESPOND_IF_ERROR(
+            state->responses, requestNumber,
+            TRITONSERVER_ErrorNew(
+                TRITONSERVER_ERROR_UNSUPPORTED,
+                "failed to create output buffer in CPU memory"
+            )
+        );
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_ERROR,
+            (std::string("request ") + std::to_string(requestNumber) +
+            ": failed to create output buffer in CPU memory, error request sent")
+            .c_str()
+        );
+        return;
+    }
+
+    // Copy Marian result -> output.
+    memcpy(output_buffer, reinterpret_cast<char*>(&c_str_size), 4);
+    memcpy(reinterpret_cast<char*>(output_buffer) + 4, concatedSentences.c_str(), c_str_size);
+
+    // Send the response.
+    LOG_IF_ERROR(
+        TRITONBACKEND_ResponseSend(
+            responses[requestNumber], TRITONSERVER_RESPONSE_COMPLETE_FINAL,
+            nullptr /* success */),
+        "failed sending response"
+    );
+
+    // Report statistics for the successful request.
+    uint64_t request_exec_end_ns = 0;
+    SET_TIMESTAMP(request_exec_end_ns);
+    LOG_IF_ERROR(
+        TRITONBACKEND_ModelInstanceReportStatistics(
+            instance_state->TritonModelInstance(), request, true /* success */,
+            state->exec_start_ns, state->exec_start_ns, request_exec_end_ns, request_exec_end_ns),
+        "failed reporting request statistics"
+    );
+
+    // Release each request as soon as we sent the corresponding response.
+    LOG_IF_ERROR(
+        TRITONBACKEND_RequestRelease(request, TRITONSERVER_REQUEST_RELEASE_ALL),
+        "failed releasing request"
+    );
+}
+
+TRITONSERVER_Error* serveRequestsAsync(
+    TRITONBACKEND_ModelInstance* instance, TRITONBACKEND_Request** requests,
+    const uint32_t request_count)
+{
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        ("Marian model instance executing " + std::to_string(request_count) +
+         " requests").c_str()
+    );
+
+    CallbackState state;
+    state.requests = requests;
+    state.responses.reserve(request_count);
+
+    // Create a single response object for each request. If something
+    // goes wrong when attempting to create the response objects just
+    // fail all of the requests by returning an error.
+    for (uint32_t r = 0; r < request_count; ++r) {
+        TRITONBACKEND_Request* request = requests[r];
+
+        TRITONBACKEND_Response* response;
+        RETURN_IF_ERROR(TRITONBACKEND_ResponseNew(&response, request));
+        state.responses.push_back(response);
+    }
+
+    uint64_t total_batch_size = 0;
+
+    // We will execute all the requests at the same time, and so there
+    // will be a single compute-start / compute-end time-range.
+    state.exec_start_ns = 0;
+    SET_TIMESTAMP(state.exec_start_ns);
+
+    // It is assumed that this is always of size request count
+    state.partially_completed_requests.resize(request_count);
+
+    std::string input_strings;
+    // Create a single response object for each request. If something
+    // goes wrong when attempting to create the response objects just
+    // fail all of the requests by returning an error.
+    for (uint32_t r = 0; r < request_count; ++r) {
+        TRITONBACKEND_Request* request = requests[r];
+
+        const char* input_name;
+        GUARDED_RESPOND_IF_ERROR(
+            state.responses, r,
+            TRITONBACKEND_RequestInputName(request, 0 /* index */, &input_name)
+        );
+
+        TRITONBACKEND_Input* input = nullptr;
+        GUARDED_RESPOND_IF_ERROR(
+            state.responses, r,
+            TRITONBACKEND_RequestInput(request, input_name, &input)
+        );
+        state.request_input.push_back(input);
+
+        // If an error response was sent while getting the input name
+        // or input then display an error message and move on
+        // to next request.
+        if (state.responses[r] == nullptr) {
+            LOG_MESSAGE(
+                TRITONSERVER_LOG_ERROR,
+                (std::string("request ") + std::to_string(r) +
+                 ": failed to read input or requested output name, error response sent")
+                 .c_str()
+            );
+            continue;
+        }
+
+        // Get input buffer count.
+        uint32_t input_buffer_count;
+        GUARDED_RESPOND_IF_ERROR(
+            state.responses, r,
+            TRITONBACKEND_InputProperties(
+                input, nullptr /* input_name */, nullptr, nullptr,
+                nullptr, nullptr, &input_buffer_count
+            )
+        );
+        if (state.responses[r] == nullptr) {
+            LOG_MESSAGE(
+                TRITONSERVER_LOG_ERROR,
+                (std::string("request ") + std::to_string(r) +
+                 ": failed to read input properties, error response sent")
+                 .c_str()
+            );
+            continue;
+        }
+
+        // Compose all the requests input to make a batch request,
+        // record the sentences count of each request for further process.
+        std::vector<char> content_buffer;
+        for (uint32_t b = 0; b < input_buffer_count; ++b) {
+            const void* input_buffer = nullptr;
+            uint64_t buffer_byte_size = 0;
+            TRITONSERVER_MemoryType input_memory_type = TRITONSERVER_MEMORY_CPU;
+            int64_t input_memory_type_id = 0;
+            GUARDED_RESPOND_IF_ERROR(
+                state.responses, r,
+                TRITONBACKEND_InputBuffer(
+                    input, b, &input_buffer, &buffer_byte_size,
+                    &input_memory_type, &input_memory_type_id
+                )
+            );
+            if ((state.responses[r] == nullptr) ||
+                (input_memory_type == TRITONSERVER_MEMORY_GPU)) {
+                GUARDED_RESPOND_IF_ERROR(
+                    state.responses, r,
+                    TRITONSERVER_ErrorNew(
+                        TRITONSERVER_ERROR_UNSUPPORTED,
+                        "failed to get input buffer in CPU memory"
+                    )
+                );
+            }
+            content_buffer.insert(
+                content_buffer.end(), reinterpret_cast<const char*>(input_buffer) + 4,
+                reinterpret_cast<const char*>(input_buffer) + buffer_byte_size
+            );
+        }
+
+        std::string s(content_buffer.begin(), content_buffer.end());
+        int count = std::count(s.begin(), s.end(), '\n');
+        content_buffer.clear();
+
+        // Ensure each request vector has enough space for its batch
+        state.partially_completed_requests[r].resize(count + 1);
+        
+        // Since a request may have multiple sentences, update the map with request_batch_size
+        // duplicates of the request number. This gives us a fast way to find the request number
+        // given the batch offset.
+        // Additionally, we map the marian batch offset to the request batch offset.
+        for (int request_batch_size = 0; request_batch_size < (count + 1); ++request_batch_size) {
+            state.marianBatch_to_tritonRequest_map.push_back(r);
+            state.marianBatchIdx_to_requestBatchIdx_map.push_back(request_batch_size);
+        }
+        
+        if (input_strings.empty()) {
+            input_strings = s;
+        } else {
+            input_strings.append("\n");
+            input_strings.append(s);
+        }
+
+        total_batch_size += (count + 1);
+    }
+
+    // Operate on the entire batch of requests for improved performance.
+    void* vstate;
+    RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceState(instance, &vstate));
+    ModelInstanceState* instance_state =
+        reinterpret_cast<ModelInstanceState*>(vstate);
+    void* marian = instance_state->Marian();
+
+    translate_async(marian, const_cast<char*>(input_strings.c_str()), sendResponse, (void*)&state);
+
+    // Report statistics for the entire batch of requests.
+    uint64_t exec_end_ns = 0;
+    SET_TIMESTAMP(exec_end_ns);
+    LOG_IF_ERROR(
+        TRITONBACKEND_ModelInstanceReportBatchStatistics(
+            instance_state->TritonModelInstance(), total_batch_size,
+            state.exec_start_ns, state.exec_start_ns, exec_end_ns, exec_end_ns),
+        "failed reporting batch request statistics"
+    );
+
+    return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+TRITONBACKEND_ModelInstanceExecute(
+    TRITONBACKEND_ModelInstance* instance, TRITONBACKEND_Request** requests,
+    const uint32_t request_count)
+{
+    return serveRequestsAsync(instance, requests, request_count)
+    // return serveRequestsSync(instance, requests, request_count);
 }
 
 }  // extern "C"

--- a/contrib/triton-aml/marian_backend/src/marian.h
+++ b/contrib/triton-aml/marian_backend/src/marian.h
@@ -11,6 +11,13 @@
     #define DLLEXPORT extern "C"
 #endif
 
+// This is gross but necessary since exporting a C interface. The callback function
+// takes an integer which corresponds to the sentence id in the batch along with
+// a char* which is the translated version of the sentence at the corresponding batch id.
+// The callback function is free to do whatever it pleases with this, including immediately
+// calling send response.
+DLLEXPORT void translate_async(void* marian, char* sent, void(*callback)(int, const char*, void*), void* userData);
+
 DLLEXPORT void* init(char* path, int device_num);
 DLLEXPORT char* translate(void* marian, char* sent);
 DLLEXPORT void free_result(char* to_free);

--- a/contrib/triton-aml/src/CMakeLists.txt
+++ b/contrib/triton-aml/src/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/3rd_party/intgemm) # running cmake o
 include_directories(${CMAKE_BINARY_DIR}/local/include)
 
 add_library(marian STATIC
+  static/cmarian.cpp
   common/aliases.cpp
   common/fastopt.cpp
   common/version.cpp

--- a/contrib/triton-aml/src/CMakeLists.txt
+++ b/contrib/triton-aml/src/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(marian STATIC
   data/corpus_sqlite.cpp
   data/corpus_nbest.cpp
   data/text_input.cpp
+  data/shortlist.cpp
 
   3rd_party/cnpy/cnpy.cpp
   3rd_party/ExceptionWithCallStack.cpp
@@ -75,6 +76,9 @@ add_library(marian STATIC
   layers/loss.cpp
   layers/weight.cpp
   layers/lsh.cpp
+  layers/embedding.cpp
+  layers/output.cpp
+  layers/logits.cpp
 
   rnn/cells.cpp
   rnn/attention.cpp
@@ -87,6 +91,7 @@ add_library(marian STATIC
   models/model_factory.cpp
   models/encoder_decoder.cpp
   models/transformer_stub.cpp
+  models/costs.cpp
 
   rescorer/score_collector.cpp
   embedder/vector_collector.cpp
@@ -109,6 +114,11 @@ add_library(marian STATIC
   # this is only compiled to catch build errors, but not linked
   microsoft/quicksand.cpp
   microsoft/cosmos.cpp
+
+  # copied from quicksand to be able to read binary shortlist
+  microsoft/shortlist/utils/Converter.cpp
+  microsoft/shortlist/utils/StringUtils.cpp
+  microsoft/shortlist/utils/ParameterTree.cpp
 
   $<TARGET_OBJECTS:libyaml-cpp>
   $<TARGET_OBJECTS:SQLiteCpp>

--- a/contrib/triton-aml/src/CMakeLists.txt
+++ b/contrib/triton-aml/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT=1)
+add_definitions(-DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT=1)
 add_subdirectory(3rd_party)
 
 include_directories(.)
@@ -5,10 +7,11 @@ include_directories(3rd_party)
 include_directories(3rd_party/SQLiteCpp/include)
 include_directories(3rd_party/sentencepiece)
 include_directories(3rd_party/fbgemm/include)
+include_directories(3rd_party/intgemm)
+include_directories(${CMAKE_BINARY_DIR}/src/3rd_party/intgemm) # running cmake on the intgemm submodule triggers config file generation in this directory.
 include_directories(${CMAKE_BINARY_DIR}/local/include)
 
 add_library(marian STATIC
-  static/cmarian.cpp
   common/aliases.cpp
   common/fastopt.cpp
   common/version.cpp
@@ -21,9 +24,12 @@ add_library(marian STATIC
   common/config_validator.cpp
   common/options.cpp
   common/binary.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/common/build_info.cpp
   common/io.cpp
   common/filesystem.cpp
   common/file_stream.cpp
+  common/file_utils.cpp
+  common/signal_handling.cpp
   common/types.cpp
 
   data/alignment.cpp
@@ -40,6 +46,8 @@ add_library(marian STATIC
   3rd_party/cnpy/cnpy.cpp
   3rd_party/ExceptionWithCallStack.cpp
 
+  3rd_party/onnx/protobuf/onnx-ml.pb-wrapper.cpp
+
   3rd_party/phf/phf.cc
 
   tensors/backend.cpp
@@ -47,11 +55,9 @@ add_library(marian STATIC
   tensors/tensor.cpp
   tensors/cpu/device.cpp
   tensors/cpu/prod.cpp
+  tensors/cpu/topk.cpp
   tensors/cpu/tensor_operators.cpp
-
-  tensors/cpu/sharp/int_gemm.cpp
-  tensors/cpu/sharp/avx_gemm.cpp
-  tensors/cpu/sharp/sse_gemm.cpp
+  tensors/cpu/integer_common.cpp
   tensors/cpu/fbgemm/packed_gemm.cpp
 
   graph/expression_graph.cpp
@@ -60,23 +66,31 @@ add_library(marian STATIC
   graph/node_operators.cpp
   graph/node_initializers.cpp
 
+  onnx/expression_graph_onnx_exporter.cpp
+  onnx/expression_graph_onnx_serialization.cpp
+
   layers/convolution.cpp
   layers/generic.cpp
   layers/loss.cpp
   layers/weight.cpp
+  layers/lsh.cpp
 
   rnn/cells.cpp
   rnn/attention.cpp
 
+  optimizers/quantizer.cpp
   optimizers/clippers.cpp
   optimizers/optimizers.cpp
+  optimizers/exponential_smoothing.cpp
 
   models/model_factory.cpp
   models/encoder_decoder.cpp
   models/transformer_stub.cpp
 
   rescorer/score_collector.cpp
+  embedder/vector_collector.cpp
 
+  translator/beam_search.cpp
   translator/history.cpp
   translator/output_collector.cpp
   translator/output_printer.cpp
@@ -85,22 +99,21 @@ add_library(marian STATIC
   translator/scorers.cpp
 
   training/graph_group_async.cpp
-  training/graph_group_async_drop.cpp
   training/graph_group_sync.cpp
+  training/graph_group.cpp
   training/graph_group_singleton.cpp
-  training/graph_group_multinode.cpp
-  training/graph_group_multinode_sync.cpp
   training/validator.cpp
   training/communicator.cpp
-  training/scheduler.cpp
 
   # this is only compiled to catch build errors, but not linked
   microsoft/quicksand.cpp
+  microsoft/cosmos.cpp
 
   $<TARGET_OBJECTS:libyaml-cpp>
   $<TARGET_OBJECTS:SQLiteCpp>
   $<TARGET_OBJECTS:pathie-cpp>
   $<TARGET_OBJECTS:zlib>
+  $<TARGET_OBJECTS:faiss>
 )
 target_compile_options(marian PUBLIC ${ALL_WARNINGS})
 
@@ -138,6 +151,9 @@ cuda_add_library(marian_cuda
   tensors/gpu/device.cu
   tensors/gpu/algorithm.cu
   tensors/gpu/prod.cpp
+  tensors/gpu/prod.cu
+  tensors/gpu/prod_sparse.cpp
+  tensors/gpu/topk.cu
   tensors/gpu/element.cu
   tensors/gpu/add.cu
   tensors/gpu/add_all.cu
@@ -145,8 +161,6 @@ cuda_add_library(marian_cuda
   tensors/gpu/cudnn_wrappers.cu
   translator/nth_element.cu
   translator/helpers.cu
-  training/gradient_dropping/gpu/dropper.cu
-  training/gradient_dropping/gpu/sparse_algorithm.cu
   STATIC)
 
   target_compile_options(marian_cuda PUBLIC ${ALL_WARNINGS})

--- a/contrib/triton-aml/src/cmarian.cpp
+++ b/contrib/triton-aml/src/cmarian.cpp
@@ -15,12 +15,14 @@
 #endif
 
 using namespace marian;
+typedef void (*callbackFunc)(int, const char*, void*);
 
 class CMarian {
 private:
     Ptr<Options> options_;
     char* configPath_;
     Ptr<TranslateService<BeamSearch>> task_;
+    Ptr<TranslateServiceAsync<BeamSearch>> taskAsync_;
 
 public:
     CMarian(char* configPath, int device_num) : configPath_(configPath) {
@@ -37,8 +39,6 @@ public:
         strcpy(argv[4], std::to_string(device_num).c_str());
 
         options_ = marian::parseOptions(argc, argv, cli::mode::translation, true);
-        task_ = New<TranslateService<BeamSearch>>(options_);
-
         delete[] argv[0];
         delete[] argv[1];
         delete[] argv[3];
@@ -51,11 +51,32 @@ public:
      * @return A string delimited by ||| with newlines separating beams.
      */
     char* translate(char* sent) {
+        // Lazy initialize so we can use either the sync or async version with this repo
+        if(!task_) {
+            task_ = New<TranslateService<BeamSearch>>(options_);
+        }
         std::string strSent(sent);
         auto outputText = task_->run(strSent);
         char* ret = (char*) malloc(outputText.length() + 1);
         snprintf(ret, outputText.length() + 1, "%s", outputText.c_str());
         return ret;
+    }
+
+    /**
+     * @brief Exposes Marian translation capabilities based on the loaded YAML config associated with this class.
+     * @param sent The sentence to run inference on.
+     * @param callback the function to run on the translated sentence. It takes the batchID of the source sentence 
+     *                   along with the translated sentence and processes those.
+     * @param userData A pointer to any state the user needs to use in their callback
+     */
+    void translate_async(char* sent, callbackFunc callback, void* userData) {
+        // Lazy initialize so we can use either the sync or async version with this repo
+        if (!taskAsync_) {
+            taskAsync_ = New<TranslateServiceAsync<BeamSearch>>(options_);
+        }
+        std::string strSent(sent);
+        taskAsync_->registerCallback(callback, userData);
+        taskAsync_->run(strSent);
     }
 };
 
@@ -67,6 +88,11 @@ DLLEXPORT void* init(char* path, int device_num) {
 DLLEXPORT char* translate(void* marian, char* sent) {
     CMarian* m = static_cast<CMarian*>(marian);
     return m->translate(sent);
+}
+
+DLLEXPORT void translate_async(void* marian, char* sent, callbackFunc callback, void* userData) {
+    CMarian* m = static_cast<CMarian*>(marian);
+    m->translate_async(sent, callback, userData);
 }
 
 DLLEXPORT void free_result(char* to_free) {

--- a/contrib/triton-aml/src/cmarian.cpp
+++ b/contrib/triton-aml/src/cmarian.cpp
@@ -75,8 +75,7 @@ public:
             taskAsync_ = New<TranslateServiceAsync<BeamSearch>>(options_);
         }
         std::string strSent(sent);
-        taskAsync_->registerCallback(callback, userData);
-        taskAsync_->run(strSent);
+        taskAsync_->run(strSent, callback, userData);
     }
 };
 

--- a/src/models/model_task.h
+++ b/src/models/model_task.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <functional>
 namespace marian {
 
 struct ModelTask {
@@ -16,6 +15,6 @@ struct ModelCallbackTask {
 
 struct ModelServiceTask {
   virtual ~ModelServiceTask() {}
-  virtual std::string run(const std::string&, std::function<void(const int, const std::string&)>) = 0;
+  virtual std::string run(const std::string&) = 0;
 };
 }  // namespace marian

--- a/src/models/model_task.h
+++ b/src/models/model_task.h
@@ -11,7 +11,8 @@ struct ModelTask {
 
 struct ModelCallbackTask {
   virtual ~ModelCallbackTask() {}
-  virtual void run(std::function<void(const int, const std::string&)>) = 0;
+  virtual void registerCallback(void (*)(int, const char*, void*), void*) = 0;
+  virtual void run(const std::string&) = 0;
 };
 
 struct ModelServiceTask {

--- a/src/models/model_task.h
+++ b/src/models/model_task.h
@@ -11,8 +11,7 @@ struct ModelTask {
 
 struct ModelCallbackTask {
   virtual ~ModelCallbackTask() {}
-  virtual void registerCallback(void (*)(int, const char*, void*), void*) = 0;
-  virtual void run(const std::string&) = 0;
+  virtual void run(const std::string&, void (*)(int, const char*, void*), void*) = 0;
 };
 
 struct ModelServiceTask {

--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -1,4 +1,5 @@
 #include "translator/beam_search.h"
+#include "tensors/tensor_allocator.h"
 #include <sstream>
 
 #include "data/factored_vocab.h"
@@ -249,7 +250,10 @@ Beams BeamSearch::purgeBeams(const Beams& beams, /*in/out=*/std::vector<IndexTyp
 
 //**********************************************************************
 // main decoding function
-Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> batch, std::function<void(const int, const std::string&)> callback) {
+Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> batch, 
+                             void (*callback)(int, const char*, void*),
+                             void* userData) {
+
   const bool nbest = options_->get<bool>("n-best");
   auto factoredVocab = trgVocab_->tryAs<FactoredVocab>();
   size_t numFactorGroups = factoredVocab ? factoredVocab->getNumGroups() : 1;
@@ -516,7 +520,7 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
             std::stringstream bestn;
             printer_->print(histories[batchIdx], best1, bestn);
             std::string result = nbest ? bestn.str() : best1.str();
-            callback(histories[batchIdx]->getLineNum(), result);
+            callback(histories[batchIdx]->getLineNum(), result.c_str(), userData);
         }
 
       } 

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -14,6 +14,7 @@ private:
   std::vector<Ptr<Scorer>> scorers_;
   size_t beamSize_;
   Ptr<const Vocab> trgVocab_;
+  Ptr<TensorAllocator> allocator_;
   Ptr<OutputPrinter> printer_; 
 
   const float INVALID_PATH_SCORE;
@@ -55,7 +56,10 @@ public:
   Beams purgeBeams(const Beams& beams, /*in/out=*/std::vector<IndexType>& batchIdxMap);
 
   // main decoding function
-  Histories search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> batch, std::function<void(const int, const std::string&)> callback = nullptr);
+  Histories search(Ptr<ExpressionGraph> graph, 
+                   Ptr<data::CorpusBatch> batch, 
+                   void (*callback)(int, const char*, void*) = nullptr,
+                   void* userData = nullptr);
 };
 
 }  // namespace marian

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -4,7 +4,6 @@
 #include "translator/history.h"
 #include "translator/output_printer.h"
 #include "translator/scorers.h"
-#include <functional>
 
 namespace marian {
 

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -382,7 +382,6 @@ private:
   size_t numDevices_;
 
   void (*callback_)(int, const char*, void*) = nullptr;
-  void* userData_ = nullptr;
 
 public:
   virtual ~TranslateServiceAsync() {}
@@ -434,12 +433,7 @@ public:
     }
   }
 
-  void registerCallback(void (*callback)(int, const char*, void*), void* userData) override {
-    callback_ = callback;
-    userData_ = userData;
-  }
-
-  void run(const std::string& input) override {
+  void run(const std::string& input, void (*callback)(int, const char*, void*), void* userData) override {
     // split tab-separated input into fields if necessary
     auto inputs = options_->get<bool>("tsv", false)
                       ? convertTsvToLists(input, options_->get<size_t>("tsv-fields", 1))
@@ -467,7 +461,7 @@ public:
           }
 
           auto search = New<Search>(options_, scorers, trgVocab_);
-          search->search(graph, batch, callback_);
+          search->search(graph, batch, callback, userData);
         };
 
         threadPool_.enqueue(task, batchId);


### PR DESCRIPTION
### Description
This PR adds a callback mechanism to the Marian beam search to allow sentences to be consumed as soon as they are translated. This PR also updates the triton backend in the Marian contrib folder to leverage this feature.

When running with Triton on batch 64, I observed 1.8X reduction in median latencies and 1.6X reduction in 99.9 percentile latencies for a proxy model. This proxy model is not the same model referred to in prior PRs.

List of changes:
- Adds call back mechanism to beam search
- Adds new ModelTask for Async return
- Updates the Triton backend to leverage the async return feature

Added dependencies: none

### How to test
Build a backend by running the build.sh script in contrib/triton-aml. Copy the libtriton_marian.so as described in the README in the contrib/triton-aml folder.

The regression tests should not be affected by this change. I have not checked this, but I have manually checked for correctness both through Triton and without Triton using some sample inputs and outputs.

Describe how you have tested your code, including OS and the cmake command.
cmake .. -DCOMPILE_CPU=on -DCOMPILE_CUDA=on -DUSE_SENTENCEPIECE=on -DUSE_STATIC_LIBS=off -DCOMPILE_SERVER=off -DUSE_FBGEMM=on -DCOMPILE_CUDA_SM35=off -DCOMPILE_CUDA_SM50=off -DCOMPILE_CUDA_SM60=off -DCOMPILE_CUDA_SM70=on -DCOMPILE_CUDA_SM75=off -DCOMPILE_TESTS=on

Ubuntu - 18.04.3 LTS
nvcc - 11.1.105
gcc - 7.5.0

### Checklist

- [x ] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
