### PR TITLE
Remove Ubuntu 16.04 from GitHub workflows

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,14 +50,7 @@ jobs:
             unit_tests: false
             examples: false
           # Ubuntu 16.04 supports CUDA 8+
-          - name: "Ubuntu 16.04 CUDA 9.2 gcc-7"
-            os: ubuntu-16.04
-            cuda: "9.2"
-            gcc: 7
-            cpu: true
-            gpu: true
-            unit_tests: true
-            examples: true
+          # But it is no longer available in GitHub workflows
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}

--- a/scripts/ci/install_cuda_ubuntu.sh
+++ b/scripts/ci/install_cuda_ubuntu.sh
@@ -91,7 +91,7 @@ sudo add-apt-repository "deb ${REPO_URL} /"
 sudo apt-get update
 
 echo "Installing CUDA packages ${CUDA_PACKAGES}"
-sudo apt-get -y install ${CUDA_PACKAGES}
+sudo apt-get -y --allow-unauthenticated install ${CUDA_PACKAGES}
 
 if [[ $? -ne 0 ]]; then
     echo "CUDA Installation Error."


### PR DESCRIPTION
### Description
GitHub will remove `ubuntu-16.04` on September 20, 2021.

Added dependencies: none
