### PR TITLE
add vector translate. 

### DIFF
--- a/src/models/model_task.h
+++ b/src/models/model_task.h
@@ -12,5 +12,6 @@ struct ModelTask {
 struct ModelServiceTask {
   virtual ~ModelServiceTask() {}
   virtual std::string run(const std::string&) = 0;
+  virtual std::vector<std::string> run(const std::vector<std::string>&) = 0;
 };
 }  // namespace marian

--- a/src/python/bench/test_translate.py
+++ b/src/python/bench/test_translate.py
@@ -14,4 +14,4 @@ def batch(s, batch_size=1600):
         yield chunk
 
 for b in batch(map(str.strip, sys.stdin)):
-    print(marian.translate("\n".join(b)))
+    print("\n".join(marian.translate(b)))

--- a/src/python/pymarian/translator.cpp
+++ b/src/python/pymarian/translator.cpp
@@ -1,4 +1,5 @@
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 
 #include "marian.h"
 #include "translator/translator.h"
@@ -10,6 +11,7 @@ PYBIND11_MODULE(pymarian, m) {
   // Classes
   py::class_<marian::TranslateService<marian::BeamSearch>>(m, "Translator")
       .def(py::init<std::string>())
-      .def("translate", &marian::TranslateService<marian::BeamSearch>::run);
+      .def("translate", py::overload_cast<const std::string&>(&marian::TranslateService<marian::BeamSearch>::run))
+      .def("translate", py::overload_cast<const std::vector<std::string>&>(&marian::TranslateService<marian::BeamSearch>::run));
 }
 

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -327,6 +327,12 @@ public:
     }
   }
 
+  std::vector<std::string> run(const std::vector<std::string>& inputs) override {
+      auto input = utils::join(inputs, "\n");
+      auto translations = run(input);
+      return utils::split(translations, "\n");
+  }
+
   std::string run(const std::string& input) override {
     // split tab-separated input into fields if necessary
     auto inputs = options_->get<bool>("tsv", false)


### PR DESCRIPTION
TODO: revisit the underlying code to not join and split unnecessarily.

### Description

This code exposes a batch-in, batch-out overload for the pymarian code. 

List of changes:
- It does this by joining the vector on a newline to re-use the underlying `marian::TranslateService<Search>::run` string-in, string-out and splits on newline. This is the naive implementation that works easily. This may be revisited in the underlying code.

Added dependencies: none

### How to test

Rebuild the pymarian and re-run the benchmark scripts.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
