### PR TITLE
Add a workflow compiling Marian using clang-14

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Configure CMake
       run: |
         [ -z "${{ matrix.gcc }}" ] || export CC=/usr/bin/gcc-${{ matrix.gcc }} CXX=/usr/bin/g++-${{ matrix.gcc }} CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}
-        [ -z "${{ matrix.clang }}" ] || export CC=/usr/bin/clang-{{ matrix.clang }} CXX=/usr/bin/clang++-${{ matrix.clang }}
+        [ -z "${{ matrix.clang }}" ] || export CC=/usr/bin/clang-${{ matrix.clang }} CXX=/usr/bin/clang++-${{ matrix.clang }}
         mkdir -p build
         cd build
         cmake .. \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,11 +30,10 @@ jobs:
             unit_tests: false
             examples: true
           # Ubuntu Clang compiler
-          - name: "Ubuntu 22.04 CPU clang-14"
-            os: ubuntu-22.04
+          - name: "Ubuntu CPU-only clang-12"
+            os: ubuntu-20.04
             cuda: ""
-            gcc: 9
-            clang: 14
+            clang: 12
             cpu: true
             gpu: false
             unit_tests: true
@@ -74,11 +73,11 @@ jobs:
     # The following packages are already installed on GitHub-hosted runners: build-essential openssl libssl-dev
     # No need to install libprotobuf{17,10,9v5} on Ubuntu {20,18,16}.04 because it is installed together with libprotobuf-dev
     # Boost is no longer pre-installed on GitHub-hosted runners
-    # Clang 14.0 is installed on the default ubuntu-22.04 image
+    # Clang 12.0 is pre-installed on the ubuntu-20.04 image
     - name: Install dependencies
       run: |
-        sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev \
-            gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
+        sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev
+        [ -z "${{ matrix.gcc }}" ] || sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-free-libs-and-python-apt-repo.html
     - name: Install MKL

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -96,8 +96,8 @@ jobs:
     # https://github.com/actions/virtual-environments/issues/687#issuecomment-610471671
     - name: Configure CMake
       run: |
-        [ -z "${{ matrix.gcc }}"] || export CC=/usr/bin/gcc-${{ matrix.gcc }} CXX=/usr/bin/g++-${{ matrix.gcc }} CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}
-        [ -z "${{ matrix.clang }}"] || export CC=/usr/bin/clang-{{ matrix.clang }} CXX=/usr/bin/clang++-${{ matrix.clang }}
+        [ -z "${{ matrix.gcc }}" ] || export CC=/usr/bin/gcc-${{ matrix.gcc }} CXX=/usr/bin/g++-${{ matrix.gcc }} CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}
+        [ -z "${{ matrix.clang }}" ] || export CC=/usr/bin/clang-{{ matrix.clang }} CXX=/usr/bin/clang++-${{ matrix.clang }}
         mkdir -p build
         cd build
         cmake .. \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,6 +16,17 @@ jobs:
             os: ubuntu-18.04
             cuda: ""
             gcc: 7
+            clang: ""
+            cpu: true
+            gpu: false
+            unit_tests: true
+            examples: false
+          # Using Clang compiler
+          - name: "Ubuntu CPU-only clang-12"
+            os: ubuntu-20.04
+            cuda: ""
+            gcc: ""
+            clang: 12
             cpu: true
             gpu: false
             unit_tests: true
@@ -25,25 +36,18 @@ jobs:
             os: ubuntu-18.04
             cuda: "10.2"
             gcc: 7
+            clang: ""
             cpu: false
             gpu: true
             unit_tests: false
             examples: true
-          # Ubuntu Clang compiler
-          - name: "Ubuntu CPU-only clang-12"
-            os: ubuntu-20.04
-            cuda: ""
-            clang: 12
-            cpu: true
-            gpu: false
-            unit_tests: true
-            examples: false
           # Ubuntu 20.04 supports CUDA 11+
           # Unit tests and examples are not compiled to save disk space
           - name: "Ubuntu 20.04 CUDA 11.2 gcc-9"
             os: ubuntu-20.04
             cuda: "11.2"
             gcc: 9
+            clang: ""
             cpu: false
             gpu: true
             unit_tests: false
@@ -54,6 +58,7 @@ jobs:
             os: ubuntu-18.04
             cuda: "10.2"
             gcc: 8
+            clang: ""
             cpu: true
             gpu: true
             unit_tests: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,6 +29,15 @@ jobs:
             gpu: true
             unit_tests: false
             examples: true
+          # Ubuntu Clang compiler
+          - name: "Ubuntu 22.04 CPU clang-14"
+            os: ubuntu-22.04
+            cuda: ""
+            clang: 14
+            cpu: true
+            gpu: false
+            unit_tests: true
+            examples: false
           # Ubuntu 20.04 supports CUDA 11+
           # Unit tests and examples are not compiled to save disk space
           - name: "Ubuntu 20.04 CUDA 11.2 gcc-9"
@@ -64,10 +73,11 @@ jobs:
     # The following packages are already installed on GitHub-hosted runners: build-essential openssl libssl-dev
     # No need to install libprotobuf{17,10,9v5} on Ubuntu {20,18,16}.04 because it is installed together with libprotobuf-dev
     # Boost is no longer pre-installed on GitHub-hosted runners
+    # Clang 14.0 is installed on the default ubuntu-22.04 image
     - name: Install dependencies
       run: |
-        sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev \
-          gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
+        sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev
+        [ -z "${{ matrix.gcc }}" ] || sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-free-libs-and-python-apt-repo.html
     - name: Install MKL
@@ -86,9 +96,10 @@ jobs:
     # https://github.com/actions/virtual-environments/issues/687#issuecomment-610471671
     - name: Configure CMake
       run: |
+        [ -z "${{ matrix.gcc }}"] || export CC=/usr/bin/gcc-${{ matrix.gcc }} CXX=/usr/bin/g++-${{ matrix.gcc }} CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}
+        [ -z "${{ matrix.clang }}"] || export CC=/usr/bin/clang-{{ matrix.clang }} CXX=/usr/bin/clang++-${{ matrix.clang }}
         mkdir -p build
         cd build
-        CC=/usr/bin/gcc-${{ matrix.gcc }} CXX=/usr/bin/g++-${{ matrix.gcc }} CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }} \
         cmake .. \
           -DBoost_ARCHITECTURE=-x64 \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,6 +33,7 @@ jobs:
           - name: "Ubuntu 22.04 CPU clang-14"
             os: ubuntu-22.04
             cuda: ""
+            gcc: 9
             clang: 14
             cpu: true
             gpu: false
@@ -76,8 +77,8 @@ jobs:
     # Clang 14.0 is installed on the default ubuntu-22.04 image
     - name: Install dependencies
       run: |
-        sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev
-        [ -z "${{ matrix.gcc }}" ] || sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
+        sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev \
+            gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-free-libs-and-python-apt-repo.html
     - name: Install MKL


### PR DESCRIPTION
### Description
Extends Ubuntu workflows by compiling Marian using clang-14, which is pre-installed on the ubuntu-22.04 image.

Added dependencies: none

### How to test
See the workflow for the cmake command.

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
