### PR TITLE
add coarse benchmarking to test inference.

### DIFF
--- a/src/python/bench/benchmark.sh
+++ b/src/python/bench/benchmark.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+function translate_native {
+ sacrebleu -t wmt20 -l en-de --echo src | \
+   spm_encode --model /home/marcinjd/MTMA/source.spm |  ../build/temp.linux-x86_64-3.8/PyMarian/marian-decoder --quiet \
+     -c  /home/marcinjd/MTMA/decoder.yml -b4 --mini-batch 16 --maxi-batch 100 -d 0 1 2 3 \
+   | spm_decode --model  /home/marcinjd/MTMA/target.spm > translations_native.txt
+}
+
+function translate_python {
+   sacrebleu -t wmt20 -l en-de --echo src | \
+   spm_encode --model /home/marcinjd/MTMA/source.spm | \
+   python test_translate.py '--config /home/marcinjd/MTMA/decoder.yml -b4 --mini-batch 16 --quiet --maxi-batch 100 -d 0 1 2 3' \
+   | spm_decode --model  /home/marcinjd/MTMA/target.spm > translations_python.txt
+}
+
+echo -n "Native: "
+time translate_native
+echo
+echo -n "Pybind: "
+time translate_python

--- a/src/python/bench/test_translate.py
+++ b/src/python/bench/test_translate.py
@@ -1,0 +1,17 @@
+import sys
+import itertools
+
+from pymarian import Translator
+
+marian = Translator(sys.argv[1])
+
+def batch(s, batch_size=1600):
+    it = iter(s)
+    while True:
+        chunk = list(itertools.islice(it, batch_size))
+        if not chunk:
+            return
+        yield chunk
+
+for b in batch(map(str.strip, sys.stdin)):
+    print(marian.translate("\n".join(b)))


### PR DESCRIPTION
### Description

Adds a tiny microbenchmarking suite so we can ensure we aren't introducing major regressions between "native" and pybind code.


List of changes:
- Adds a tiny script and driver code with decoder parity. 

Added dependencies: none

### How to test

After installing pymarian and sacrebleu, run `bash benchmark.sh`. Optionally one can check the translations are identical with `diff *.txt`

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
