### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
 env:
-  cuda_version: "10.2"
+  cuda_version: "11.2"
   gcc_version: 8
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
             fbgemm: false
             cuda: false
           - name: "Build Ubuntu CPU+CUDA"
-            suffix: cuda10.2
+            suffix: cuda11.2
             fbgemm: false
             cuda: true
 
@@ -59,8 +59,8 @@ jobs:
         # Get the tag name only to use it in the archive name. The variable github.ref can not be used because it starts with refs/tags/
         TAG_NAME=$(echo ${{ github.ref }} | cut -d/ -f3-)
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-        echo "::set-env name=github_tag_name::${TAG_NAME}"
-        echo "::set-env name=archive_name::${{ github.event.repository.name }}-${TAG_NAME}_linux-x64-static_${{ matrix.suffix }}"
+        echo "github_tag_name=${TAG_NAME}" >> $GITHUB_ENV
+        echo "archive_name=${{ github.event.repository.name }}-${TAG_NAME}_linux-x64-static_${{ matrix.suffix }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Checkout
@@ -72,7 +72,7 @@ jobs:
     # No need to install libprotobuf{17,10,9v5} on Ubuntu {20,18,16}.04 because it is installed together with libprotobuf-dev
     # Boost is no longer pre-installed on GitHub-hosted runners
     - name: Install dependencies
-      run: sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev
+      run: sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev gcc-${{ env.gcc_version }} g++-${{ env.gcc_version }}
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-free-libs-and-python-apt-repo.html
     - name: Install MKL
@@ -133,7 +133,7 @@ jobs:
             fbgemm: false
             cuda: false
           - name: "Build Windows CPU+CUDA"
-            suffix: cuda10.2
+            suffix: cuda11.2
             fbgemm: false
             cuda: true
 
@@ -147,8 +147,8 @@ jobs:
         # Get the tag name only to use it in the archive name. The variable github.ref can not be used because it starts with refs/tags/
         TAG_NAME=$(echo ${{ github.ref }} | cut -d/ -f3-)
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-        echo "::set-env name=github_tag_name::${TAG_NAME}"
-        echo "::set-env name=archive_name::${{ github.event.repository.name }}-${TAG_NAME}_windows-x64_${{ matrix.suffix }}"
+        echo "github_tag_name=${TAG_NAME}" >> $GITHUB_ENV
+        echo "archive_name=${{ github.event.repository.name }}-${TAG_NAME}_windows-x64_${{ matrix.suffix }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Checkout
@@ -162,20 +162,20 @@ jobs:
         Expand-Archive -Force mkl.zip ${{ github.workspace }}\mkl
         # Set the MKLROOT environment variable so that CMake can find MKL.
         # GITHUB_WORKSPACE is an environment variable available on all GitHub-hosted runners
-        echo "::set-env name=MKLROOT::$env:GITHUB_WORKSPACE/mkl"
-      shell: powershell
+        echo "MKLROOT=$env:GITHUB_WORKSPACE/mkl" | Out-File -FilePath $env:GITHUB_ENV -Append
+      shell: pwsh
 
     - name: Install CUDA
       run: |
         .\scripts\ci\install_cuda_windows.ps1 '${{ env.cuda_version }}'
         # Set path to CUDA for subsequent steps so that CMake can find it
-        echo "::set-env name=CUDA_PATH::$env:CUDA_PATH"
-        echo "::add-path::$env:CUDA_PATH/bin"
-      shell: powershell
+        echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
+        echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+      shell: pwsh
       if: matrix.cuda == true
 
     - name: Prepare vcpkg
-      uses: lukka/run-vcpkg@v2
+      uses: lukka/run-vcpkg@v4
       with:
         vcpkgArguments: protobuf
         vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da
@@ -184,7 +184,7 @@ jobs:
 
     # Build with a simplified CMake settings JSON file
     - name: Run CMake
-      uses: lukka/run-cmake@v2
+      uses: lukka/run-cmake@v3
       with:
         buildDirectory: ${{ github.workspace }}/build/
         cmakeAppendedArgs: '-G Ninja
@@ -207,14 +207,14 @@ jobs:
       run: |
         cp ../README.md .
         Compress-Archive -Path marian*.exe,README.md -DestinationPath ../${{ env.archive_name }}.zip
-      shell: powershell
+      shell: pwsh
       working-directory: build
 
     # For testing only
     #- name: Test archive
       #run: |
         #Compress-Archive -Path README.md -DestinationPath ${{ env.archive_name }}.zip
-      #shell: powershell
+      #shell: pwsh
 
     - name: Upload archive
       uses: actions/upload-artifact@v2

--- a/scripts/ci/install_cuda_windows.ps1
+++ b/scripts/ci/install_cuda_windows.ps1
@@ -29,7 +29,10 @@ $CUDA_KNOWN_URLS = @{
     "10.0" = "http://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
     "10.1" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
     "10.2" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
-    "11.0" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe"
+    "11.0" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
+    "11.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
+    "11.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
+    "11.3" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe"
 }
 
 ## ------------------------------------------------------------------


### PR DESCRIPTION
### Description
This PR fixes the `release.yml` workflow that builds Marian executables and attaches them to a new release.

List of changes:
- Fixed `add-path` and `set-env` in the workflow.
- Added support for CUDA 11.x in the Windows CUDA installation script.
- Changed CUDA 10.2 to CUDA 11.2 in the workflow.

Added dependencies: none

### How to test
Create a new tag and push to the remote repo. I tested it on a fork.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
