### PR TITLE
Fix guaranteed `YAML::InvalidNode` when compiled with `COMPILE_CPU=Off`

### DIFF
--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -54,8 +54,10 @@ void ConfigValidator::validateOptionsTranslation() const {
   ABORT_IF(models.empty() && configs.empty(),
            "You need to provide at least one model file or a config file");
 
+#ifdef COMPILE_CPU
   ABORT_IF(get<bool>("model-mmap") && get<size_t>("cpu-threads") == 0,
            "Model MMAP is CPU-only, please use --cpu-threads");
+#endif
 
   for(const auto& modelFile : models) {
     filesystem::Path modelPath(modelFile);


### PR DESCRIPTION
### Description
This is a quick fix for marian-decoder always aborting on an uncaught `YAML::InvalidNode` exception when marian is compiled without CPU support.

It is being thrown from the `get<bool>("model-mmap")` call in https://github.com/marian-nmt/marian-dev/blob/e27da623938b84f9abe600774af6fad4fd5f1dd6/src/common/config_validator.cpp#L57-L58

I suspect because that option is only defined when `COMPILE_CPU` is defined: https://github.com/marian-nmt/marian-dev/blob/e27da623938b84f9abe600774af6fad4fd5f1dd6/src/common/config_parser.cpp#L186-L191

It is related to issues: #860 

List of changes:
- Add `ifdef` around check for `model-mmap` config option

Added dependencies: none

### How to test
Compiled with `cmake -DCOMPILE_CPU=Off` and configuration parsing always failed. After adding this bit of code, it works as intended.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
