### PR TITLE
Task alias validation during training mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed loading binary models on architectures where `size_t` != `uint64_t`.
 - Missing float template specialisation for elem::Plus
 - Broken links to MNIST data sets
+- Enforce validation for the task alias in training mode.
 
 ### Changed
 - Optimize LSH for speed by treating is as a shortlist generator. No option changes in decoder

--- a/src/command/marian_train.cpp
+++ b/src/command/marian_train.cpp
@@ -13,19 +13,6 @@ int main(int argc, char** argv) {
   using namespace marian;
   auto options = parseOptions(argc, argv, cli::mode::training);
 
-  // Validate that we are using a valid training aliases for the task option.
-  // They should be the same as the ones listed in src/common/aliases.cpp + a blank one ("")
-  static const std::unordered_set<std::string> aliases = {"", "transformer-base", "transformer-big",
-                                    "transformer-base-prenorm", "transformer-big-prenorm"};
-
-  std::string mytask = options->get<std::vector<std::string> >("task")[0];
-  std::string alltasks = "";
-  for (auto&& alias : aliases) {
-    alltasks = alltasks + "\"" + alias + "\" ";
-  }
-  ABORT_IF(aliases.find(mytask) == aliases.end(), "Unrecognised task option: \"{}\". Permited {}", mytask, alltasks);
-
-
   // --sync-sgd always selects SyncGraphGroup
   //
   // If given, then this implementation is used for all combinations of (single, multiple) MPI

--- a/src/command/marian_train.cpp
+++ b/src/command/marian_train.cpp
@@ -13,6 +13,19 @@ int main(int argc, char** argv) {
   using namespace marian;
   auto options = parseOptions(argc, argv, cli::mode::training);
 
+  // Validate that we are using a valid training aliases for the task option.
+  // They should be the same as the ones listed in src/common/aliases.cpp + a blank one ("")
+  static const std::unordered_set<std::string> aliases = {"", "transformer-base", "transformer-big",
+                                    "transformer-base-prenorm", "transformer-big-prenorm"};
+
+  std::string mytask = options->get<std::vector<std::string> >("task")[0];
+  std::string alltasks = "";
+  for (auto&& alias : aliases) {
+    alltasks = alltasks + "\"" + alias + "\" ";
+  }
+  ABORT_IF(aliases.find(mytask) == aliases.end(), "Unrecognised task option: {}. Permited {}", mytask, alltasks);
+
+
   // --sync-sgd always selects SyncGraphGroup
   //
   // If given, then this implementation is used for all combinations of (single, multiple) MPI

--- a/src/command/marian_train.cpp
+++ b/src/command/marian_train.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
   for (auto&& alias : aliases) {
     alltasks = alltasks + "\"" + alias + "\" ";
   }
-  ABORT_IF(aliases.find(mytask) == aliases.end(), "Unrecognised task option: {}. Permited {}", mytask, alltasks);
+  ABORT_IF(aliases.find(mytask) == aliases.end(), "Unrecognised task option: \"{}\". Permited {}", mytask, alltasks);
 
 
   // --sync-sgd always selects SyncGraphGroup

--- a/src/common/aliases.cpp
+++ b/src/common/aliases.cpp
@@ -19,6 +19,8 @@ namespace marian {
  * As aliases are key-value pairs by default, values are compared as std::string. 
  * If the command line option corresponding to the alias is a vector, the alias 
  * will be triggered if the requested value exists in that vector at least once.
+ * By design if an option value that is not defined for that alias option below
+ * is used, the CLI parser will abort with 'unknown value for alias' error.
  *
  * @see CLIWrapper::alias()
  *

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -162,9 +162,10 @@ void CLIWrapper::parseAliases() {
   }
 
   // Remove aliases from the global config to avoid redundancy when writing/reading config files
-  for(const auto &alias : aliases_) {
-    config_.remove(alias.key);
-  }
+  // This code is commented out so we can validate the actual options of tasks
+  // for(const auto &alias : aliases_) {
+  //   config_.remove(alias.key);
+  // }
 }
 
 void CLIWrapper::updateConfig(const YAML::Node &config, cli::OptionPriority priority, const std::string &errorMsg) {

--- a/src/common/cli_wrapper.cpp
+++ b/src/common/cli_wrapper.cpp
@@ -135,11 +135,11 @@ void CLIWrapper::parseAliases() {
   // Find the set of values allowed for each alias option.
   // Later we will check and abort if an alias option has an unknown value.
   std::unordered_map<std::string, std::unordered_set<std::string>> allowedAliasValues;
-  for(const auto &alias : aliases_)
+  for(auto &&alias : aliases_)
     allowedAliasValues[alias.key].insert(alias.value);
 
   // Iterate all known aliases, each alias has a key, value, and config
-  for(const auto &alias : aliases_) {
+  for(auto &&alias : aliases_) {
     // Check if the alias option exists in the config (it may come from command line or a config
     // file)
     if(config_[alias.key]) {
@@ -153,10 +153,13 @@ void CLIWrapper::parseAliases() {
         auto aliasOpts = config_[alias.key].as<std::vector<std::string>>();
         // Abort if an alias option has an unknown value, i.e. value that has not been defined
         // in common/aliases.cpp
-        for(const auto &aliasOpt : aliasOpts)
-          if(allowedAliasValues[alias.key].count(aliasOpt) == 0)
+        for(auto &&aliasOpt : aliasOpts)
+          if(allowedAliasValues[alias.key].count(aliasOpt) == 0) {
+            std::vector<std::string> allowedOpts(allowedAliasValues[alias.key].begin(),
+                                                 allowedAliasValues[alias.key].end());
             ABORT("Unknown value '" + aliasOpt + "' for alias option --" + alias.key + ". "
-                  "Run with --help to see allowed values.");
+                  "Allowed values: " + utils::join(allowedOpts, ", "));
+          }
         expand = std::find(aliasOpts.begin(), aliasOpts.end(), alias.value) != aliasOpts.end();
       } else {
         expand = config_[alias.key].as<std::string>() == alias.value;

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -557,7 +557,8 @@ void ConfigParser::addOptionsTraining(cli::CLIWrapper& cli) {
   addSuboptionsULR(cli);
 
   cli.add<std::vector<std::string>>("--task",
-     "Use predefined set of options. Possible values: transformer, transformer-big");
+     "Use predefined set of options. Possible values: transformer-base, transformer-big, transformer-base-prenorm, transformer-big-prenorm",
+     {"", "transformer-base", "transformer-big", "transformer-base-prenorm", "transformer-big-prenorm"});
   cli.switchGroup(previous_group);
   // clang-format on
 }

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -557,8 +557,8 @@ void ConfigParser::addOptionsTraining(cli::CLIWrapper& cli) {
   addSuboptionsULR(cli);
 
   cli.add<std::vector<std::string>>("--task",
-     "Use predefined set of options. Possible values: transformer-base, transformer-big, transformer-base-prenorm, transformer-big-prenorm",
-     {"", "transformer-base", "transformer-big", "transformer-base-prenorm", "transformer-big-prenorm"});
+     "Use predefined set of options. Possible values: transformer-base, transformer-big, "
+     "transformer-base-prenorm, transformer-big-prenorm");
   cli.switchGroup(previous_group);
   // clang-format on
 }


### PR DESCRIPTION
### Description
This PR fixes #740 by adding an explicit validation of the task alias. Beforehand it used to be the case that if a task alias was provided that is not in `aliases.cpp` you would get random default options and things would break in unexpected ways with no feedback.

List of changes:
- Added validation of the task option if the mode is training.
- Updated the help at `config_parser.cpp`
- Removed the behaviour where aliases are removed from the config after being parsed so that we can check them later. Not sure if this breaks anything else. @graemenail  is there a better way to achieve this?

Added dependencies: none

### How to test
If you provide something like `task: transformer` you will get something like:
```
[2021-10-25 15:25:47] Error: Unrecognised task option: "transformer". Permited "transformer-base-prenorm" "transformer-big-prenorm" "transformer-big" "transformer-base" "" 
[2021-10-25 15:25:47] Error: Aborted from int mainTrainer(int, char**) in /home/USER/marian-dev/src/command/marian_train.cpp:26
```

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
