### PR TITLE
Fix fp16 training/inference with factors-combine concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Scripts using PyYAML now use `safe_load`; see https://msg.pyyaml.org/load
 - Fixed check for `fortran_ordering` in cnpy
+- Fixed fp16 training/inference with factors-combine concat method
 
 ### Changed
 - Make guided-alignment faster via sparse memory layout, add alignment points for EOS, remove losses other than ce

--- a/src/layers/embedding.cpp
+++ b/src/layers/embedding.cpp
@@ -57,8 +57,7 @@ Embedding::Embedding(Ptr<ExpressionGraph> graph, Ptr<Options> options)
   auto lemmaEmbs = rows(E_, lemmaIndices);
   int dimFactors = FactorEmbMatrix_->shape()[0];
   auto factEmbs
-      = dot(graph->constant(
-                {(int)data.size(), dimFactors}, inits::fromVector(factorIndices), Type::float32),
+      = dot(graph->constant({(int)data.size(), dimFactors}, inits::fromVector(factorIndices)),
             FactorEmbMatrix_);
 
   return concatenate({lemmaEmbs, factEmbs}, -1);


### PR DESCRIPTION
### Description
This PR fixes a crash that occurs when training/decoding factored model with --fp16 and --factors-combine concat options provided at the same time.

It is related to issues: #922
Resolves: #922 

List of changes:
- Removed explicit type cast to `Type::float32` in `embedWithConcat` method

Added dependencies: none

### How to test
Try to train/decode factored model with --fp16 and --factors-combine-concat options provided at the same time.

### Checklist

- [X] I have tested the code manually
- [ ] I have run regression tests
- [X] I have read and followed CONTRIBUTING.md
- [X] I have updated CHANGELOG.md
