### PR TITLE
Add optimised max_element implementation as a specific case of nth_element with beam = 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Optimised special case for nth_element when decoding with beam size of 1.
+
 ## [1.12.0] - 2023-02-20
 
 ### Added


### PR DESCRIPTION
### Description
Add optimised max_element implementation as a specific case of nth_element with n = 1

Depending on the compiler used, this should speed up beam search by a factor of 2 to 10. Synthetic benchmark can be found here https://github.com/XapaJIaMnu/maxelem_test
A summary:

### Cascade lake results

|                                | GCC 11.2 | clang 14 | icc 2022.1.0 |
|--------------------------------|----------|----------|--------------|
| std::max_element               | 2.6696s  | 0.4221s  | 0.4662s      |
| sequential                     | 1.0831s  | 1.1924s  | 1.1472s      |
| AVX512 max + max_reduce        | 0.2412s  | 0.2152s  | 0.2142s      |
| AVX512 max_reduce only         | 0.2570s  | 0.2629s  | 0.2325s      |
| AVX512 cmp_ps_mask             | 0.1884s  | 0.1826s  | 0.1833s      |
| AVX512 ^ + vectorized overhang | 0.2097s  | 0.2089s  | 0.2072s      |
| AVX cmp_ps + movemask          | 0.2181s  | 0.1697s  | 0.1702s      |
| SSE cmplt_psp + movemask       | 0.2692s  | 0.2051s  | 0.2221s      |

### Ryzen 9 5900HS results

|                          | GCC 11.2 | clang 14 |
|--------------------------|----------|----------|
| std::max_element         | 2.4101s  | 0.7221s  |
| sequential               | 0.3252s  | 0.3518s  |
| AVX cmp_ps + movemask    | 0.1476s  | 0.1214s  |
| SSE cmplt_psp + movemask | 0.1693s  | 0.1468s  |

Added dependencies: none

### How to test
Just load any model with the new code path and test it with beam size of 1. In our testing this reduced runtime by about 1%.
I didn't run all regression tests because there's something broken in them right now.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
