### PR TITLE
static link Threads lib for a portable bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Fixed compilation with clang 16.0.6
+- Added Threads::Threads to EXT_LIBS
+
 
 ### Added
 - Added `--no-spm-encode` option, allowing the model to use vocabulary IDs directly to train/decode.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,15 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+########
+# pThreads: consider it as EXT_LIBS for a more portable binary
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+set(EXT_LIBS ${EXT_LIBS} Threads::Threads)
+########
+
+
 ###############################################################################
 # Set compilation flags
 if(MSVC)


### PR DESCRIPTION
### Description
adding Threads as EXT_LIB so we can statically link.


This PR partially fixes #1011 

List of changes:
- CMakeLists.txt: `set(EXT_LIBS ${EXT_LIBS} Threads::Threads)`

Added dependencies: none

### How to test
1) build marian on ubuntu20.04
2) scp build/marian to a machine having ubuntu22.04
3) run `./marian --help`  and see that marian doesnt crash!


Describe how you have tested your code, including OS and the cmake command.

```
# cpu only build
cmake .. -DUSE_MPI=off -DUSE_STATIC_LIBS=on -DCOMPILE_CUDA=off -DCOMPILE_CPU=on

# cuda build
cmake .. -DUSE_MPI=off -DUSE_STATIC_LIBS=on -DCOMPILE_PASCAL=on -DCOMPILE_VOLTA=on -DCOMPILE_AMPERE=on -DBUILD_ARCH=x86-64 
```

### Checklist

- [X] I have tested the code manually
- [X] I have run regression tests
- [X] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
