### PR TITLE
best-deep alias broken

### DIFF
--- a/src/common/aliases.cpp
+++ b/src/common/aliases.cpp
@@ -46,6 +46,7 @@ void ConfigParser::addAliases(cli::CLIWrapper& cli) {
 
     // Options setting the BiDeep architecture proposed in http://www.aclweb.org/anthology/W17-4710
     cli.alias("best-deep", "true", [](YAML::Node& config) {
+      config["type"] = "s2s";
       config["layer-normalization"] = true;
       config["tied-embeddings"] = true;
       config["enc-type"] = "alternating";


### PR DESCRIPTION


### Description
The best-deep alias in marian is currently broken, because it doesn't set the model type and the default is `amum` which is incompatible with multiple layers. This commit just adds the type to the best-deep alias entry.
List of changes:
- Add `type: s2s` to the `--best-deep` alias entry.

Added dependencies: none

### How to test
Try to train a `--best-deep` model with a bare minimum config.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
