### PR TITLE
Fixed some warnings on clang 15 that are promoted into errors

### DIFF
--- a/src/data/factored_vocab.cpp
+++ b/src/data/factored_vocab.cpp
@@ -130,7 +130,7 @@ namespace marian {
     // @TODO: add checks for empty factor groups until it stops crashing (training already works; decoder still crashes)
 
     io::InputFileStream in(modelPath);
-    for (WordIndex v = 0; io::getline(in, line); v++) {
+    for(; io::getline(in, line);) {
       utils::splitAny(line, tokBuf, " \t");
       factorMapTokenized.push_back(tokBuf);
     }

--- a/src/data/shortlist.h
+++ b/src/data/shortlist.h
@@ -221,7 +221,6 @@ private:
   }
 
   void prune(float threshold = 0.f) {
-    size_t i = 0;
     for(auto& probs : data_) {
       std::vector<std::pair<float, WordIndex>> sorter;
       for(auto& it : probs)
@@ -237,8 +236,6 @@ private:
         else
           break;
       }
-
-      ++i;
     }
   }
 

--- a/src/training/communicator.h
+++ b/src/training/communicator.h
@@ -130,7 +130,6 @@ private:
       int totalSize = (int)graphs_[0]->params()->vals()->size();
       int shardSize = (int)ceil(totalSize / (float)graphs_.size());
 
-      int pos = 0;
       for(auto graph : graphs_) {
         int __size__ = std::min(shardSize, totalSize);
 
@@ -145,7 +144,6 @@ private:
         tmpTensors_.push_back(tmp);
 
         // move to next shard
-        pos += __size__;
         totalSize -= __size__;
       }
     }


### PR DESCRIPTION
### Description
When building with Clang 15 its diagnostics detects some issues in the code that are promoted into errors.

List of changes:
- removed some unused variables
- ...
- ...

Added dependencies: none

### How to test
Install clang-15 from its official deb repo and build with it, setting CMake to use it.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md - minor change, not needed
