### PR TITLE
Fix clang 13.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Scripts using PyYAML now use `safe_load`; see https://msg.pyyaml.org/load
 - Fixed check for `fortran_ordering` in cnpy
 - Fixed fp16 training/inference with factors-combine concat method
+- Fixed clang 13.0.1 compatibility
 
 ### Changed
 - Make guided-alignment faster via sparse memory layout, add alignment points for EOS, remove losses other than ce

--- a/src/training/communicator.h
+++ b/src/training/communicator.h
@@ -130,7 +130,7 @@ private:
       int totalSize = (int)graphs_[0]->params()->vals()->size();
       int shardSize = (int)ceil(totalSize / (float)graphs_.size());
 
-      int pos = 0;
+      // int pos = 0; // This was used at some point, but no longer is causes compilation fails with clang 13.0.1
       for(auto graph : graphs_) {
         int __size__ = std::min(shardSize, totalSize);
 
@@ -145,7 +145,7 @@ private:
         tmpTensors_.push_back(tmp);
 
         // move to next shard
-        pos += __size__;
+        // pos += __size__;
         totalSize -= __size__;
       }
     }

--- a/src/training/communicator.h
+++ b/src/training/communicator.h
@@ -130,7 +130,6 @@ private:
       int totalSize = (int)graphs_[0]->params()->vals()->size();
       int shardSize = (int)ceil(totalSize / (float)graphs_.size());
 
-      // int pos = 0; // This was used at some point, but no longer is causes compilation fails with clang 13.0.1
       for(auto graph : graphs_) {
         int __size__ = std::min(shardSize, totalSize);
 
@@ -145,7 +144,6 @@ private:
         tmpTensors_.push_back(tmp);
 
         // move to next shard
-        // pos += __size__;
         totalSize -= __size__;
       }
     }


### PR DESCRIPTION
### Description
compilation with clang 13.0.1 fails due to set but unused value:
```bash
[ 53%] Building CXX object src/CMakeFiles/marian.dir/training/graph_group_async.cpp.o
cd marian-dev/build/src && /usr/bin/clang++ -DBLAS_FOUND=1 -DBUILD_INFO_AVAILABLE=1 -DCOMPILE_CPU=1 -DDETERMINISTIC=0 -DMKL_FOUND=1 -I/opt/intel/mkl/include -Imarian-dev/src -Imarian-dev/src/. -Imarian-dev/src/3rd_party -Imarian-dev/src/3rd_party/SQLiteCpp/include -Imarian-dev/src/3rd_party/sentencepiece -Imarian-dev/src/3rd_party/sentencepiece/third_party/protobuf-lite -Imarian-dev/src/3rd_party/fbgemm/include -Imarian-dev/src/3rd_party/intgemm -Imarian-dev/build/src/3rd_party/intgemm -Imarian-dev/build/local/include -Imarian-dev/src/3rd_party/intgemm/. -std=c++11 -pthread  -fPIC -Wno-unused-result -Wno-unknown-warning-option -Wno-unknown-cuda-version -march=native  -DUSE_SENTENCEPIECE -DMKL_ILP64 -m64 -O3 -m64 -funroll-loops -g  -Wall -Werror -Wextra -Wno-unused-result -Wno-deprecated -Wno-pragmas -Wno-unused-parameter -Wno-unused-function -Wno-unused-value -Wno-unknown-pragmas -Wno-sign-compare -Wno-missing-field-initializers -std=gnu++17 -MD -MT src/CMakeFiles/marian.dir/training/graph_group_async.cpp.o -MF CMakeFiles/marian.dir/training/graph_group_async.cpp.o.d -o CMakeFiles/marian.dir/training/graph_group_async.cpp.o -c marian-dev/src/training/graph_group_async.cpp
In file included from marian-dev/src/training/graph_group_async.cpp:1:
In file included from marian-dev/src/training/graph_group_async.h:4:
In file included from marian-dev/src/training/graph_group.h:9:
In file included from marian-dev/src/training/scheduler.h:7:
marian-dev/src/training/communicator.h:133:11: error: variable 'pos' set but not used [-Werror,-Wunused-but-set-variable]
      int pos = 0;
          ^
1 error generated.
make[2]: *** [src/CMakeFiles/marian.dir/build.make:1154: src/CMakeFiles/marian.dir/training/graph_group_async.cpp.o] Error 1
make[2]: Leaving directory 'marian-dev/build'
make[1]: *** [CMakeFiles/Makefile2:334: src/CMakeFiles/marian.dir/all] Error 2
make[1]: Leaving directory 'marian-dev/build'
make: *** [Makefile:156: all] Error 2
```

This PR fixes the issue.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
