### PR TITLE
Improve checks on transformer cache

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(MARIAN_SOURCES
   common/filesystem.cpp
   common/file_stream.cpp
   common/file_utils.cpp
+  common/hash.cpp
   common/signal_handling.cpp
   common/types.cpp
 

--- a/src/common/hash.cpp
+++ b/src/common/hash.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "hash.h"
 #include "common/shape.h"
 

--- a/src/common/hash.cpp
+++ b/src/common/hash.cpp
@@ -1,0 +1,10 @@
+#include "hash.h"
+#include "common/shape.h"
+
+namespace std {
+size_t hash<pair<string, marian::Shape>>::operator()(pair<string, marian::Shape> const& k) const {
+  size_t seed = hash<string>{}(k.first);
+  marian::util::hash_combine(seed, k.second.hash());
+  return seed;
+}
+}  // namespace std

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -7,16 +7,18 @@ namespace util {
 
 template <class T> using hash = std::hash<T>;
 
-// This combinator is based on boost::hash_combine, but uses
-// std::hash as the hash implementation. Used as a drop-in
-// replacement for boost::hash_combine.
+/**
+ * Combine hash values.
+ * This combinator is based on boost::hash_combine, but uses std::hash as the hash implementation.
+ * Used as a drop-in replacement for boost::hash_combine.
+ */
 template <class T, class HashType = std::size_t>
 inline void hash_combine(HashType& seed, T const& v) {
   hash<T> hasher;
   seed ^= static_cast<HashType>(hasher(v)) + 0x9e3779b9 + (seed<<6) + (seed>>2);
 }
 
-// Hash a whole chunk of memory, mostly used for diagnostics
+/** Hash a whole chunk of memory. */
 template <class T, class HashType = std::size_t>
 inline HashType hashMem(const T* beg, size_t len) {
   HashType seed = 0;

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -25,5 +25,17 @@ inline HashType hashMem(const T* beg, size_t len) {
   return seed;
 }
 
-}
+}  // namespace util
+
+struct Shape;  // Forward declaration
+}  // namespace marian
+
+namespace std {
+/**
+ * std::hash specialization for the string-shape pair used as a cache key in transformer.h.
+ */
+template <>
+struct hash<pair<string, marian::Shape>> {
+  size_t operator()(pair<string, marian::Shape> const& k) const;
+};
 }

--- a/src/models/transformer.h
+++ b/src/models/transformer.h
@@ -5,6 +5,7 @@
 
 #include "marian.h"
 
+#include "common/hash.h"
 #include "layers/constructors.h"
 #include "models/decoder.h"
 #include "models/encoder.h"
@@ -13,19 +14,6 @@
 #include "rnn/constructors.h"
 #define _USE_MATH_DEFINES  // enables math constants. We need M_PI_2
 #include <math.h>
-
-// std::hash specialization for custom cache key (prefix, shape)
-namespace std {
-  template <>
-  struct hash<pair<string, marian::Shape>> {
-    size_t operator()(pair<string, marian::Shape> const& k) const {
-      size_t seed = hash<string>{}(k.first);
-      marian::util::hash_combine(seed, k.second.hash());
-
-      return seed;
-    }
-  };
-}  // namespace std
 
 namespace marian {
 


### PR DESCRIPTION
### Description
This PR strengthens the check on the cache in transformer attention, and improves cache access.

As background to this, @fiqas and I were encountering segfaults in some transformer models, on a custom branch, during decoding on both GPU and CPU. This emerged during a call to`suppressWords` in which `suppressedWordIndices` had been corrupted, and pointed to an index beyond the vocabulary size. We traced this issue back to a `bdot(q,k,...)` operation in Attention where the batch dimension of `q` is smaller than that of `k`. In MultiHead, the former input is not cached, while the latter input _is_ cached, and is currently only recomputed when the total number of elements of a relevant input change. We were unlucky to encounter a situation in which a cache value was kept.

The memory corruption seems to have occured because in the node operation for bdot `bdot(a,b,...)`, it is implicitly assumed that `a` has the larger (or equal) batch dimension, and this is used when setting the resulting shape. The tensor operation ProdBatched takes the maximum of the batch sizes. Ideally, I would add some logic here to deal with this in some way, but I notice that these have been moved to `_legacy` in favour of a new implementation.

While I have not seen this arise on master, replacing the check on the number of elements to a check on the input shape from which the cache entry was computed is a stronger requirement, and should remove such calls to bdot.

List of changes:
- Transformer attention cache is checked against the shape of the input
- Improved access to the cache
- Remove trailing whitespaces

Added dependencies: none

### How to test
I tested the fix on the impacted model on our branch. I also ran the regression tests on this PR, after updating the expected outputs to match those obtained from current master on the same machine. 

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
