### PR TITLE
Fix AVX2+ detection on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+- Fix AVX2 and AVX512 detection on MacOS
 
 ### Added
 - Adds option --add-lsh to marian-conv which allows the LSH to be memory-mapped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-- Fix AVX2 and AVX512 detection on MacOS
 
 ### Added
 - Adds option --add-lsh to marian-conv which allows the LSH to be memory-mapped.
@@ -33,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Integrate a shortlist converter (which can convert a text lexical shortlist to a binary shortlist) into marian-conv with --shortlist option
 
 ### Fixed
+- Fix AVX2 and AVX512 detection on MacOS
 - Add GCC11 support into FBGEMM
 - Added pragma to ignore unused-private-field error on elementType_ on macOS
 - Do not set guided alignments for case augmented data if vocab is not factored

--- a/cmake/FindSSE.cmake
+++ b/cmake/FindSSE.cmake
@@ -74,8 +74,7 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
    ENDIF (AVX512_TRUE)
 
 ELSEIF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-   EXEC_PROGRAM("/usr/sbin/sysctl -n machdep.cpu.features" OUTPUT_VARIABLE
-      CPUINFO)
+   EXEC_PROGRAM("/usr/sbin/sysctl -n machdep.cpu.features machdep.cpu.leaf7_features" OUTPUT_VARIABLE CPUINFO)
 
    STRING(REGEX REPLACE "^.*[^S](SSE2).*$" "\\1" SSE_THERE ${CPUINFO})
    STRING(COMPARE EQUAL "SSE2" "${SSE_THERE}" SSE2_TRUE)


### PR DESCRIPTION
MacOS is weird and its CPUflags are separated in two separate fields returned by the sysctl interfrace. To get around this, we need to test both of them, so here goes

### Checklist

- [x] I have tested the code manually
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
