### PR TITLE
Update NVIDIA CUDA signing key for CI; fix for building docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ myst-parser==0.14.0a3
 mistune<2.0.0
 m2r
 sphinx-mathjax-offline
+Jinja2<3.1

--- a/scripts/ci/install_cuda_ubuntu.sh
+++ b/scripts/ci/install_cuda_ubuntu.sh
@@ -79,7 +79,7 @@ echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
 
 PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
 PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
-APT_KEY_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
+APT_KEY_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/3bf863cc.pub"
 REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
 
 echo "PIN_FILENAME ${PIN_FILENAME}"


### PR DESCRIPTION
### Description
See https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772

Removes old signing key in favour of the updated one sso that CI works again

@snukky I'm not sure if you said this fix was in the coming sync or not, but I needed to fix it for CI on my fork anyway. Feel free to merge/close as needed

List of changes:
- Updated signing key for CUDA installs in CI

Added dependencies: none

### How to test
Run CI

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
