### PR TITLE
docs: Constrain version of mistune to before v2

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,4 +3,5 @@ breathe==4.13.0
 exhale
 sphinx_rtd_theme
 recommonmark
+mistune<2.0.0
 m2r


### PR DESCRIPTION
### Description
Fixes CI for API document generation.

List of changes:
- Constrain version of mistune

### How to test
https://github.com/marian-nmt/marian-dev/runs/4431055213

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
