### PR TITLE
Performance: Convert an FDIV to an FMUL in a hot loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Convert an FDIV to an FMUL in a hot loop in CPU tensor operation.
 - Fixed compilation with clang 16.0.6
 - Added Threads::Threads to `EXT_LIBS`
 - Updates to pymarian: building for multiple python versions; disabling tcmalloc; hosting gated COMETs on HuggingFace

--- a/src/tensors/cpu/tensor_operators.cpp
+++ b/src/tensors/cpu/tensor_operators.cpp
@@ -1110,11 +1110,11 @@ void LayerNormalizationImpl(float* out,
       sqSum += ex * ex;
     }
 
-    float sigma = std::sqrt(sqSum / cols + eps);
+    float invSigma = 1.0/std::sqrt(sqSum / cols + eps);
 
     #pragma omp simd
     for(int i = 0; i < cols; ++i) {
-      float t = alpha[alphaStride * i] * ((sp[i] - mean) / sigma);
+      float t = alpha[alphaStride * i] * ((sp[i] - mean) * invSigma);
       if(hasBeta)
         t += beta[betaStride * i];
 


### PR DESCRIPTION
### Description
For the generic/CPU path, we noticed a super hot loop executing a floating point divide, where the divisor is a loop invariant and can be replaced by a floating point multiply. This can provide some speedup for microarchitectures which implement FMUL faster than FDIV.

Added dependencies: none

### How to test
I could not build this repository on my box. We were testing with the SPEC CPU candidate drop of marian. The edit is small and contained, and verified within our framework without loss of accuracy. We are offering this patch in case it helps the community.

Here is a snippet of coverage from `tensor_operations.cpp`, where hit counts are listed to the right of the line numbers. In this image, line 1177 and 1181 are the ones we would edit. 

<img width="460" alt="image" src="https://github.com/user-attachments/assets/4994dc89-62b6-4f0e-9234-d40618ed3e49">


### Checklist

- [y] I have tested the code manually
- [n] I have run regression tests
- [y] I have read and followed CONTRIBUTING.md
- [y] I have updated CHANGELOG.md
