### PR TITLE
PyYaml safe_load instead of load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Fixed
+- Scripts using PyYAML now use `safe_load`; see https://msg.pyyaml.org/load
 
 ### Changed
 

--- a/scripts/bert/bert4marian.py
+++ b/scripts/bert/bert4marian.py
@@ -31,7 +31,7 @@ parser.add_argument('--marian', help='Output path for Marian weight file', requi
 args = parser.parse_args()
 
 print("Loading TensorFlow config from %s" % (args.bert_config,))
-bertConfig = yaml.load(open(args.bert_config))
+bertConfig = yaml.safe_load(open(args.bert_config))
 bertConfigYamlStr = yaml.dump(bertConfig, default_flow_style=False)
 print(bertConfigYamlStr)
 

--- a/scripts/contrib/model_info.py
+++ b/scripts/contrib/model_info.py
@@ -27,9 +27,9 @@ def main():
         # fix the invalid trailing unicode character '#x0000' added to the YAML
         # string by the C++ cnpy library
         try:
-            yaml_node = yaml.load(yaml_text)
+            yaml_node = yaml.safe_load(yaml_text)
         except yaml.reader.ReaderError:
-            yaml_node = yaml.load(yaml_text[:-1])
+            yaml_node = yaml.safe_load(yaml_text[:-1])
 
         print(yaml_node[args.key])
     else:

--- a/scripts/embeddings/export_embeddings.py
+++ b/scripts/embeddings/export_embeddings.py
@@ -18,7 +18,7 @@ def main():
 
     print("Loading model")
     model = np.load(args.model)
-    special = yaml.load(model["special:model.yml"][:-1].tobytes())
+    special = yaml.safe_load(model["special:model.yml"][:-1].tobytes())
 
     if special["tied-embeddings-all"] or special["tied-embeddings-src"]:
         all_emb = model["Wemb"]


### PR DESCRIPTION
### Description
Tests in `tests/training/features/custom-embeddings` can fail due to calls to `yaml.load` producing warnings.

```log
TypeError: load() missing 1 required positional argument: 'Loader'
```

See https://msg.pyyaml.org/load for details.


List of changes:
- replaces `yaml.load` with `yaml.safe_load` in `scripts/`

Added dependencies: none

### How to test
`safe_load` should be equivalent since we're not loading anything exotic

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
