### PR TITLE
Directory listing in Ubuntu and macOS workflows

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,4 +48,4 @@ jobs:
         ./marian-decoder --version
         ./marian-scorer --version
         ./spm_encode --version
-
+        ls -hlv $(find . -maxdepth 1 -type f -perm +ugo+x \( -name "marian*" -o -name "spm*" \))

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -122,4 +122,4 @@ jobs:
         ./marian-scorer --version
         ./marian-server --version
         ./spm_encode --version
-
+        ls -hlv $(find . -maxdepth 1 -type f -executable \( -name "marian*" -o -name "spm*" \))


### PR DESCRIPTION
### Description
The windows workflow includes a directory listing of the executables. This PR adds the same to the Ubuntu and macOS workflows. Perhaps useful to check for any unforeseen increases in binary size (as in #937).

List of changes:
- Adds ls command to Ubuntu & macOS workflows

Added dependencies: none

### How to test
Ran on CI in fork

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
