### PR TITLE
Temporarily download MKL tarball from a mirror server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
 
     - name: Download MKL
       run: |
-        C:\msys64\usr\bin\wget.exe -nv https://romang.blob.core.windows.net/mariandev/ci/mkl-2020.1-windows-static.zip -O mkl.zip
+        C:\msys64\usr\bin\wget.exe -nv https://data.statmt.org/romang/marian-regression-tests/ci/mkl-2020.1-windows-static.zip -O mkl.zip
         Expand-Archive -Force mkl.zip ${{ github.workspace }}\mkl
         # Set the MKLROOT environment variable so that CMake can find MKL.
         # GITHUB_WORKSPACE is an environment variable available on all GitHub-hosted runners

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  MKL_URL: "https://romang.blob.core.windows.net/mariandev/ci/mkl-2020.1-windows-static.zip"
+  MKL_URL: "https://data.statmt.org/romang/marian-regression-tests/ci/mkl-2020.1-windows-static.zip"
   BOOST_ROOT: "C:/hostedtoolcache/windows/Boost/1.72.0/x86_64"
   BOOST_URL: "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
 


### PR DESCRIPTION
### Description
The previous blob storage doesn't have public access, so we are temporarily switching to a mirror hosting to keep GitHub builds running. 

Added dependencies: none

### How to test
GitHub actions should succeed.

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
